### PR TITLE
UAR-824 - Adding rice krms dependency into kc_custom pom.xml.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,11 @@
             <version>3.8.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.kuali.rice</groupId>
+            <artifactId>rice-krms-impl</artifactId>
+            <version>${rice.version}</version>
+        </dependency>
 		<dependency>
 			<groupId>org.kuali.rice</groupId>
 			<artifactId>rice-kim-ldap</artifactId>


### PR DESCRIPTION
Since ProtocolDocument was promoted up from foundation, the krms.Facts.Builder symbol was not being found by mvn compile. Explicitly adding the dependency at the kc_custom overlay fixes this compile time error.
