### PR TITLE
UAR-756: Protocol Attachments tab "Sort By" not working

### DIFF
--- a/src/main/webapp/WEB-INF/tags/irb/protocolAttachmentProtocol.tag
+++ b/src/main/webapp/WEB-INF/tags/irb/protocolAttachmentProtocol.tag
@@ -237,6 +237,7 @@
             </table>
         <table cellpadding="4" cellspacing="0" summary="" id="protocol-attachment-table">
         <tbody>
+        <c:set var="activeDisplayIndex" value="0"/>
 		<c:forEach var="attachmentProtocol" items="${filteredAttachmentProtocols}" varStatus="itrStatus">
         
           <!--  Display logic to show the correct attribute being sorted on in the attachment header -->
@@ -254,10 +255,10 @@
           <c:set var="lastUpdateDisplay">
               <fmt:formatDate value="${attachmentProtocol.updateTimestamp}" pattern="MM/dd/yyyy KK:mm a" />                      
           </c:set>	
-          	
+          
 		  <c:choose>
 		    <c:when test="${attachmentProtocol.active}">
-		      <tr id="protocol-attachment-row-${itrStatus.index}" class="fake-class-level-1">
+		      <tr id="protocol-attachment-row-${activeDisplayIndex}" class="fake-class-level-1">
 		        <td>
 		             <c:set var="modify" value="${KualiForm.notesAttachmentsHelper.modifyAttachments and attachmentProtocol.documentStatusCode != '3' and (not KualiForm.document.protocolList[0].renewalWithoutAmendment or attachmentProtocol.documentStatusCode != '2')}" />
 		    			<kul:innerTab tabTitle="${attachmentProtocol.type.description} - ${descDisplay} - ${updateUserDisplay} (${lastUpdateDisplay})" parentTab="Protocol Attachments(${size})" defaultOpen="false" tabErrorKey="document.protocolList[0].attachmentProtocols[${itrStatus.index}]*,document.protocolList[0].attachmentProtocols[${itrStatus.index}]*" useCurrentTabIndexAsKey="true" tabAuditKey="document.protocolList[0].attachmentProtocols[${itrStatus.index}]*" auditCluster="NoteAndAttachmentAuditErrors">
@@ -270,7 +271,7 @@
 			         			</div>
 			         		</th>
 			         		<td align="left" valign="middle" colspan="3">
-			                	<div align="left" id="attachment-type-${itrStatus.index}">
+			                	<div align="left" id="attachment-type-${activeDisplayIndex}">
 			                		<kul:htmlControlAttribute property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].typeCode" attributeEntry="${protocolAttachmentProtocolAttributes['typeCode']}" readOnly="true" readOnlyAlternateDisplay ="${attachmentProtocol.type.description}" />
 				            	</div>
 							</td>
@@ -304,7 +305,7 @@
 			         			</div>
 			         		</th>
 			         		<td align="left" valign="middle">
-			                	<div align="left" id="updated-by-${itrStatus.index}">
+			                	<div align="left" id="updated-by-${activeDisplayIndex}">
 			                		<kul:htmlControlAttribute property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].updateUserFullName" attributeEntry="${protocolAttachmentProtocolAttributes.updateUser}" readOnly="true"/>
 				            	</div>
 							</td>
@@ -326,7 +327,7 @@
 			         			</div>
 			         		</th>
 			         		<td align="left" valign="middle">
-			                	<div align="left" id="last-updated-${itrStatus.index}">
+			                	<div align="left" id="last-updated-${activeDisplayIndex}">
 			                	 	     <kul:htmlControlAttribute property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].updateTimestamp" attributeEntry="${protocolAttachmentProtocolAttributes.updateTimestamp}" readOnly="true"/>  
 				            	</div>
 							</td>
@@ -358,7 +359,7 @@
 								</div>
 							</th>
 			         		<td align="left" valign="middle">
-			                	<div align="left" id="row-description-${itrStatus.index}">
+			                	<div align="left" id="row-description-${activeDisplayIndex}">
 			                		<kul:htmlControlAttribute property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].description" attributeEntry="${protocolAttachmentProtocolAttributes.description}" readOnly="${!modify}"/>
 				            	</div>
 							</td>
@@ -457,6 +458,7 @@
 		    
 		        </td>
 		      </tr>
+		      <c:set var="activeDisplayIndex" value="${activeDisplayIndex+1}"/>
 		    </c:when>
 		    <c:otherwise>
 		      <html:hidden property="document.protocolList[0].attachmentProtocols[${itrStatus.index}].typeCode" value="${KualiForm.document.protocolList[0].attachmentProtocols[itrStatus.index].typeCode}" />


### PR DESCRIPTION
I modified protocolAttachmentProtocol.tag to include another variable, activeDisplayIndex, to be used as the unique id suffix for active protocolAttachments. 

I increment this new variable when the tag creates a new table row, and then append it as the unique suffix of the element id. 

I then replaced several of the legacy protocolAttachment.iterator.index references in the tag to be this new activeDisplayIndex. 

This guarantees that the element id sequence remains uninterrupted, that the javascript finds the elements it is searches for, and the functions behave as desired. 
