### PR TITLE
UAR-960 Hide 'send notification' button on all modules

### DIFF
--- a/src/main/webapp/css/uar_kuali_application.css
+++ b/src/main/webapp/css/uar_kuali_application.css
@@ -421,3 +421,7 @@ div#budgetPersonnelSelectBudgetPeriod {
 div.questionnaireContent {
     clear: left;
 }
+
+div#globalbuttons input[name="methodToCall.sendNotification"] {
+	display: none;
+}


### PR DESCRIPTION
Added CSS to hide the send notification button for the ProposalDevelopment, IP, Award and Protocol modules.