### PR TITLE
UAR 785: Copy custom data from amendment back into main protocol when amendment is merged

### DIFF
--- a/src/main/java/org/kuali/kra/irb/ProtocolDocument.java
+++ b/src/main/java/org/kuali/kra/irb/ProtocolDocument.java
@@ -61,6 +61,8 @@ import org.kuali.rice.krad.util.GlobalVariables;
 import org.kuali.rice.krad.util.ObjectUtils;
 import org.kuali.rice.krms.api.engine.Facts.Builder;
 
+import edu.arizona.kra.protocol.ProtocolCustomDataService;
+
 
 /**
  * 
@@ -144,6 +146,8 @@ public class ProtocolDocument extends ProtocolDocumentBase {
             currentProtocol.setProtocolDocument((ProtocolDocument)getDocumentService().getByDocumentHeaderId(currentProtocol.getProtocolDocument().getDocumentNumber()));
             currentProtocol.setMergeAmendment(true);
             newProtocolDocument = (ProtocolDocument) getProtocolVersionService().versionProtocolDocument(currentProtocol.getProtocolDocument());
+            // merge Custom Data from the amendment back into the main protocol
+            KraServiceLocator.getService(ProtocolCustomDataService.class).copyCustomDataAttributeValues(this, newProtocolDocument);
         } catch (Exception e) {
             throw new ProtocolMergeException(e);
         }


### PR DESCRIPTION
Fix consists of calling the ProtocolCustomDataService to copy the custom data from the amendment back into the main protocol, when the amendment is approved and merged.
Note: this fix is located in org.kuali.kra.irb.ProtocolDocument. I expect a similar fix for IACUC since they don't share the code base for the mergeAmendment method.
