### PR TITLE
UAR-625 Edit risk levels within an admin correction [FE UAR-13]

### DIFF
--- a/src/main/java/org/kuali/kra/irb/actions/ProtocolProtocolActionsAction.java
+++ b/src/main/java/org/kuali/kra/irb/actions/ProtocolProtocolActionsAction.java
@@ -1677,6 +1677,12 @@ public class ProtocolProtocolActionsAction extends ProtocolAction implements Aud
         ActionForward forward = mapping.findForward(Constants.MAPPING_BASIC);
         ProtocolForm protocolForm = (ProtocolForm) form;
         if(getProtocolActionRequestService().isOpenProtocolForAdminCorrectionAuthorized(protocolForm)) {
+        	ProtocolDocument protocolDocument = protocolForm.getProtocolDocument();
+            if(!(protocolDocument.getProtocol().isAmendment() || 
+            		protocolDocument.getProtocol().isRenewal() || 
+            		protocolDocument.getProtocol().isRenewalWithoutAmendment())){
+            	protocolForm.getProtocolHelper().setModifyRiskLevels(true);
+            }
             String forwardTo = getProtocolActionRequestService().openProtocolForAdminCorrection(protocolForm);
             forward = mapping.findForward(forwardTo);
         }

--- a/src/main/java/org/kuali/kra/irb/actions/risklevel/ProtocolRiskLevelBean.java
+++ b/src/main/java/org/kuali/kra/irb/actions/risklevel/ProtocolRiskLevelBean.java
@@ -28,6 +28,8 @@ public class ProtocolRiskLevelBean implements Serializable {
     
     private ProtocolRiskLevel newProtocolRiskLevel;
     
+    private boolean modifyRiskLevels;
+    
     /**
      * Constructs a ProtocolRiskLevelBean.
      */
@@ -49,4 +51,12 @@ public class ProtocolRiskLevelBean implements Serializable {
         this.newProtocolRiskLevel = newProtocolRiskLevel;
     }
 
+	public boolean isModifyRiskLevels() {
+		return modifyRiskLevels;
+	}
+
+	public void setModifyRiskLevels(boolean modifyRiskLevels) {
+		this.modifyRiskLevels = modifyRiskLevels;
+	}
+    
 }

--- a/src/main/java/org/kuali/kra/irb/protocol/ProtocolHelper.java
+++ b/src/main/java/org/kuali/kra/irb/protocol/ProtocolHelper.java
@@ -24,6 +24,9 @@ import org.kuali.kra.irb.ProtocolDocument;
 import org.kuali.kra.irb.ProtocolForm;
 import org.kuali.kra.irb.actions.ProtocolAction;
 import org.kuali.kra.irb.actions.ProtocolActionType;
+import org.kuali.kra.irb.actions.approve.ProtocolApproveBean;
+import org.kuali.kra.irb.actions.risklevel.ProtocolRiskLevel;
+import org.kuali.kra.irb.actions.risklevel.ProtocolRiskLevelBean;
 import org.kuali.kra.irb.actions.submit.ProtocolExemptStudiesCheckListItem;
 import org.kuali.kra.irb.actions.submit.ProtocolSubmission;
 import org.kuali.kra.irb.auth.ProtocolTask;
@@ -64,9 +67,11 @@ public class ProtocolHelper extends ProtocolHelperBase {
 
     private boolean modifySubjects = false;
     
+    private ProtocolForm form;
+    
     public ProtocolHelper(ProtocolForm form) {        
-        
         super(form);
+        this.form = form;
         setNewProtocolParticipant(new ProtocolParticipant());
     }    
     
@@ -249,4 +254,25 @@ public class ProtocolHelper extends ProtocolHelperBase {
         return new ProtocolPerson();
     }
     
+    private ProtocolRiskLevelBean getProtocolRiskLevelBean(){
+    	ProtocolApproveBean protocolApproveBean = (ProtocolApproveBean) form.getActionHelper().getProtocolFullApprovalBean();
+    	return protocolApproveBean.getProtocolRiskLevelBean();
+    }
+    
+    
+    public ProtocolRiskLevel getNewProtocolRiskLevel() {
+        return getProtocolRiskLevelBean().getNewProtocolRiskLevel();
+    }
+    
+    public void setNewProtocolRiskLevel(ProtocolRiskLevel newProtocolRiskLevel) {
+    	getProtocolRiskLevelBean().setNewProtocolRiskLevel(newProtocolRiskLevel);
+    }
+    
+    public boolean getModifyRiskLevels() {
+        return getProtocolRiskLevelBean().isModifyRiskLevels();
+    }
+
+    public void setModifyRiskLevels(boolean modifyRiskLevels) {
+    	getProtocolRiskLevelBean().setModifyRiskLevels(modifyRiskLevels);
+    }
 }

