### PR TITLE
UAR-708 - 'Other' and 'Attachments' section not open for admin correction

### DIFF
--- a/src/main/java/edu/arizona/kra/irb/actions/CustomActionHelper.java
+++ b/src/main/java/edu/arizona/kra/irb/actions/CustomActionHelper.java
@@ -17,10 +17,12 @@ package edu.arizona.kra.irb.actions;
 
 import org.kuali.kra.irb.actions.ActionHelper;
 import org.kuali.kra.irb.actions.amendrenew.ProtocolAmendmentBean;
+import org.kuali.kra.irb.actions.correction.AdminCorrectionBean;
 import org.kuali.kra.protocol.actions.ActionHelperBase;
 
 import edu.arizona.kra.irb.CustomProtocolForm;
 import edu.arizona.kra.irb.actions.amendrenew.CustomProtocolAmendmentBean;
+import edu.arizona.kra.irb.actions.correction.CustomAdminCorrectionBean;
 
 // import org.kuali.kra.irb.actions.notifyirb.ProtocolActionAttachment;
 
@@ -42,6 +44,11 @@ public class CustomActionHelper extends org.kuali.kra.irb.actions.ActionHelper {
     @Override
     protected ProtocolAmendmentBean getNewProtocolAmendmentBeanInstanceHook(ActionHelperBase actionHelper) {
         return new CustomProtocolAmendmentBean((ActionHelper) actionHelper);
+    }
+    
+    @Override
+    protected AdminCorrectionBean getNewAdminCorrectionBeanInstanceHook(ActionHelperBase actionHelper) {
+        return new CustomAdminCorrectionBean((ActionHelper) actionHelper);
     }
 
 }

--- a/src/main/java/edu/arizona/kra/irb/actions/correction/CustomAdminCorrectionBean.java
+++ b/src/main/java/edu/arizona/kra/irb/actions/correction/CustomAdminCorrectionBean.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2005-2014 The Kuali Foundation
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.opensource.org/licenses/ecl1.php
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.arizona.kra.irb.actions.correction;
+
+import org.kuali.kra.irb.actions.ActionHelper;
+
+public class CustomAdminCorrectionBean extends org.kuali.kra.irb.actions.correction.AdminCorrectionBean {
+	private static final long serialVersionUID = -7246448632911841016L;
+
+	/**
+     * UA implementation constructor to default 2 modules
+     * to always being enabled. This ensures the original
+     * Protocol can be "Admin Corrected" even after an open
+     * Ammendment has been created.
+     * 
+     * @param actionHelper Reference back to the action helper for this bean
+     */
+    public CustomAdminCorrectionBean(ActionHelper actionHelper) {
+        super(actionHelper);
+        super.setAddModifyAttachmentsEnabled(true);
+        super.setOthersEnabled(true);
+    }
+
+    /**
+     * UA implementation to not consider "Other" and "Notes/Attachment"
+     * modules when deciding if an amendment/renewal is outstanding.
+     */
+    @Override
+    public boolean isAmendmentRenewalOutstanding() {
+        return !(getGeneralInfoEnabled() &&  
+            getFundingSourceEnabled() && 
+            getProtocolReferencesEnabled() && 
+            getProtocolOrganizationsEnabled() && 
+            getSubjectsEnabled() && 
+            getAreasOfResearchEnabled() && 
+            getSpecialReviewEnabled() && 
+            getProtocolPersonnelEnabled() && 
+            getProtocolPermissionsEnabled() &&
+            getQuestionnaireEnabled());
+    }
+
+}

--- a/src/main/java/org/kuali/kra/protocol/actions/amendrenew/ProtocolAmendRenewServiceImplBase.java
+++ b/src/main/java/org/kuali/kra/protocol/actions/amendrenew/ProtocolAmendRenewServiceImplBase.java
@@ -20,7 +20,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.kuali.kra.dao.KraLookupDao;
+import org.kuali.kra.irb.actions.amendrenew.ProtocolModule;
 import org.kuali.kra.protocol.ProtocolBase;
 import org.kuali.kra.protocol.ProtocolDocumentBase;
 import org.kuali.kra.protocol.ProtocolFinderDao;
@@ -517,14 +519,17 @@ public abstract class ProtocolAmendRenewServiceImplBase implements
 		List<ProtocolBase> protocols = getAmendmentAndRenewals(protocolNumber);
 		for (ProtocolBase protocol : protocols) {
 			if (!isAmendmentCompleted(protocol)) {
-				ProtocolAmendRenewalBase amendRenewal = protocol
-						.getProtocolAmendRenewal();
+				ProtocolAmendRenewalBase amendRenewal = protocol.getProtocolAmendRenewal();
 				if (amendRenewal != null) {
-					List<ProtocolAmendRenewModuleBase> modules = amendRenewal
-							.getModules();
+					List<ProtocolAmendRenewModuleBase> modules = amendRenewal.getModules();
 					for (ProtocolAmendRenewModuleBase module : modules) {
-						moduleTypeCodes.remove(module
-								.getProtocolModuleTypeCode());
+						if (StringUtils.equals(module.getProtocolModuleTypeCode(), ProtocolModule.OTHERS)
+						    || StringUtils.equals(module.getProtocolModuleTypeCode(), ProtocolModule.ADD_MODIFY_ATTACHMENTS)) {
+							// These two modules should be editable even with ammend/renewals
+							// active. This should be true for both IRB and IACUC.
+							continue;
+						}
+						moduleTypeCodes.remove(module.getProtocolModuleTypeCode());
 					}
 				}
 			}


### PR DESCRIPTION
- CustomAdminCorrectionBean.java - Overriding to intitialize 'Other' and 'Notes/Attachment' modules to be enabled by default
- CustomActionHelper.java - Modifying to use CustomAdminCorrectionBean
- ProtocolAmendRenewServiceImplBase.java - Added logic to not exclude 'Other' and 'Notes/Attachment' modules
