### PR TITLE
UAR-629: Adding Amendment/Renewal number to protocol attachment and set the default sorting to this number.

### DIFF
--- a/src/main/java/edu/arizona/kra/irb/noteattachment/ProtocolAttachmentFilter.java
+++ b/src/main/java/edu/arizona/kra/irb/noteattachment/ProtocolAttachmentFilter.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2005-2014 The Kuali Foundation
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.opensource.org/licenses/ecl1.php
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.arizona.kra.irb.noteattachment;
+
+import java.util.Comparator;
+
+import org.kuali.kra.protocol.noteattachment.ProtocolAttachmentProtocolBase;
+
+public class ProtocolAttachmentFilter extends org.kuali.kra.irb.noteattachment.ProtocolAttachmentFilter {
+
+    private static final long serialVersionUID = -8420432117877485410L;
+
+    /**
+     * This method returns a comparator used to sort protocol attachments
+     * @return a comparator used to sort protocol attachments
+     */
+    @Override
+    public Comparator<ProtocolAttachmentProtocolBase> getProtocolAttachmentComparator() {
+        if ("ARNO".equalsIgnoreCase(getSortBy())) { 
+            return new ProtocolAmendRenewNumberComparator();
+        }  else if ("LAUP".equalsIgnoreCase(getSortBy())) {
+            return new ProtocolAttachmentLastUpdatedComparator();
+        }
+        else
+            return super.getProtocolAttachmentComparator();
+    }   
+    
+    
+    /**
+     *  Implements the ARNO - Amendment/Renewal comparator for the default ARNO sorting.
+     *  Primary sort by Amend/Renewal Number, secondary sort by Date/Timestamp, tertiary sort by Attachment Type.
+     */
+    private class ProtocolAmendRenewNumberComparator implements Comparator<ProtocolAttachmentProtocolBase>
+    {
+        @Override
+        public int compare(ProtocolAttachmentProtocolBase o1, ProtocolAttachmentProtocolBase o2) {
+            if ( o1 instanceof ProtocolAttachmentProtocol && o2 instanceof ProtocolAttachmentProtocol){
+                String sparn0 = ((ProtocolAttachmentProtocol) o1).getSourceProtocolAmendRenewalNumber();
+                String sparn1 = ((ProtocolAttachmentProtocol) o2).getSourceProtocolAmendRenewalNumber();
+                
+                if( sparn0.equalsIgnoreCase(sparn1) ){
+                    if( o1.getUpdateTimestamp() != null && o2.getUpdateTimestamp() != null) {
+                        return o1.getUpdateTimestamp().compareTo(o2.getUpdateTimestamp());
+                    }
+                    else 
+                        return 0;
+                }                   
+                else {
+                    return sparn0.compareTo(sparn1);
+                }
+            }
+            else if (o1.getUpdateTimestamp() != null && o2.getUpdateTimestamp() != null){
+                return o1.getUpdateTimestamp().compareTo(o2.getUpdateTimestamp());
+            }
+            else 
+                return 0;
+        }
+
+    }
+    
+    
+    private class ProtocolAttachmentLastUpdatedComparator implements Comparator<ProtocolAttachmentProtocolBase>
+    {
+        @Override
+        public int compare(ProtocolAttachmentProtocolBase o1, ProtocolAttachmentProtocolBase o2) {
+            if(o1.getUpdateTimestamp() != null && o2.getUpdateTimestamp() != null){
+                return o1.getUpdateTimestamp().compareTo(o2.getUpdateTimestamp());
+            }
+            else{
+                return 0;
+            }
+                
+        }
+        
+    }
+   
+}

--- a/src/main/java/edu/arizona/kra/irb/noteattachment/ProtocolAttachmentProtocol.java
+++ b/src/main/java/edu/arizona/kra/irb/noteattachment/ProtocolAttachmentProtocol.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2005-2014 The Kuali Foundation
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.opensource.org/licenses/ecl1.php
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.arizona.kra.irb.noteattachment;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.kuali.kra.infrastructure.KraServiceLocator;
+import org.kuali.rice.krad.service.BusinessObjectService;
+
+/**
+ * This class represents the UofA Custom Protocol Attachment Protocol.
+ */
+public class ProtocolAttachmentProtocol extends org.kuali.kra.irb.noteattachment.ProtocolAttachmentProtocol {
+
+    private static final long serialVersionUID = -1874526982821035896L;
+
+    
+    private String sourceProtocolAmendRenewalNumber;
+    private String sourceProtocolNumber;
+
+    
+    /**
+     * Returns the source protocol number for when this attachment was last added in.
+     */
+    public String getSourceProtocolNumber() {
+        if (sourceProtocolNumber == null) {
+            if (getFileId() != null) {
+                // find the protocol number for this attachment's most recent attachment/modification
+                // by retrieving all attachments with the same fileId and ordering them by id
+                Map param = new HashMap();
+                param.put("fileId", getFileId());
+                BusinessObjectService businessObjectService = KraServiceLocator.getService(BusinessObjectService.class);
+                List<ProtocolAttachmentProtocol> protocolAttachmentProtocols = 
+                        (List<ProtocolAttachmentProtocol>) businessObjectService.findMatchingOrderBy(ProtocolAttachmentProtocol.class, param, "id", true);
+                ProtocolAttachmentProtocol protocolAttachmentProtocol = protocolAttachmentProtocols.get(0);
+                sourceProtocolNumber = protocolAttachmentProtocol.getProtocolNumber();
+            }
+            // Null FileId means attachment newly added and is not in the database yet
+            else {
+                sourceProtocolNumber = getProtocolNumber();
+            }
+        }
+        // avoid further lookups when this field is accessed and NPEs
+        if (sourceProtocolNumber == null) {
+            sourceProtocolNumber = "";
+        }
+        return sourceProtocolNumber;
+    }
+
+    
+    /**
+     * Returns the source amendment or renewal this attachment was added in.
+     */
+    public String getSourceProtocolAmendRenewalNumber() {
+        String sourceProtocolNumber = getSourceProtocolNumber();
+
+        if (sourceProtocolNumber.length() >= 10) {
+            sourceProtocolAmendRenewalNumber = sourceProtocolNumber.substring(10);
+        } else {
+            sourceProtocolAmendRenewalNumber = "";
+        }
+
+        return sourceProtocolAmendRenewalNumber;
+    }
+    
+}

