### PR TITLE
UAR-849 Protocol Contingency View [FE KCI-843]

### DIFF
--- a/src/main/resources/edu/arizona/kra/datadictionary/CustomProtocolContingency.xml
+++ b/src/main/resources/edu/arizona/kra/datadictionary/CustomProtocolContingency.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?><!--
+ Copyright 2005-2014 The Kuali Foundation
+
+ Licensed under the Educational Community License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.osedu.org/licenses/ECL-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+--><beans xmlns="http://www.springframework.org/schema/beans" xmlns:p="http://www.springframework.org/schema/p" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <!-- Business Object Lookup Definition -->
+    <bean id="ProtocolContingency-lookupDefinition" parent="ProtocolContingency-lookupDefinition-parentBean">
+        <property name="resultFields">
+            <list>
+                <bean p:attributeName="protocolContingencyCode" p:forceInquiry="true" parent="FieldDefinition"/>
+                <bean p:attributeName="description" parent="FieldDefinition" p:maxLength="-1"/>
+            </list>
+        </property>
+    </bean>
+</beans>


### PR DESCRIPTION
Set protocol contingency description results field maxLength to -1 which disables the Kuali default maxLength, so the full description is displayed in the search results.