--- a/src/main/webapp/WEB-INF/jsp/irb/ProtocolProtocol.jsp
+++ b/src/main/webapp/WEB-INF/jsp/irb/ProtocolProtocol.jsp
@@ -38,12 +38,7 @@
 
 <kra-irb:protocolRequiredFields />
 <kra-irb:protocolStatusDate />
-
-<c:choose>
-	<c:when test="${KualiForm.displayRiskLevelPanel}" > 
-		<kra-irb:protocolRiskLevel />
-	</c:when>
-</c:choose>
+<kra-irb:protocolRiskLevel />
 <kra-irb:protocolAdditionalInformation />
 <kra-irb:protocolLocations />
 <kra-irb:protocolFundingSources />

--- a/src/main/webapp/WEB-INF/tags/irb/protocolRiskLevel.tag
+++ b/src/main/webapp/WEB-INF/tags/irb/protocolRiskLevel.tag
@@ -1,66 +1,145 @@
+<%--
+ Copyright 2005-2010 The Kuali Foundation
+
+ Licensed under the Educational Community License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.osedu.org/licenses/ECL-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+--%>
 <%@ include file="/WEB-INF/jsp/kraTldHeader.jsp"%>
 
-<c:set var="protocolRiskLevelsAttributes" value="${DataDictionary.ProtocolRiskLevel.attributes}" />
-<c:set var="riskLevelAttributes" value="${DataDictionary.RiskLevel.attributes}" />
-<c:set var="action" value="protocolProtocol" />
-<c:set var="commentDisplayLength" value="<%=org.kuali.kra.infrastructure.Constants.PROTOCOL_RISK_LEVEL_COMMENT_LENGTH%>" />
 
-<kul:tab tabTitle="Risk Levels" defaultOpen="false" tabErrorKey="" >
+<c:set var="attributes" value="${DataDictionary.ProtocolRiskLevel.attributes}" />
+<c:set var="readOnly" value="${!KualiForm.protocolHelper.modifyRiskLevels}" />
+
+<kul:tab tabTitle="Risk Levels" defaultOpen="false" tabErrorKey="protocolHelper.newProtocolRiskLevel*,document.protocol.protocolRiskLevels*">
     <div class="tab-container" align="center">
