### PR TITLE
UAR-969 Workflow annotation still says 'DOCUMENT REJECTED instead of 'DOCUMENT RETURNED FOR EDIT'

### DIFF
--- a/src/main/resources/ApplicationResources.properties
+++ b/src/main/resources/ApplicationResources.properties
@@ -853,7 +853,7 @@ message.proposalDevelopment.workflow.annotation.parentCanceled = SYSTEM ROUTED -
 message.proposalDevelopment.workflow.annotation.parentSubmitted = SYSTEM SUBMITTED - PARENT SUBMITTED
 message.proposalDevelopment.workflow.annotation.parentResubmitted = SYSTEM APPROVED - PARENT RE-SUBMITTED.
 message.proposalDevelopment.workflow.annotation.parentRejected = SYSTEM REJECTED DOCUEMENT - PARENT REJECTED: {0}
-message.proposalDevelopment.workflow.annotation.rejected = DOCUMENT REJECTED: {0}
+message.proposalDevelopment.workflow.annotation.rejected = DOCUMENT RETURNED FOR EDIT: {0}
 
 error.award.invalidObligatedAmount = Obligated Amount must be valid to add an Award Budget.
 error.award.budgetVersion.startDate.required=Obligation Start Date is required to add an Award Budget.


### PR DESCRIPTION
Changed property to correct value in ApplicationResources.properties.