--- a/src/main/java/edu/arizona/kra/irb/noteattachment/SortByValuesFinder.java
+++ b/src/main/java/edu/arizona/kra/irb/noteattachment/SortByValuesFinder.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2005-2014 The Kuali Foundation
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.opensource.org/licenses/ecl1.php
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.arizona.kra.irb.noteattachment;
+
+import org.kuali.rice.core.api.util.ConcreteKeyValue;
+import org.kuali.rice.core.api.util.KeyValue;
+
+import java.util.List;
+
+/**
+ * 
+ * This add a new sort for Amendment/Renewal Number for the fields used to sort protocol attachments.
+ */
+public class SortByValuesFinder extends org.kuali.kra.irb.noteattachment.SortByValuesFinder {
+
+    @Override
+    public List<KeyValue> getKeyValues() {
+        List<KeyValue> keyValues = super.getKeyValues();
+        keyValues.add(new ConcreteKeyValue("ARNO", new String("Amend/Renewal Number")));
+
+        return keyValues;
+    }
+
+}

--- a/src/main/resources/META-INF/kc-config-defaults.xml
+++ b/src/main/resources/META-INF/kc-config-defaults.xml
@@ -212,4 +212,5 @@
 	 
 	<param name="rice.portal.allowed.regex" override="false">^(${application.url}|${rice.server.url})(/.*|)</param>
 	
+    <param name="rice.kc.core.additionalSpringFiles">classpath:edu/arizona/kra/CustomCoreSpringBeans.xml,classpath:edu/arizona/kra/irb/CustomIrbSpringBeans.xml</param>
 </config>

--- a/src/main/resources/edu/arizona/kra/CustomCoreSpringBeans.xml
+++ b/src/main/resources/edu/arizona/kra/CustomCoreSpringBeans.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2005-2014 The Kuali Foundation.
+
+    Licensed under the Educational Community License, Version 1.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.opensource.org/licenses/ecl1.php
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+       xmlns:p="http://www.springframework.org/schema/p" 
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xmlns:beans="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:lang="http://www.springframework.org/schema/lang"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="http://www.springframework.org/schema/aop
+                           http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                           http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                           http://www.springframework.org/schema/context
+                           http://www.springframework.org/schema/context/spring-context-3.0.xsd
+                           http://www.springframework.org/schema/lang
+                           http://www.springframework.org/schema/lang/spring-lang-3.0.xsd
+                           http://www.springframework.org/schema/tx
+                           http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                           http://www.springframework.org/schema/util
+                           http://www.springframework.org/schema/util/spring-util-3.0.xsd">
+    
+    <bean id="coreModuleConfiguration" parent="coreModuleConfiguration-parentBean">
+        <property name="packagePrefixes">
+            <list merge="true">
+                <value>edu.arizona.kra</value>
+            </list>
+        </property>
+        <property name="dataDictionaryPackages">
+            <list merge="true">
+                <value>edu/arizona/kra/datadictionary</value>
+            </list>
+        </property>
+    </bean>
+</beans>

--- a/src/main/resources/edu/arizona/kra/datadictionary/CustomProtocolAttachmentFilter.xml
+++ b/src/main/resources/edu/arizona/kra/datadictionary/CustomProtocolAttachmentFilter.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+     Copyright 2005-2014 The Kuali Foundation
+    
+     Licensed under the Educational Community License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+    
+     http://www.osedu.org/licenses/ECL-2.0
+    
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+    http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <bean id="ProtocolAttachmentFilter" parent="ProtocolAttachmentFilter-parentBean" >
+        <property name="businessObjectClass" value="edu.arizona.kra.irb.noteattachment.ProtocolAttachmentFilter" />
+    </bean>
+    <bean id="ProtocolAttachmentFilter-sortBy" parent="ProtocolAttachmentFilter-sortBy-parentBean" >
+        <property name="control" >
+          <bean parent="SelectControlDefinition"
+                p:valuesFinderClass="edu.arizona.kra.irb.noteattachment.SortByValuesFinder" />
+        </property>
+    </bean>
+
+</beans>

--- a/src/main/resources/edu/arizona/kra/datadictionary/CustomProtocolAttachmentProtocol.xml
+++ b/src/main/resources/edu/arizona/kra/datadictionary/CustomProtocolAttachmentProtocol.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2005-2014 The Kuali Foundation
+    
+    Licensed under the Educational Community License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+    http://www.osedu.org/licenses/ECL-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+    http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <bean id="ProtocolAttachmentProtocol" parent="ProtocolAttachmentProtocol-parentBean" >
+        <property name="businessObjectClass" value="edu.arizona.kra.irb.noteattachment.ProtocolAttachmentProtocol" />
+    </bean>
+
+</beans>

--- a/src/main/resources/edu/arizona/kra/irb/CustomIrbSpringBeans.xml
+++ b/src/main/resources/edu/arizona/kra/irb/CustomIrbSpringBeans.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2005-2014 The Kuali Foundation.
+
+    Licensed under the Educational Community License, Version 1.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.opensource.org/licenses/ecl1.php
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+       xmlns:p="http://www.springframework.org/schema/p" 
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xmlns:beans="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:lang="http://www.springframework.org/schema/lang"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="http://www.springframework.org/schema/aop
+                           http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                           http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                           http://www.springframework.org/schema/context
+                           http://www.springframework.org/schema/context/spring-context-3.0.xsd
+                           http://www.springframework.org/schema/lang
+                           http://www.springframework.org/schema/lang/spring-lang-3.0.xsd
+                           http://www.springframework.org/schema/tx
+                           http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                           http://www.springframework.org/schema/util
+                           http://www.springframework.org/schema/util/spring-util-3.0.xsd">
+
+    <bean id="irbModuleConfiguration" parent="irbModuleConfiguration-parentBean">
+        <property name="dataDictionaryPackages">
+            <list merge="true">
+                <value>edu/arizona/kra/datadictionary</value>
+            </list>
+        </property>
+    </bean>
+
+</beans>

