### PR TITLE
UAR-840: Hidden exception prevents amendment merging back into main protocol after SMR approved

### DIFF
--- a/src/main/java/org/kuali/kra/irb/ProtocolDocument.java
+++ b/src/main/java/org/kuali/kra/irb/ProtocolDocument.java
@@ -89,7 +89,7 @@ public class ProtocolDocument extends ProtocolDocumentBase {
     private static final String APPROVED_COMMENT = "Approved";
     @SuppressWarnings("unused")
     private static final String DISAPPROVED_COMMENT = "Disapproved";
-    private static final String listOfStatiiEligibleForMerging = ProtocolStatus.SUBMITTED_TO_IRB + " " + ProtocolStatus.SPECIFIC_MINOR_REVISIONS_REQUIRED + " " + 
+    private static final String listOfStatesisEligibleForMerging = ProtocolStatus.SUBMITTED_TO_IRB + " " + ProtocolStatus.SPECIFIC_MINOR_REVISIONS_REQUIRED + " " + 
                                                                  ProtocolStatus.DEFERRED + " " + ProtocolStatus.SUBSTANTIVE_REVISIONS_REQUIRED + " " +  
                                                                  ProtocolStatus.AMENDMENT_IN_PROGRESS + " " + ProtocolStatus.RENEWAL_IN_PROGRESS + " " + 
                                                                  ProtocolStatus.SUSPENDED_BY_PI + " " + ProtocolStatus.DELETED + " " + ProtocolStatus.WITHDRAWN;
@@ -292,7 +292,7 @@ public class ProtocolDocument extends ProtocolDocumentBase {
         }
         
     private boolean isEligibleForMerging(String status, Protocol otherProtocol) {
-        return listOfStatiiEligibleForMerging.contains(status) && !StringUtils.equals(this.getProtocol().getProtocolNumber(), otherProtocol.getProtocolNumber());
+        return listOfStatesisEligibleForMerging.contains(status) && !StringUtils.equals(this.getProtocol().getProtocolNumber(), otherProtocol.getProtocolNumber());
     }
 
     /*
@@ -316,16 +316,28 @@ public class ProtocolDocument extends ProtocolDocumentBase {
         return KraServiceLocator.getService(ProtocolFinderDao.class);
     }
 
+    /**
+     * Finds and returns the approval action in the protocol's action list. 
+     * It assumes that there can be only one approve action in the list, and thus it returns the first one found.
+     * @return approvalAction - if any found, otherwise null.
+     */
     private ProtocolActionBase getLastApprovalAction() {
-        ProtocolActionBase result = null;
         for (ProtocolActionBase action: getProtocol().getProtocolActions()) {
-            if (ProtocolActionType.APPROVED.equals(action.getProtocolActionTypeCode()) ||
-                ProtocolActionType.EXPEDITE_APPROVAL.equals(action.getProtocolActionTypeCode()) ||
-                ProtocolActionType.GRANT_EXEMPTION.equals(action.getProtocolActionTypeCode().equals(ProtocolActionType.APPROVED))) {
-                result = action;
+            String protocolActionTypeCode = action.getProtocolActionTypeCode();
+            if (ProtocolActionType.APPROVED.equals(protocolActionTypeCode) ||
+                ProtocolActionType.EXPEDITE_APPROVAL.equals(protocolActionTypeCode) ||
+                ProtocolActionType.RESPONSE_APPROVAL.equals(protocolActionTypeCode) ||
+                ProtocolActionType.GRANT_EXEMPTION.equals(protocolActionTypeCode)) {
+                if ( LOG.isDebugEnabled() ){
+                    LOG.debug("Protocol:"+getProtocol().getProtocolNumber()+" getLastApprovalAction():"+protocolActionTypeCode);
+                }
+                return action;
             }
         }
-        return result;
+        if ( LOG.isDebugEnabled() ){
+            LOG.debug("Protocol:"+getProtocol().getProtocolNumber()+" getLastApprovalAction(): NULL!!!!");
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/org/kuali/kra/protocol/ProtocolDocumentBase.java
+++ b/src/main/java/org/kuali/kra/protocol/ProtocolDocumentBase.java
@@ -16,6 +16,8 @@
 package org.kuali.kra.protocol;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.kuali.kra.authorization.KraAuthorizationConstants;
 import org.kuali.kra.bo.KcPerson;
 import org.kuali.kra.bo.ResearchAreaBase;
@@ -23,6 +25,7 @@ import org.kuali.kra.bo.RolePersons;
 import org.kuali.kra.common.notification.service.KcNotificationService;
 import org.kuali.kra.document.ResearchDocumentBase;
 import org.kuali.kra.infrastructure.KraServiceLocator;
+import org.kuali.kra.irb.ProtocolDocument;
 import org.kuali.kra.krms.KcKrmsConstants;
 import org.kuali.kra.krms.KrmsRulesContext;
 import org.kuali.kra.protocol.actions.ProtocolActionBase;
@@ -58,7 +61,8 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 
 public abstract class ProtocolDocumentBase extends ResearchDocumentBase implements Copyable, SessionDocument, KrmsRulesContext {
-
+    private static final Log LOG = LogFactory.getLog(ProtocolDocumentBase.class);
+    
     private static final String AMENDMENT_KEY = "A";
     private static final String RENEWAL_KEY = "R";
     @SuppressWarnings("unused")
@@ -213,7 +217,7 @@ public abstract class ProtocolDocumentBase extends ResearchDocumentBase implemen
                 }
             }
             catch (Exception e) {
-
+                LOG.error("Exception when merging protocol amendment:", e);
             }
         }
         else if (isDisapproved(statusChangeEvent)) { 
@@ -226,8 +230,8 @@ public abstract class ProtocolDocumentBase extends ResearchDocumentBase implemen
                 performVersioningOperationsOnProtocolAfterDisapproval();
             }
             catch (Exception e) {
-                // TODO Need to figure out what to do if the versioning throws exceptions
-                e.printStackTrace();
+                //TODO Need to figure out what to do if the versioning throws exceptions
+                LOG.error("Exception when versioning protocol after disapproval:", e);
             }
         } else if (isRecall(statusChangeEvent)) {
             getProtocolGenericActionService().recall(getProtocol());

--- a/src/main/java/org/kuali/kra/protocol/ProtocolVersionServiceImplBase.java
+++ b/src/main/java/org/kuali/kra/protocol/ProtocolVersionServiceImplBase.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.kuali.kra.bo.CoeusSubModule;
 import org.kuali.kra.bo.DocumentNextvalue;
 import org.kuali.kra.infrastructure.KraServiceLocator;
+import org.kuali.kra.irb.Protocol;
 import org.kuali.kra.protocol.noteattachment.ProtocolAttachmentPersonnelBase;
 import org.kuali.kra.protocol.noteattachment.ProtocolAttachmentProtocolBase;
 import org.kuali.kra.protocol.personnel.ProtocolPersonBase;
@@ -222,16 +223,32 @@ public abstract class ProtocolVersionServiceImplBase implements ProtocolVersionS
         }
     }
 
