### PR TITLE
UAR-899 - College of lead unit not appearing in workflow from copied proposal

### DIFF
--- a/src/main/resources/org/kuali/kra/datadictionary/ProposalDevelopmentDocument.xml
+++ b/src/main/resources/org/kuali/kra/datadictionary/ProposalDevelopmentDocument.xml
@@ -146,7 +146,8 @@
               <bean parent="WorkflowProperty" p:path="developmentProposalList.principalInvestigatorName"/>
               <bean parent="WorkflowProperty" p:path="developmentProposalList.title"/>
               <bean parent="WorkflowProperty" p:path="developmentProposalList.sponsor.sponsorCode"/>
-              <bean parent="WorkflowProperty" p:path="developmentProposalList.proposalPersonUnits"/>
+              <bean parent="WorkflowProperty" p:path="developmentProposalList.proposalPersons"/>
+              <bean parent="WorkflowProperty" p:path="developmentProposalList.proposalPersons.units"/>
 			 </list>
           </property>
         </bean>


### PR DESCRIPTION
The root issue here again lies with the (lack of) workflow header xml. 

The new rice generates around ten times less header xml. To change this, one needs to explicitly change DataDictionary entries to be additive. 

More specifically, I'm changing: 
src/main/resources/org/kuali/kra/datadictionary/ProposalDevelopmentDocument.xml 

from: 
{snip} 
<bean parent="WorkflowProperty" p:path="developmentProposalList.proposalPersonUnits"/> 
{/snip} 

to: 
{snip} 
<bean parent="WorkflowProperty" p:path="developmentProposalList.proposalPersons"/> 
<bean parent="WorkflowProperty" p:path="developmentProposalList.proposalPersons.units"/> 
{/snip} 

This small changed seems to corrected the issue of unit hierarchy nodes disappearing from a copied proposal.