--- a/src/main/resources/org/kuali/kra/irb/repository-irb.xml
+++ b/src/main/resources/org/kuali/kra/irb/repository-irb.xml
@@ -98,7 +98,7 @@
         <collection-descriptor name="specialReviews" proxy="true" element-class-ref="org.kuali.kra.irb.specialreview.ProtocolSpecialReview" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
             <inverse-foreignkey field-ref="protocolId" />
         </collection-descriptor>        
-        <collection-descriptor name="attachmentProtocols" proxy="true" element-class-ref="org.kuali.kra.irb.noteattachment.ProtocolAttachmentProtocol" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="true" auto-delete="true">
+        <collection-descriptor name="attachmentProtocols" proxy="true" element-class-ref="edu.arizona.kra.irb.noteattachment.ProtocolAttachmentProtocol" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="true" auto-delete="true">
             <inverse-foreignkey field-ref="protocolId" />
         </collection-descriptor>
         <collection-descriptor name="notepads" proxy="false" element-class-ref="org.kuali.kra.irb.noteattachment.ProtocolNotepad" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="true" auto-delete="true">
@@ -604,7 +604,7 @@
         </reference-descriptor>
     </class-descriptor>
     
-    <class-descriptor class="org.kuali.kra.irb.noteattachment.ProtocolAttachmentProtocol" table="PROTOCOL_ATTACHMENT_PROTOCOL">
+    <class-descriptor class="edu.arizona.kra.irb.noteattachment.ProtocolAttachmentProtocol" table="PROTOCOL_ATTACHMENT_PROTOCOL">
         <field-descriptor name="id" column="PA_PROTOCOL_ID" jdbc-type="BIGINT" primarykey="true" sequence-name="SEQ_PROTOCOL_ID" autoincrement="true"/>
         <field-descriptor name="protocolId" column="PROTOCOL_ID_FK" jdbc-type="BIGINT" />
         <field-descriptor name="protocolNumber" column="PROTOCOL_NUMBER" jdbc-type="VARCHAR" />

