### PR TITLE
UAR-720 - Adding in UA fix which essentially re-adds setters for partici...

### DIFF
--- a/src/main/java/edu/arizona/kra/irb/actions/copy/CustomProtocolCopyServiceImpl.java
+++ b/src/main/java/edu/arizona/kra/irb/actions/copy/CustomProtocolCopyServiceImpl.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2005-2014 The Kuali Foundation
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.osedu.org/licenses/ECL-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.arizona.kra.irb.actions.copy;
+
+import java.util.List;
+
+import org.kuali.kra.irb.Protocol;
+import org.kuali.kra.irb.ProtocolDocument;
+import org.kuali.kra.irb.actions.risklevel.ProtocolRiskLevel;
+import org.kuali.kra.irb.protocol.participant.ProtocolParticipant;
+
+/**
+ * A class that encapsulates custom UA logic that pertains
+ * to IRB but not IACUC.
+ */
+public class CustomProtocolCopyServiceImpl extends org.kuali.kra.irb.actions.copy.ProtocolCopyServiceImpl {
+    
+    
+    /**
+     * Copy lists that exist in IRB but not IACUC.
+     * 
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+	@Override
+	protected void copyProtocolLists(ProtocolDocument srcDoc, ProtocolDocument destDoc) {
+		super.copyProtocolLists(srcDoc, destDoc);
+		Protocol srcProtocol = srcDoc.getProtocol();
+        Protocol destProtocol = destDoc.getProtocol();
+		destProtocol.setProtocolRiskLevels((List<ProtocolRiskLevel>) deepCopy(srcProtocol.getProtocolRiskLevels()));
+		destProtocol.setProtocolParticipants((List<ProtocolParticipant>) deepCopy(srcProtocol.getProtocolParticipants()));
+	}
+
+}
+
+	

--- a/src/main/resources/edu/arizona/kra/irb/CustomIrbSpringBeans.xml
+++ b/src/main/resources/edu/arizona/kra/irb/CustomIrbSpringBeans.xml
@@ -53,7 +53,17 @@
 		<property name="parameterService" ref="parameterService" />
 		<property name="kcPersonService" ref="kcPersonService" />
 	</bean>
- 	 
+
+    <bean id="protocolCopyService" class="edu.arizona.kra.irb.actions.copy.CustomProtocolCopyServiceImpl">
+        <property name="documentService" ref="documentService" />
+        <property name="systemAuthorizationService" ref="systemAuthorizationService" />
+        <property name="kraAuthorizationService" ref="kraAuthorizationService" />
+        <property name="protocolNumberService" ref="protocolNumberService" />
+        <property name="sequenceAccessorService">
+            <ref bean="sequenceAccessorService" />
+        </property>
+    </bean>
+    
 </beans>
 
 


### PR DESCRIPTION
...pants and risk level lists in the copy protocol service. This is something that was broken by foundation when they refactored IRB/IACUC to share ancestor classes. This is also the fix for UAR-672, and UAR-673.