+  
     /*
-     * seems that deepcopy is not really create new instance for copied obj.  this is really confusing
+     * UAR-840: Due to lazy loading, collections are not populated in the protocol before versioning, and because of null Ids OJB thinks we're
+     * trying to delete stuff from the DB. The current workaround is access the first object on all the collections on a protocol 
+     * before versioning it
+     *  
+     * @param protocol
      */
     protected void materializeCollections(ProtocolBase protocol) {
         checkCollection(protocol.getAttachmentProtocols());
         checkCollection(protocol.getProtocolLocations());
         checkCollection(protocol.getProtocolAmendRenewals());
+        checkCollection(protocol.getProtocolResearchAreas());
+        checkCollection(protocol.getProtocolActions());
+        checkCollection(protocol.getProtocolSubmissions());
+        checkCollection(protocol.getSpecialReviews());
+        
         for (ProtocolPersonBase person : protocol.getProtocolPersons()) {
             checkCollection(person.getAttachmentPersonnels());
             checkCollection(person.getProtocolUnits());
+        }
+        
+        if ( protocol instanceof Protocol){
+            Protocol irbProtocol = (Protocol) protocol;
+            checkCollection( irbProtocol.getProtocolRiskLevels());
+            checkCollection( irbProtocol.getProtocolParticipants());
         }
         
     }


### PR DESCRIPTION
Issue1: Due to lazy loading on the protocol object for collections, when the protocol is versioned prior to merging an amendment,it had objects with null ids inside the collections. So when trying to save it back to the DB, OJB was thinking that we are trying to delete those objects.
Solution: Add all protocol collections to ProtocolVersionServiceImplBase.materializeCollections and issue a call to this method prior to saving the initial protocol during versioning

Issue2: ProtocolActionType.RESPONSE_APPROVAL was not set as an acceptable "approval" action, which determined getLastApprovalAction() to return null, and that caused ProtocolDocumentBase to throw and silently catch an exception and not merge the amenment back
Solution: added ProtocolActionType.RESPONSE_APPROVAL and refactored getLastApprovalAction() in ProtocolVersionServiceImplBase and also added logging to ProtocolDocumentBase, especially where we have silent catches.