--- a/src/main/webapp/WEB-INF/tags/irb/protocolAttachmentProtocol.tag
+++ b/src/main/webapp/WEB-INF/tags/irb/protocolAttachmentProtocol.tag
@@ -1,0 +1,476 @@
+<%--
+ Copyright 2005-2014 The Kuali Foundation
+
+ Licensed under the Educational Community License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.osedu.org/licenses/ECL-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+--%>
+<%@ include file="/WEB-INF/jsp/kraTldHeader.jsp"%>
+
+<c:set var="protocolAttachmentProtocolAttributes" value="${DataDictionary.ProtocolAttachmentProtocol.attributes}" />
+<c:set var="attachmentFileAttributes" value="${DataDictionary.AttachmentFile.attributes}" />
+<c:set var="protocolAttachmentFilterAttributes" value="${DataDictionary.ProtocolAttachmentFilter.attributes}" />
+<c:set var="notesAttachmentsHelper" value="${KualiForm.notesAttachmentsHelper}" />
+<c:set var="modify" value="${KualiForm.notesAttachmentsHelper.modifyAttachments}" />
+<c:set var="action" value="protocolNoteAndAttachment" />
+<c:set var="attachmentProtocols" value="${KualiForm.document.protocolList[0].attachmentProtocols}"/>
+<c:set var="filteredAttachmentProtocols" value="${KualiForm.document.protocolList[0].filteredAttachmentProtocols}"/>
+
+<kul:tab tabTitle="Protocol Attachments" tabItemCount="${fn:length(KualiForm.document.protocolList[0].activeAttachmentProtocolsNoDelete)}" defaultOpen="false" tabErrorKey="notesAttachmentsHelper.newAttachmentProtocol.*" transparentBackground="true" tabAuditKey="document.protocolList[0].attachmentProtocols*">
+	<div class="tab-container" align="center">
+   		<kra:permission value="${modify}">
+	   		<h3>
+	   			<span class="subhead-left">Add Protocol Attachment</span>
+	   			<span class="subhead-right"><kul:help businessObjectClassName="org.kuali.kra.irb.noteattachment.ProtocolAttachmentProtocol" altText="help"/></span>
+	       </h3>
+	       <table cellpadding="4" cellspacing="0" summary="">
+	       		<tbody class="addline">
+	         	<tr>
+	         		<th>
+	         			<div align="right">
+	         				<kul:htmlAttributeLabel attributeEntry="${protocolAttachmentProtocolAttributes['typeCode']}" noColon="false"/>
+	         			</div>
+	         		</th>
+	         		<td align="left" valign="middle" colspan="3">
+	                	<div align="left">
+	                		<c:set var="property" value="notesAttachmentsHelper.newAttachmentProtocol.typeCode" />
+	                	
+	               			<%-- attachment type finder logic start--%>
+								<jsp:useBean id="typeParamsType" class="java.util.HashMap"/>
+								<c:set target="${typeParamsType}" property="groupCode" value="${notesAttachmentsHelper.newAttachmentProtocol.groupCode}" />
+								<c:set var="options" value="${krafn:getOptionList('org.kuali.kra.irb.noteattachment.ProtocolAttachmentTypeByGroupValuesFinder', typeParamsType)}" />
+							<%-- attachment type finder logic end --%>
+							
+	               			<%-- attachment type error handling logic start--%>
+	               				<kul:checkErrors keyMatch="${property}" auditMatch="${property}"/>
+	               			<%-- 	<c:set var="textStyle" value="${hasErrors == true ? 'background-color:#FFD5D5' : ''}"/>--%>
+	               			<%-- attachment type error handling logic start--%>
+	               			<html:select property="${property}">
+	               				<html:options collection="options" labelProperty="value" property="key" />
+	               			</html:select>
+	               			<c:if test="${hasErrors}">
+                    	 		<kul:fieldShowErrorIcon />
+                            </c:if>
+ 
+		            	</div>
+					</td>
+	         	</tr>
+	         	<tr>
+	         		<th>
+	         			<div align="right">
+	         				<kul:htmlAttributeLabel attributeEntry="${protocolAttachmentProtocolAttributes['statusCode']}" noColon="false"/>
+	         			</div>
+	         		</th>
+	         		<td align="left" valign="middle">
+	                	<div align="left">
+	                		<kul:htmlControlAttribute property="notesAttachmentsHelper.newAttachmentProtocol.statusCode" attributeEntry="${protocolAttachmentProtocolAttributes['statusCode']}"/>
+		            	</div>
+					</td>
+					<th>
+						<div align="right">
+							<kul:htmlAttributeLabel attributeEntry="${protocolAttachmentProtocolAttributes.contactName}" noColon="false" />
+						</div>
+					</th>
+	         		<td align="left" valign="middle">
+	                	<div align="left">
+	                		<kul:htmlControlAttribute property="notesAttachmentsHelper.newAttachmentProtocol.contactName" attributeEntry="${protocolAttachmentProtocolAttributes.contactName}"/>
+		            	</div>
+					</td>
+	         	</tr>
+	         	<tr>
+	         		<th>
+	         			<div align="right">
+	         				<kul:htmlAttributeLabel attributeEntry="${protocolAttachmentProtocolAttributes.updateUser}" noColon="false" />
+	         			</div>
+	         		</th>
+	         		<td align="left" valign="middle">
+	                	<div align="left">
+	                		<kul:htmlControlAttribute property="notesAttachmentsHelper.newAttachmentProtocol.updateUser" attributeEntry="${protocolAttachmentProtocolAttributes.updateUser}" readOnly="true"/>
+		            	</div>
+					</td>
+					<th>
+						<div align="right">
+							<kul:htmlAttributeLabel attributeEntry="${protocolAttachmentProtocolAttributes.contactEmailAddress}" noColon="false" />
+						</div>
+					</th>
+	         			<td align="left" valign="middle">
+	                	<div align="left">
+	                		<kul:htmlControlAttribute property="notesAttachmentsHelper.newAttachmentProtocol.contactEmailAddress" attributeEntry="${protocolAttachmentProtocolAttributes.contactEmailAddress}"/>
+		            	</div>
+					</td>
+	         	</tr>
+	         	<tr>
+	         		<th>
+	         			<div align="right">
+	         				<kul:htmlAttributeLabel attributeEntry="${protocolAttachmentProtocolAttributes.updateTimestamp}" noColon="false" />
+	         			</div>
+	         		</th>
+	         		<td align="left" valign="middle">
+	                	<div align="left">
+	                		<kul:htmlControlAttribute property="notesAttachmentsHelper.newAttachmentProtocol.updateTimestamp" attributeEntry="${protocolAttachmentProtocolAttributes.updateTimestamp}" readOnly="true"/>
+		            	</div>
+					</td>
+					<th>
+						<div align="right">
+							<kul:htmlAttributeLabel attributeEntry="${protocolAttachmentProtocolAttributes.contactPhoneNumber}" noColon="false" />
+						</div>
+					</th>
+	         		<td align="left" valign="middle">
+	                	<div align="left">
+	                		<kul:htmlControlAttribute property="notesAttachmentsHelper.newAttachmentProtocol.contactPhoneNumber" attributeEntry="${protocolAttachmentProtocolAttributes.contactPhoneNumber}"/>
+		            	</div>
+					</td>
+	         	</tr>
+	         	<tr>
+	         		<th>
+	         			<div align="right">
+	         				<kul:htmlAttributeLabel attributeEntry="${protocolAttachmentProtocolAttributes.comments}" noColon="false" />
+	         			</div>
+	         		</th>
+	         		<td align="left" valign="middle">
+	                	<div align="left">
+	                		<kul:htmlControlAttribute property="notesAttachmentsHelper.newAttachmentProtocol.comments" attributeEntry="${protocolAttachmentProtocolAttributes.comments}"/>
+		            	</div>
+					</td>
+					<th>
+						<div align="right">
+							<kul:htmlAttributeLabel attributeEntry="${protocolAttachmentProtocolAttributes.description}" noColon="false"/>
+						</div>
+					</th>
+	         		<td align="left" valign="middle">
+                        <div align="left">
+                            <c:set var="property" value="notesAttachmentsHelper.newAttachmentProtocol.description" />
+                                   
+                            <%-- attachment description error handling logic start--%>
+                            <kul:checkErrors keyMatch="${property}" auditMatch="${property}"/>
+                            <%-- attachment type description handling logic start--%>
+                            <kul:htmlControlAttribute property="notesAttachmentsHelper.newAttachmentProtocol.description" attributeEntry="${protocolAttachmentProtocolAttributes.description}"/>
+                            
+                        </div>
+					</td>
+	         	</tr>
+	         	<tr>
+	         		<th>
+						<div align="right">
+							<kul:htmlAttributeLabel attributeEntry="${attachmentFileAttributes['name']}" noColon="false" />
+						</div>
+					</th>
+	       			<td align="left" valign="middle" colspan="3">
+	              		<div align="left">
+	              			<c:set var="property" value="notesAttachmentsHelper.newAttachmentProtocol.newFile" />
+	              		
+	              		    <%-- attachment file error handling logic start--%>
+	               				<kul:checkErrors keyMatch="${property}" auditMatch="${property}"/>
+	               				<%-- highlighting does not work in firefox but does in ie... --%>
+	               				<%-- <c:set var="textStyle" value="${hasErrors == true ? 'background-color:#FFD5D5' : ''}"/>--%>
+	               			<%-- attachment file error handling logic start--%>
+	              			<html:file property="${property}" size="50"/>
+	               			<c:if test="${hasErrors}">
+                    	 		<kul:fieldShowErrorIcon />
+                            </c:if>
+	           			</div>
+					</td>
+	         	</tr>
+	         	<tr>
+	         		<td colspan="4" class="infoline">
+						<div align="center">
+							<html:image property="methodToCall.addAttachmentProtocol.anchor${tabKey}"
+							src="${ConfigProperties.kra.externalizable.images.url}tinybutton-add1.gif" styleClass="tinybutton addButton"/>
+						</div>
+					</td>
+	         	</tr>
+	         	</tbody>
+			</table>
+		</kra:permission>
+		
+		<c:if test="${not empty attachmentProtocols}">
+
+
+		<!--  Attached Items sub-panel -->
+		<br/>
+        <h3>
+	        <span class="subhead-left">Attached Items</span>
+	        <span class="subhead-right"><kul:help businessObjectClassName="org.kuali.kra.irb.noteattachment.ProtocolAttachmentProtocol" altText="help"/></span>        
+        </h3>
+        
+            <table cellpadding="4" cellspacing="0" summary="">
+                <tr>
+                    <td style="border: none; width: 30%;">
+                        <div align="right">
+                            Show:
+                        </div>
+                    </td style="border: none; width: 20%;">
+                    <td align="left" valign="middle" style="border: none;">
+                        <div align="left">
+                            <kul:htmlControlAttribute property="notesAttachmentsHelper.newAttachmentFilter.filterBy" attributeEntry="${protocolAttachmentFilterAttributes.filterBy}" readOnly="false" onchange="filterTableByCriteria(this)"/>
+                        </div>
+                    </td>
+                    <td style="border: none; width: 10%;">
+                        <div align="right">
+                            Sort By:
+                        </div>
+                    </td>
+                    <td align="left" valign="middle" style="border: none; width: 40%;">
+                        <div align="left">
+                            <kul:htmlControlAttribute property="notesAttachmentsHelper.newAttachmentFilter.sortBy" attributeEntry="${protocolAttachmentFilterAttributes.sortBy}" readOnly="false" onchange="sortTableByCriteria(this)"/>
+                        </div>
+                    </td>                    
+                </tr>
+                <!-- replaced by jquery/javascript functions 
+                <tr>
+                    <td colspan="4" class="infoline" style="border: none;">
+                        <div align="center">
+                            <html:image property="methodToCall.updateAttachmentFilter.anchor${tabKey}"
+                            src="${ConfigProperties.kra.externalizable.images.url}tinybutton-filter.gif" styleClass="tinybutton"/>
+                        </div>
+                    </td>
+                </tr>
+                -->                
+            </table>
+        <table cellpadding="4" cellspacing="0" summary="" id="protocol-attachment-table">
+        <tbody>
+		<c:forEach var="attachmentProtocol" items="${filteredAttachmentProtocols}" varStatus="itrStatus">
+        
+          <!--  Display logic to show the correct attribute being sorted on in the attachment header -->
+          <c:set var="descDisplay" >
+              <c:choose>
+                  <c:when test="${fn:length(attachmentProtocol.description) > 29}">
+                      <c:out value="${fn:substring(attachmentProtocol.description, 0, 29)}..." />
+                  </c:when>
+                  <c:otherwise>
+                      <c:out value="${attachmentProtocol.description}" />
+                  </c:otherwise>
+              </c:choose>
+          </c:set>
+          <c:set var="updateUserDisplay" value="${attachmentProtocol.updateUserFullName}"/>
+          <c:set var="lastUpdateDisplay">
+              <fmt:formatDate value="${attachmentProtocol.updateTimestamp}" pattern="MM/dd/yyyy KK:mm a" />                      
+          </c:set>	
+          	
+		  <c:choose>
+		    <c:when test="${attachmentProtocol.active}">
+		      <tr id="protocol-attachment-row-${itrStatus.index}" class="fake-class-level-1">
+		        <td>
+		             <c:set var="modify" value="${KualiForm.notesAttachmentsHelper.modifyAttachments and attachmentProtocol.documentStatusCode != '3' and (not KualiForm.document.protocolList[0].renewalWithoutAmendment or attachmentProtocol.documentStatusCode != '2')}" />
+						<kul:innerTabRightAligned tabTitleRightAligned="${attachmentProtocol.sourceProtocolAmendRenewalNumber}" tabTitle="${attachmentProtocol.type.description} - ${descDisplay} - ${updateUserDisplay} (${lastUpdateDisplay})" parentTab="Protocol Attachments(${size})" defaultOpen="false" tabErrorKey="document.protocolList[0].attachmentProtocols[${itrStatus.index}]*,document.protocolList[0].attachmentProtocols[${itrStatus.index}]*" useCurrentTabIndexAsKey="true" tabAuditKey="document.protocolList[0].attachmentProtocols[${itrStatus.index}]*" auditCluster="NoteAndAttachmentAuditErrors">
+				<div class="innerTab-container" align="left">
+            		<table class=tab cellpadding=0 cellspacing="0" summary="">
+						<tr>
+			         		<th>
+			         			<div align="right">
+			         				<kul:htmlAttributeLabel attributeEntry="${protocolAttachmentProtocolAttributes['typeCode']}" noColon="false" />
+			         			</div>
+			         		</th>
+			         		<td align="left" valign="middle" colspan="3">
+			                	<div align="left" id="attachment-type-${itrStatus.index}">
+			                		<kul:htmlControlAttribute property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].typeCode" attributeEntry="${protocolAttachmentProtocolAttributes['typeCode']}" readOnly="true" readOnlyAlternateDisplay ="${attachmentProtocol.type.description}" />
+				            	</div>
+							</td>
+			         	</tr>
+			         	<tr>
+			         		<th>
+			         			<div align="right">
+			         				<kul:htmlAttributeLabel attributeEntry="${protocolAttachmentProtocolAttributes['statusCode']}" noColon="false"/>
+			         			</div>
+			         		</th>
+			         		<td align="left" valign="middle">
+			                	<div align="left">
+			                		<kul:htmlControlAttribute property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].statusCode" attributeEntry="${protocolAttachmentProtocolAttributes['statusCode']}" readOnly="${!modify}"/>
+				            	</div>
+							</td>
+							<th>
+								<div align="right">
+									<kul:htmlAttributeLabel attributeEntry="${protocolAttachmentProtocolAttributes.contactName}" noColon="false" />
+								</div>
+							</th>
+			         		<td align="left" valign="middle">
+			                	<div align="left">
+			                		<kul:htmlControlAttribute property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].contactName" attributeEntry="${protocolAttachmentProtocolAttributes.contactName}" readOnly="${!modify}"/>
+				            	</div>
+							</td>
+			         	</tr>
+			         	<tr>
+			         		<th>
+			         			<div align="right">
+			         				<kul:htmlAttributeLabel attributeEntry="${protocolAttachmentProtocolAttributes.updateUser}" noColon="false" />
+			         			</div>
+			         		</th>
+			         		<td align="left" valign="middle">
+			                	<div align="left" id="updated-by-${itrStatus.index}">
+			                		<kul:htmlControlAttribute property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].updateUserFullName" attributeEntry="${protocolAttachmentProtocolAttributes.updateUser}" readOnly="true"/>
+				            	</div>
+							</td>
+							<th>
+								<div align="right">
+									<kul:htmlAttributeLabel attributeEntry="${protocolAttachmentProtocolAttributes.contactEmailAddress}" noColon="false" />
+								</div>
+							</th>
+			         			<td align="left" valign="middle">
+			                	<div align="left">
+			                		<kul:htmlControlAttribute property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].contactEmailAddress" attributeEntry="${protocolAttachmentProtocolAttributes.contactEmailAddress}" readOnly="${!modify}"/>
+				            	</div>
+							</td>
+			         	</tr>
+			         	<tr>
+			         		<th>
+			         			<div align="right">
+			         				<kul:htmlAttributeLabel attributeEntry="${protocolAttachmentProtocolAttributes.updateTimestamp}" noColon="false" />
+			         			</div>
+			         		</th>
+			         		<td align="left" valign="middle">
+			                	<div align="left" id="last-updated-${itrStatus.index}">
+			                	 	     <kul:htmlControlAttribute property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].updateTimestamp" attributeEntry="${protocolAttachmentProtocolAttributes.updateTimestamp}" readOnly="true"/>  
+				            	</div>
+							</td>
+							<th>
+								<div align="right">
+									<kul:htmlAttributeLabel attributeEntry="${protocolAttachmentProtocolAttributes.contactPhoneNumber}" noColon="false" />
+								</div>
+							</th>
+			         		<td align="left" valign="middle">
+			                	<div align="left">
+			                		<kul:htmlControlAttribute property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].contactPhoneNumber" attributeEntry="${protocolAttachmentProtocolAttributes.contactPhoneNumber}" readOnly="${!modify}"/>
+				            	</div>
+							</td>
+			         	</tr>
+			         	<tr>
+			         		<th>
+			         			<div align="right">
+			         				<kul:htmlAttributeLabel attributeEntry="${protocolAttachmentProtocolAttributes.comments}" noColon="false" />
+			         			</div>
+			         		</th>
+			         		<td align="left" valign="middle">
+			                	<div align="left">
+			                		<kul:htmlControlAttribute property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].comments" attributeEntry="${protocolAttachmentProtocolAttributes.comments}" readOnly="${!modify}"/>
+				            	</div>
+							</td>
+							<th>
+								<div align="right">
+									<kul:htmlAttributeLabel attributeEntry="${protocolAttachmentProtocolAttributes.description}" noColon="false"/>
+								</div>
+							</th>
+			         		<td align="left" valign="middle">
+			                	<div align="left" id="row-description-${itrStatus.index}">
+			                		<kul:htmlControlAttribute property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].description" attributeEntry="${protocolAttachmentProtocolAttributes.description}" readOnly="${!modify}"/>
+				            	</div>
+							</td>
+			         	</tr>
+			         	<tr>
+			         	<th>
+								<div align="right">
+									<kul:htmlAttributeLabel attributeEntry="${attachmentFileAttributes['name']}" noColon="false" />
+								</div>
+							</th>
+			       			<td align="left" valign="middle" colspan="3">
+			              		<div align="left" style="display: none;" id="attachmentProtocolFile${itrStatus.index}">
+			              			<html:file property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].newFile" size="50" />
+			           			</div>
+			           			<div align="left" id="attachmentProtocolFileName${itrStatus.index}">
+			           			   <c:if test="${attachmentProtocol.documentStatusCode == '3'}">
+			           			      <font color="red">Deleted -&nbsp;</font>
+			           			   </c:if>
+			              			<kra:fileicon attachment="${attachmentProtocol.file}"/>${attachmentProtocol.file.name}
+			           			</div>
+			           			
+			           			<%-- this assumes that the versions collection is sorted descending by sequence number --%>
+			           			<c:set var="doVersionsExist" value="${fn:length(attachmentProtocol.versions) > 0}" />
+			           			<c:if test="${doVersionsExist}">
+				           			<kul:innerTab tabTitle="File Versions" parentTab="${attachmentProtocol.type.description} - ${attachmentProtocol.status.description} - ${itrStatus.index}" defaultOpen="false">
+										<div class="innerTab-container" align="left">
+				         					<table class=tab cellpadding=0 cellspacing="0" summary="" width="100%">
+			         							<tr>
+					         						<th style="width: 20%">
+					         							Last Modifier
+					         						</th>
+					         						<th style="width: 20%">
+					         							Created Date
+					         						</th>
+					         						<th style="width: 20%">
+					         							Last Modified Date
+					         						</th>
+					         						<th style="width: 60%">
+					         							Description
+					         						</th>
+					         					</tr>
+							         			<c:forEach var="attachmentProtocolVersion" items="${attachmentProtocol.versions}" varStatus="innerItrStatus">
+						         					<tr>
+						         						<td style="width: 20%">
+						         							${attachmentProtocolVersion.authorPersonName}
+						         						</td>
+						         						<td style="width: 20%">
+	                                                       <fmt:formatDate value="${attachmentProtocolVersion.createTimestamp}" pattern="MM/dd/yyyy KK:mm a" />
+						         							
+						         						</td>
+						         						<td style="width: 20%">
+	                                                       <fmt:formatDate value="${attachmentProtocolVersion.updateTimestamp}" pattern="MM/dd/yyyy KK:mm a" />
+						         						</td>
+														<td style="width: 60%">
+														   <div align="left">
+						         							${attachmentProtocolVersion.description}
+						         							</div>
+						         						</td>
+						         					</tr>
+							         			</c:forEach>
+						         			</table>
+					         			</div>
+				         			</kul:innerTab>
+				         		</c:if>
+							</td>
+			         	</tr>
+						<tr>
+			         		<td colspan="4" class="infoline">
+								<div align="center">
+									<input type="hidden" id="protocolRefreshButtonClicked${itrStatus.index}" name="protocolRefreshButtonClicked${itrStatus.index}" value="F"/>
+									<html:image property="methodToCall.viewAttachmentProtocol.line${itrStatus.index}.anchor${currentTabIndex}"
+										src='${ConfigProperties.kra.externalizable.images.url}tinybutton-view.gif' styleClass="tinybutton"
+										alt="View Protocol Attachment" onclick="excludeSubmitRestriction = true;"/>
+									<kra:permission value="${KualiForm.notesAttachmentsHelper.modifyAttachments and (not KualiForm.document.protocolList[0].renewalWithoutAmendment or attachmentProtocol.documentStatusCode != '2')}">
+										<input class="tinybutton" type="image"
+											src='${ConfigProperties.kra.externalizable.images.url}tinybutton-replace.gif'
+											id="replaceButton${itrStatus.index}"
+											alt="Replace Protocol Attachment"
+											onclick="document.getElementById('attachmentProtocolFile${itrStatus.index}').style.display = 'block';
+											document.getElementById('attachmentProtocolFileName${itrStatus.index}').style.display = 'none';
+											document.getElementById('replaceButton${itrStatus.index}').style.display = 'none';
+											document.getElementById('protocolRefreshButtonClicked${itrStatus.index}').value = 'T';
+											return false;"/>
+									    <c:if test="${modify}">
+										    <html:image property="methodToCall.deleteAttachmentProtocol.line${itrStatus.index}.anchor${currentTabIndex}"
+											    src='${ConfigProperties.kra.externalizable.images.url}tinybutton-delete1.gif' styleClass="tinybutton"
+											    alt="Delete Protocol Attachment"/>
+			           			        </c:if>											
+									</kra:permission>
+								</div>
+							</td>
+			         	</tr>
+         			</table>
+         		</div>
+		    </kul:innerTabRightAligned>
+		        </td>
+		      </tr>
+		    </c:when>
+		    <c:otherwise>
+		      <html:hidden property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].typeCode" value="${KualiForm.document.protocolList[0].attachmentProtocols[itrStatus.index].typeCode}" />
+		      <html:hidden property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].statusCode" value="${KualiForm.document.protocolList[0].attachmentProtocols[itrStatus.index].statusCode}" />
+		      <html:hidden property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].contactName" value="${KualiForm.document.protocolList[0].attachmentProtocols[itrStatus.index].contactName}" />
+		      <html:hidden property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].contactEmailAddress" value="${KualiForm.document.protocolList[0].attachmentProtocols[itrStatus.index].contactEmailAddress}" />
+		      <html:hidden property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].contactPhoneNumber" value="${KualiForm.document.protocolList[0].attachmentProtocols[itrStatus.index].contactPhoneNumber}" />
+		      <html:hidden property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].comments" value="${KualiForm.document.protocolList[0].attachmentProtocols[itrStatus.index].comments}" />
+		      <html:hidden property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].description" value="${KualiForm.document.protocolList[0].attachmentProtocols[itrStatus.index].description}" />
+		      <html:hidden property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].file.name" value="${KualiForm.document.protocolList[0].attachmentProtocols[itrStatus.index].file.name}" />
+		    </c:otherwise>
+		  </c:choose>
+		</c:forEach>
+		</tbody>
+		</table>
+		</c:if>
+     </div>		
+</kul:tab>