-		<h3>
-			<span class="subhead-left">Risk Levels</span>
-		    <span class="subhead-right"><kul:help businessObjectClassName="org.kuali.kra.bo.RiskLevel" altText="help"/></span>
-		</h3>
-		
-		<table cellpadding=0 cellspacing=0 summary="">
-		    <tbody>
-				<tr>
-				    <kul:htmlAttributeHeaderCell literalLabel="&nbsp;" /> 
-			       	<kul:htmlAttributeHeaderCell attributeEntry="${protocolRiskLevelsAttributes.riskLevelCode}" />
-			        <kul:htmlAttributeHeaderCell attributeEntry="${protocolRiskLevelsAttributes.dateAssigned}" />
-			        <kul:htmlAttributeHeaderCell attributeEntry="${protocolRiskLevelsAttributes.dateInactivated}" />
-			        <kul:htmlAttributeHeaderCell attributeEntry="${protocolRiskLevelsAttributes.status}" />
-			        <kul:htmlAttributeHeaderCell attributeEntry="${protocolRiskLevelsAttributes.comments}" />
-				</tr>
-			    <c:forEach var="protocolRiskLevel" items="${KualiForm.document.protocol.protocolRiskLevels}" varStatus="status">
-					<tr>
-					    <th class="infoline">
-	                        <c:out value="${status.index + 1}" />
-	                    </th>
-			           	<td align="left" valign="middle">
-			           	    <div align="left">
-			             	    <kul:htmlControlAttribute property="document.protocol.protocolRiskLevels[${status.index}].riskLevel.description" 
-			             	                              attributeEntry="${riskLevelAttributes.description}" readOnly="true" styleClass="fixed-size-200-select" />
-			                </div>
-			            </td>
-			            <td align="left" valign="middle">
-			                <div align="left">
-			             	    <kul:htmlControlAttribute property="document.protocol.protocolRiskLevels[${status.index}].dateAssigned" 
-			             	                              attributeEntry="${protocolRiskLevelsAttributes.dateAssigned}" readOnly="true" />
-			                </div>
-			            </td>
-			            <td align="left" valign="middle">
-			                <div align="left">
-			             	    <kul:htmlControlAttribute property="document.protocol.protocolRiskLevels[${status.index}].dateInactivated" 
-			             	                              attributeEntry="${protocolRiskLevelsAttributes.dateInactivated}" readOnly="true" />
-			                </div>
-			            </td>
-			          	<td align="left" valign="middle">
-			          	    <div align="left">
-			          	       <kul:htmlControlAttribute property="document.protocol.protocolRiskLevels[${status.index}].statusText" 
-			          	                                 attributeEntry="${protocolRiskLevelsAttributes.status}" readOnly="true" />
-			                </div>
-			            </td>
-			            <td align="left" valign="middle">
-			                <div align="left">
-			                    <kra:truncateComment textAreaFieldName="document.protocol.protocolRiskLevels[${status.index}].comments" action="${action}" 
-			                                         textAreaLabel="${protocolRiskLevelsAttributes.comments.label}" textValue="${protocolRiskLevel.comments}"  
-			                                         displaySize="${commentDisplayLength}"/>
-			                </div>
-			            </td>
-					</tr>
-				</tbody>
-			</c:forEach>
-		</table>
+
+        <h3>
+            <span class="subhead-left">Risk Levels</span>
+            <span class="subhead-right"><kul:help businessObjectClassName="org.kuali.kra.bo.RiskLevel" altText="help"/></span>
+        </h3>
+
+   
+        <table class="tab" cellpadding="0" cellspacing="0" summary="">
+            
+            <%-- Header --%>
+            <tr>
+                <th><div align="left">&nbsp;</div></th> 
+                <kul:htmlAttributeHeaderCell attributeEntry="${attributes.riskLevelCode}" />
+                <kul:htmlAttributeHeaderCell attributeEntry="${attributes.dateAssigned}" />
+                <kul:htmlAttributeHeaderCell attributeEntry="${attributes.dateInactivated}" />
+                <kul:htmlAttributeHeaderCell attributeEntry="${attributes.status}" />
+                <kul:htmlAttributeHeaderCell attributeEntry="${attributes.comments}" />
+                <c:if test="${!readOnly}">
+                    <kul:htmlAttributeHeaderCell literalLabel="Actions" scope="col"/>
+                </c:if>
+            </tr>
+                
+            <%-- New data --%>  
+            <kra:permission value="${KualiForm.protocolHelper.modifyRiskLevels}">              
+            <tr> 
+                <th class="infoline">
+                    <c:out value="Add:" />
+                </th>
+                <td align="left" valign="middle">
+                    <div align="left">
+                        <kul:htmlControlAttribute property="protocolHelper.newProtocolRiskLevel.riskLevelCode" attributeEntry="${attributes.riskLevelCode}" styleClass="fixed-size-200-select" />
+                    </div>
+                </td>
+                <td align="left" valign="middle">
+                    <div align="center">
+                        <kul:htmlControlAttribute property="protocolHelper.newProtocolRiskLevel.dateAssigned" attributeEntry="${attributes.dateAssigned}" />
+                    </div>
+                </td>
+                <td align="left" valign="middle">
+                    <div align="center">
+                        <kul:htmlControlAttribute property="protocolHelper.newProtocolRiskLevel.dateInactivated" attributeEntry="${attributes.dateInactivated}" readOnly="true" />
+                    </div>
+                </td>
+                <td align="left" valign="middle">
+                    <div align="center">
+                        <kul:htmlControlAttribute property="protocolHelper.newProtocolRiskLevel.status" attributeEntry="${attributes.status}" readOnly="true" />
+                    </div>
+                </td>
+                <td align="left" valign="middle">
+                    <div align="left">
+                        <kul:htmlControlAttribute property="protocolHelper.newProtocolRiskLevel.comments" attributeEntry="${attributes.comments}" />
+                    </div>
+                </td>
+                <td align="left" valign="middle">
+                    <div align="center">
+                        <html:image property="methodToCall.addRiskLevel.anchor${tabKey}"
+                                    src='${ConfigProperties.kra.externalizable.images.url}tinybutton-add1.gif' styleClass="tinybutton"/>
+                    </div>
+                </td>
+            </tr>
+              </kra:permission>
+               <%-- New data --%>
+            
+            <%-- Existing data --%>
+            <c:forEach var="protocolRiskLevel" items="${KualiForm.document.protocol.protocolRiskLevels}" varStatus="status">
+                <c:set var="updateOnly" value="${protocolRiskLevel.persisted}" />
+                <tr>
+                     <th class="infoline">
+                         ${status.index + 1}
+                     </th>
+                    <td align="left" valign="middle">
+                         <div align="left">
+                             <kul:htmlControlAttribute property="document.protocol.protocolRiskLevels[${status.index}].riskLevelCode" 
+                                                       attributeEntry="${attributes.riskLevelCode}" readOnly="true" />
+                         </div>
+                    </td>
+                    <td align="left" valign="middle">
+                         <div align="center">
+                             <kul:htmlControlAttribute property="document.protocol.protocolRiskLevels[${status.index}].dateAssigned" 
+                                                       attributeEntry="${attributes.dateAssigned}" readOnly="true" />
+                         </div>
+                    </td>
+                    <td align="left" valign="middle">
+                         <div align="center">
+                             <kul:htmlControlAttribute property="document.protocol.protocolRiskLevels[${status.index}].dateInactivated" 
+                                                       attributeEntry="${attributes.dateInactivated}" readOnly="${!protocolRiskLevel.persisted || readOnly}" />
+                         </div>
+                    </td>
+                    <td align="left" valign="middle">
+                        <div align="center">
+                             <kul:htmlControlAttribute property="document.protocol.protocolRiskLevels[${status.index}].status" 
+                                                       attributeEntry="${attributes.status}" readOnly="true" />
+                        </div>
+                    </td>
+                    <td align="left" valign="middle">
+                        <div align="left">
+                             <%--<kul:htmlControlAttribute property="document.protocol.protocolRiskLevels[${status.index}].comments" 
+                                                       attributeEntry="${attributes.comments}" readOnly="true" />--%>
+                             <kra:truncateComment textAreaFieldName="document.protocol.protocolRiskLevels[${status.index}].comments" action="protocolProtocolActions" textAreaLabel="${attributes.comments.label}" textValue="${KualiForm.document.protocolList[0].protocolRiskLevels[status.index].comments}" displaySize="200"/>
+                        </div>
+                    </td>
+                    <c:if test="${!readOnly}">
+                    <td align="left" valign="middle">
+                        <div align="center">
+                            <c:choose>
+                                <c:when test="${!protocolRiskLevel.persisted}">
+                                    <html:image property="methodToCall.deleteRiskLevel.line${status.index}.anchor${tabKey}"
+                                                src='${ConfigProperties.kra.externalizable.images.url}tinybutton-delete1.gif' styleClass="tinybutton"/>
+                                </c:when>
+                                <c:otherwise>
+                                    <html:image property="methodToCall.updateRiskLevel.line${status.index}.anchor${tabKey}"
+                                                src='${ConfigProperties.kra.externalizable.images.url}tinybutton-update.gif' styleClass="tinybutton"/>
+                                </c:otherwise>
+                            </c:choose>
+                        </div>
+                    </td>
+                     </c:if>
+                </tr>
+            </c:forEach>
+        </table>       
     </div>
 </kul:tab>


### PR DESCRIPTION
- ProtocolRiskLevelBean.java
  - Modifying to encapsulate modifyRiskLevels state
- ProtocolProtocolActionsAction.java
  - Modifying to disallow risk editing when in Amendment/Renewal/Amend+Renewal
- ProtocolHelper.java
  - Adding methods to get/set risk level states
- ProtocolProtocolAction.java
  - Adding core logic to add/remove/update risk levels
- ProtocolProtocol.jsp
  - Modifying to always display risk level panel
- protocolRiskLevel.tag
  - Modifying core logic to edit risk levels