--- a/src/main/webapp/WEB-INF/tags/kr/innerTabRightAligned.tag
+++ b/src/main/webapp/WEB-INF/tags/kr/innerTabRightAligned.tag
@@ -1,0 +1,116 @@
+<%--
+ Copyright 2005-2014 The Kuali Foundation
+
+ Licensed under the Educational Community License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.osedu.org/licenses/ECL-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+--%>
+<%@ include file="/WEB-INF/jsp/kraTldHeader.jsp"%>
+<%@ attribute name="tabTitle" required="true" %>
+<%@ attribute name="tabTitleRightAligned" required="true" %>
+<%@ attribute name="parentTab" required="true" %>
+<%@ attribute name="tabItemCount" required="false" %>
+<%@ attribute name="tabDescription" required="false" %>
+<%@ attribute name="defaultOpen" required="true" %>
+<%@ attribute name="noShowHideButton" required="false" description="Boolean to hide the show/hide button (but the row is displayed anyway)." %>
+<%@ attribute name="tabErrorKey" required="false" %>
+<%@ attribute name="auditCluster" required="false" %>
+<%@ attribute name="tabAuditKey" required="false" %>
+<%@ attribute name="useCurrentTabIndexAsKey" required="false" %>
+<%@ attribute name="overrideToggleTabMethodString" required="false" %>
+<%-- Add 'overrideDivClass', so if this is an inner tab in an innertab.  The child
+     innertab can change the inner div properties, such as background color etc.
+     ie, the parent and children inner tabs are not exactly the same look. --%>
+<%@ attribute name="overrideDivClass" required="false" %>
+
+<c:set var="currentTabIndex" value="${KualiForm.currentTabIndex}" scope="request"/>
+<c:set var="topLevelTabIndex" value="${KualiForm.currentTabIndex}" scope="request"/>
+
+<c:choose>
+    <c:when test="${(useCurrentTabIndexAsKey)}">
+        <c:set var="tabKey" value="${currentTabIndex}" scope="request"/>
+    </c:when>
+    <c:otherwise>
+        <c:set var="tabKey" value="${kfunc:generateTabKey(parentTab)}:${kfunc:generateTabKey(tabTitle)}" scope="request"/>
+    </c:otherwise>
+</c:choose>
+    <c:if test="${empty overrideDivClass}">
+        <c:set var="overrideDivClass" value="innerTab-head"/>
+    </c:if>
+
+<!--  hit form method to increment tab index -->
+<c:set var="doINeedThis" value="${kfunc:incrementTabIndex(KualiForm, tabKey)}" />
+
+<c:set var="currentTab" value="${kfunc:getTabState(KualiForm, tabKey)}"/>
+<c:choose>
+    <c:when test="${empty currentTab}">
+        <c:set var="isOpen" value="${defaultOpen}" />
+    </c:when>
+    <c:when test="${!empty currentTab}" >
+        <c:set var="isOpen" value="${currentTab == 'OPEN'}" />
+    </c:when>
+</c:choose>
+
+<!-- if the section has errors, override and set isOpen to true -->
+<c:if test="${!empty tabErrorKey or not empty tabAuditKey}">
+  <kul:checkErrors keyMatch="${tabErrorKey}" auditMatch="${tabAuditKey}"/>
+  <c:set var="isOpen" value="${hasErrors ? true : isOpen}"/>
+</c:if>
+
+<html:hidden property="tabStates(${tabKey})" value="${(isOpen ? 'OPEN' : 'CLOSE')}" />
+<!-- TAB -->
+
+<c:if test="${! empty tabItemCount}">
+  <c:set var="tabTitle" value="${tabTitle} (${tabItemCount})" />
+</c:if>
+              
+	              <div class="${overrideDivClass}">
+	              <c:if test="${!noShowHideButton}" >	              
+	               <c:if test="${isOpen == 'true' || isOpen == 'TRUE'}">
+	                 <html:image property="methodToCall.toggleTab.tab${tabKey}" src="${ConfigProperties.kr.externalizable.images.url}tinybutton-hide.gif" title="close ${tabTitle}" alt="close ${tabTitle}" styleClass="tinybutton"  styleId="tab-${tabKey}-imageToggle" onclick="javascript: return toggleTab(document, '${tabKey}'); " align="absmiddle" />&nbsp;
+	               </c:if>
+	               <c:if test="${isOpen != 'true' && isOpen != 'TRUE'}">
+	                 <html:image  property="methodToCall.toggleTab${overrideToggleTabMethodString}.tab${tabKey}" src="${ConfigProperties.kr.externalizable.images.url}tinybutton-show.gif" title="open ${tabTitle}" alt="open ${tabTitle}" styleClass="tinybutton" styleId="tab-${tabKey}-imageToggle" onclick="javascript: return toggleTab${overrideToggleTabMethodString}(document, '${tabKey}'); " align="absmiddle"/>&nbsp;
+	               </c:if>
+	               </c:if>
+	               ${tabTitle} <div style="float: right; margin-right:5px;"> ${tabTitleRightAligned}</div>
+	              </div>
+	              
+
+<c:if test="${isOpen == 'true' || isOpen == 'TRUE'}">
+<div style="display: block;" id="tab-${tabKey}-div">
+</c:if>
+<c:if test="${isOpen != 'true' && isOpen != 'TRUE'}" >
+<div style="display: none;" id="tab-${tabKey}-div">
+</c:if>
+  
+ 
+      
+        <!-- display errors for this tab -->
+        <c:if test="${! (empty tabErrorKey)}">
+          <div class="tab-container-error"><div class="left-errmsg-tab"><kul:errors keyMatch="${tabErrorKey}"/></div></div>
+        </c:if>
+        
+        <c:if test="${! (empty tabAuditKey)}">
+        	<div class="tab-container-error"><div class="left-errmsg-tab">
+				<c:forEach items="${fn:split(auditCluster,',')}" var="cluster">
+        	   		<kul:auditErrors cluster="${cluster}" keyMatch="${tabAuditKey}" isLink="false" includesTitle="true"/>
+				</c:forEach>
+        	</div></div>
+      	</c:if>
+      
+        <!-- Before the jsp:doBody of the kul:tab tag -->            
+        <jsp:doBody/>            
+        <!-- After the jsp:doBody of the kul:tab tag -->
+ 
+      
+  
+</div>         


### PR DESCRIPTION
Created 3 custom classes derived from the corresponding irb class for:
ProtocolAttachmentProtocol
ProtocolAttachmentFilter
SortByValuesFinder

The main code change in ProtocolAttachmentProtocol adds two fields, protocolSourceProtocol and sourceProtocolAmendRenewalNumber. ProtocolSourceProtocol is populated by looking at all the attachments that have the same fileID and picking the newest one (by sorting by ID and picking the first one) and then storing the protocolId for that attachment. The amendment/renewal number consists of the last 4 alphanumeric characters (if any) in the protocolId.

Added corresponding spring beans to load the custom edu.arizona classes above:
CustomProtocolAttachmentProtocol.xml
CustomProtocolAttachmentFilter.xml

Changed the repository-irb.xml to load the ProtocolAttachmentProtocols in the custom edu.arizona class.

Added innerTabRightAligned.tag to display the A/R number on the protocol attachments page and modified protocolAttachmentProtocol.tag to use it.
