### PR TITLE
UAR-1048, UAR-993: Increase the negotiation_unassoc_detail.title to allow 200 characters

### DIFF
--- a/src/main/resources/edu/arizona/kc/db/changelog/changesets/db.changelog-UAR-1048.xml
+++ b/src/main/resources/edu/arizona/kc/db/changelog/changesets/db.changelog-UAR-1048.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ 
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog 
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+ 
+    <changeSet id="UAR-1048" author="Natalia Costea Ibanez">
+        <comment>
+        	Increase the negotiation_unassoc_detail.title to allow 200 characters
+        </comment>
+        <sql>
+			alter table negotiation_unassoc_detail
+            modify ( 
+              title VARCHAR2(200 BYTE)
+            );
+		</sql>
+		<rollback>
+			alter table negotiation_unassoc_detail
+            modify ( 
+              title VARCHAR2(45 BYTE)
+            );
+		</rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/edu/arizona/kc/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/edu/arizona/kc/db/changelog/db.changelog-master.xml
@@ -9,5 +9,6 @@
   <!-- include file="changesets/db.changelog-UAR-###.xml" -->
   
   <include file="changesets/db.changelog-UAR-821.xml" />
+  <include file="changesets/db.changelog-UAR-1048.xml" />
 
 </databaseChangeLog>

--- a/src/main/resources/org/kuali/kra/datadictionary/NegotiationUnassociatedDetail.xml
+++ b/src/main/resources/org/kuali/kra/datadictionary/NegotiationUnassociatedDetail.xml
@@ -1,0 +1,299 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+  <bean id="NegotiationUnassociatedDetail" parent="NegotiationUnassociatedDetail-parentBean" />
+  <bean id="NegotiationUnassociatedDetail-parentBean" abstract="true" parent="BusinessObjectEntry">
+    <property name="businessObjectClass" value="org.kuali.kra.negotiations.bo.NegotiationUnassociatedDetail" />
+		<property name="objectLabel" value="NegotiationUnassociatedDetail-parentBean" />
+    <property name="titleAttribute" value="negotiationUnassociatedDetailId" />
+    <property name="lookupDefinition" >
+      <ref bean="NegotiationUnassociatedDetail-lookupDefinition" />
+    </property>
+    <property name="inquiryDefinition" >
+      <ref bean="NegotiationUnassociatedDetail-inquiryDefinition" />
+    </property>
+    <property name="attributes" >
+      <list>
+        <ref bean="NegotiationUnassociatedDetail-negotiationUnassociatedDetailId" />
+        <ref bean="NegotiationUnassociatedDetail-negotiationId" />
+        <ref bean="NegotiationUnassociatedDetail-title" />
+        <ref bean="NegotiationUnassociatedDetail-piPersonId" />
+        <ref bean="NegotiationUnassociatedDetail-piRolodexId" />
+        <ref bean="NegotiationUnassociatedDetail-piName" />
+        <ref bean="NegotiationUnassociatedDetail-leadUnitNumber" />
+        <ref bean="NegotiationUnassociatedDetail-sponsorCode" />
+        <ref bean="NegotiationUnassociatedDetail-primeSponsorCode" />
+        <ref bean="NegotiationUnassociatedDetail-sponsorAwardNumber" />
+        <ref bean="NegotiationUnassociatedDetail-contactAdminPersonId" />
+        <ref bean="NegotiationUnassociatedDetail-subAwardOrganizationId" />
+        <ref bean="NegotiationUnassociatedDetail-negotiableProposalTypeCode" />
+        <ref bean="NegotiationUnassociatedDetail-subAwardRequisitionerName" />
+        <ref bean="NegotiationUnassociatedDetail-subAwardRequisitionerUnitName" />
+        <ref bean="NegotiationUnassociatedDetail-subAwardRequisitionerUnitNumber" />
+      </list>
+    </property>
+  </bean>
+
+<!-- Attribute Definitions -->
+
+  <bean id="NegotiationUnassociatedDetail-negotiationUnassociatedDetailId" parent="NegotiationUnassociatedDetail-negotiationUnassociatedDetailId-parentBean" />
+  <bean id="NegotiationUnassociatedDetail-negotiationUnassociatedDetailId-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="negotiationUnassociatedDetailId" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="negotiationUnassociatedDetailId" />
+    <property name="shortLabel" value="negotiationUnassociatedDetailId" />
+    <property name="required" value="false" />
+    <property name="maxLength" value="22" />
+    <property name="validationPattern" >
+      <bean parent="NumericValidationPattern" />
+    </property>
+    <property name="control" >
+      <bean parent="TextControlDefinition" p:size="8" />
+    </property>
+    <property name="summary" value="negotiationUnassociatedDetailId" />
+    <property name="description" value="negotiationUnassociatedDetailId" />
+  </bean>
+  
+  <bean id="NegotiationUnassociatedDetail-negotiationId" parent="NegotiationUnassociatedDetail-negotiationId-parentBean" />
+  <bean id="NegotiationUnassociatedDetail-negotiationId-parentBean" abstract="true" parent="Negotiation-negotiationId">
+    <property name="name" value="negotiationId" />
+  </bean>
+  
+  <bean id="NegotiationUnassociatedDetail-title" parent="NegotiationUnassociatedDetail-title-parentBean" />
+  <bean id="NegotiationUnassociatedDetail-title-parentBean" abstract="true" parent="Award-title">
+    <property name="name" value="title" />
+    <property name="label" value="Title" />
+    <property name="shortLabel" value="Title" />
+    <property name="required" value="false" />
+    <property name="maxLength" value="45" />
+	<property name="control" >
+		<bean parent="TextControlDefinition" p:size="45" />
+	</property>    
+    <property name="summary" value="Title" />
+    <property name="description" value="Title" />
+  </bean>
+  
+  <bean id="NegotiationUnassociatedDetail-piPersonId" parent="NegotiationUnassociatedDetail-piPersonId-parentBean" />
+  <bean id="NegotiationUnassociatedDetail-piPersonId-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="piPersonId" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Principal Investigator Employee" />
+    <property name="shortLabel" value="PI Person" />
+    <property name="required" value="false" />
+    <property name="maxLength" value="40" />
+    <property name="validationPattern" >
+      <bean parent="AnyCharacterValidationPattern" />
+    </property>
+    <property name="control" >
+      <bean parent="TextControlDefinition" p:size="40" />
+    </property>
+    <property name="summary" value="Principal Investigator Employee" />
+    <property name="description" value="Principal Investigator Employee" />
+  </bean>
+  
+  <bean id="NegotiationUnassociatedDetail-piRolodexId" parent="NegotiationUnassociatedDetail-piRolodexId-parentBean" />
+  <bean id="NegotiationUnassociatedDetail-piRolodexId-parentBean" abstract="true" parent="Rolodex-rolodexId">
+    <property name="name" value="piRolodexId" />
+    <property name="label" value="Principal Investigator Non-Employee" />
+    <property name="shortLabel" value="PI Address Book" />
+    <property name="required" value="false" />
+    <property name="summary" value="Principal Investigator Non-Employee" />
+    <property name="description" value="Principal Investigator Non-Employee" />
+  </bean>
+  
+  <bean id="NegotiationUnassociatedDetail-piName" parent="NegotiationUnassociatedDetail-piName-parentBean" />
+  <bean id="NegotiationUnassociatedDetail-piName-parentBean" abstract="true" parent="KcPerson-fullName">
+    <property name="name" value="piName" />
+    <property name="label" value="Principal Investigator Name" />
+    <property name="shortLabel" value="PI Name" />
+    <property name="required" value="false" />
+    <property name="summary" value="Principal Investigator Name" />
+    <property name="description" value="Principal Investigator Name" />
+  </bean>  
+  
+  <bean id="NegotiationUnassociatedDetail-leadUnitNumber" parent="NegotiationUnassociatedDetail-leadUnitNumber-parentBean" />
+  <bean id="NegotiationUnassociatedDetail-leadUnitNumber-parentBean" abstract="true" parent="Award-unitNumber">
+    <property name="name" value="leadUnitNumber" />
+    <property name="label" value="Lead Unit" />
+    <property name="shortLabel" value="Lead Unit" />
+    <property name="required" value="false" />
+    <property name="maxLength" value="8" />
+    <property name="summary" value="Lead Unit" />
+    <property name="description" value="Lead Unit" />
+  </bean>
+  
+  <bean id="NegotiationUnassociatedDetail-sponsorCode" parent="NegotiationUnassociatedDetail-sponsorCode-parentBean" />
+  <bean id="NegotiationUnassociatedDetail-sponsorCode-parentBean" abstract="true" parent="Award-sponsorCode">
+    <property name="name" value="sponsorCode" />
+    <property name="label" value="Sponsor" />
+    <property name="shortLabel" value="Sponsor" />
+    <property name="required" value="false" />
+    <property name="summary" value="Sponsor" />
+    <property name="description" value="Sponsor" />
+  </bean>
+  
+  <bean id="NegotiationUnassociatedDetail-primeSponsorCode" parent="NegotiationUnassociatedDetail-primeSponsorCode-parentBean" />
+  <bean id="NegotiationUnassociatedDetail-primeSponsorCode-parentBean" abstract="true" parent="Award-primeSponsorCode">
+    <property name="name" value="primeSponsorCode" />
+    <property name="label" value="Prime Sponsor" />
+    <property name="shortLabel" value="Prime Sponsor" />
+    <property name="required" value="false" />
+    <property name="maxLength" value="6" />
+    <property name="summary" value="Prime Sponsor" />
+    <property name="description" value="Prime Sponsor" />
+  </bean>
+  
+  <bean id="NegotiationUnassociatedDetail-sponsorAwardNumber" parent="NegotiationUnassociatedDetail-sponsorAwardNumber-parentBean" />
+  <bean id="NegotiationUnassociatedDetail-sponsorAwardNumber-parentBean" abstract="true" parent="Award-sponsorAwardNumber">
+    <property name="name" value="sponsorAwardNumber" />
+    <property name="label" value="Sponsor Award" />
+    <property name="shortLabel" value="Sponsor Award" />
+    <property name="required" value="false" />
+    <property name="maxLength" value="70" />
+    <property name="summary" value="Sponsor Award" />
+    <property name="description" value="Sponsor Award" />
+  </bean>
+  
+  <bean id="NegotiationUnassociatedDetail-contactAdminPersonId" parent="NegotiationUnassociatedDetail-contactAdminPersonId-parentBean" />
+  <bean id="NegotiationUnassociatedDetail-contactAdminPersonId-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="contactAdminPersonId" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Admin Person" />
+    <property name="shortLabel" value="Admin Person" />
+    <property name="required" value="false" />
+    <property name="maxLength" value="40" />
+    <property name="validationPattern" >
+      <bean parent="AnyCharacterValidationPattern" />
+    </property>
+    <property name="control" >
+      <bean parent="TextControlDefinition" p:size="40" />
+    </property>
+    <property name="summary" value="Admin Person" />
+    <property name="description" value="Admin Person" />
+  </bean>
+  
+  <bean id="NegotiationUnassociatedDetail-subAwardOrganizationId" parent="NegotiationUnassociatedDetail-subAwardOrganizationId-parentBean" />
+  <bean id="NegotiationUnassociatedDetail-subAwardOrganizationId-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="subAwardOrganizationId" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Subaward Organization" />
+    <property name="shortLabel" value="Subaward Org" />
+    <property name="required" value="false" />
+    <property name="maxLength" value="8" />
+    <property name="validationPattern" >
+      <bean parent="AnyCharacterValidationPattern" />
+    </property>
+    <property name="control" >
+      <bean parent="TextControlDefinition" p:size="8" />
+    </property>
+    <property name="summary" value="Subaward Organization" />
+    <property name="description" value="Subaward Organization" />
+  </bean>
+  
+  <bean id="NegotiationUnassociatedDetail-negotiableProposalTypeCode" parent="NegotiationUnassociatedDetail-negotiableProposalTypeCode-parentBean" />
+  <bean id="NegotiationUnassociatedDetail-negotiableProposalTypeCode-parentBean" abstract="true" parent="InstitutionalProposal-proposalTypeCode">
+    <property name="name" value="negotiableProposalTypeCode" />
+    <property name="label" value="Proposal Type" />
+    <property name="shortLabel" value="Proposal Type" />
+    <property name="summary" value="Proposal Type" />
+    <property name="description" value="Proposal Type" />
+    <property name="required" value="false" />
+  </bean>
+  
+  <bean id="NegotiationUnassociatedDetail-subAwardRequisitionerName" parent="NegotiationUnassociatedDetail-subAwardRequisitionerName-parentBean" />
+  <bean id="NegotiationUnassociatedDetail-subAwardRequisitionerName-parentBean" abstract="true" parent="NegotiationUnassociatedDetail-piName">
+  	<property name="name" value="subAwardRequisitionerName" />
+    <property name="label" value="Requisitioner Name" />
+    <property name="shortLabel" value="Requisitioner Name" />
+    <property name="summary" value="Requisitioner Name" />
+    <property name="description" value="Requisitioner Name" />
+  </bean>
+  
+  <bean id="NegotiationUnassociatedDetail-subAwardRequisitionerUnitName" parent="NegotiationUnassociatedDetail-subAwardRequisitionerUnitName-parentBean" />
+  <bean id="NegotiationUnassociatedDetail-subAwardRequisitionerUnitName-parentBean" abstract="true" parent="NegotiationUnassociatedDetail-leadUnitNumber">
+  	<property name="name" value="subAwardRequisitionerUnitName" />
+    <property name="label" value="Requisitioner Unit" />
+    <property name="shortLabel" value="Requisitioner Unit" />
+    <property name="summary" value="Requisitioner Unit" />
+    <property name="description" value="Requisitioner Unit" />
+  </bean>
+  
+  <bean id="NegotiationUnassociatedDetail-subAwardRequisitionerUnitNumber" parent="NegotiationUnassociatedDetail-subAwardRequisitionerUnitNumber-parentBean" />
+  <bean id="NegotiationUnassociatedDetail-subAwardRequisitionerUnitNumber-parentBean" abstract="true" parent="NegotiationUnassociatedDetail-leadUnitNumber">
+  	<property name="name" value="subAwardRequisitionerUnitNumber" />
+    <property name="label" value="Requisitioner Unit Number" />
+    <property name="shortLabel" value="Requisitioner Unit Number" />
+    <property name="summary" value="Requisitioner Unit Number" />
+    <property name="description" value="Requisitioner Unit Number" />
+  </bean>
+  
+  <bean id="NegotiationUnassociatedDetail-inquiryDefinition" parent="NegotiationUnassociatedDetail-inquiryDefinition-parentBean" />
+  <bean id="NegotiationUnassociatedDetail-inquiryDefinition-parentBean" abstract="true" parent="InquiryDefinition">
+    <property name="title" value="Award" />
+    <property name="inquirySections" >
+      <list>
+        <bean parent="InquirySectionDefinition">
+          <property name="title" value="Negotiation Unassociated Detail Inquiry" />
+          <property name="numberOfColumns" value="2" />
+          <property name="inquiryFields" >
+            <list>
+				<bean p:attributeName="negotiationUnassociatedDetailId" p:forceInquiry="true" parent="FieldDefinition" />
+	            <bean p:attributeName="negotiationId" parent="FieldDefinition" />
+	            <bean p:attributeName="title" parent="FieldDefinition" />
+	            <bean p:attributeName="piPersonId" parent="FieldDefinition" />
+	            <bean p:attributeName="piRolodexId" parent="FieldDefinition" />
+	            <bean p:attributeName="leadUnitNumber" parent="FieldDefinition" />
+	            <bean p:attributeName="sponsorCode" parent="FieldDefinition" />
+	            <bean p:attributeName="primeSponsorCode" parent="FieldDefinition" />
+	            <bean p:attributeName="sponsorAwardNumber" parent="FieldDefinition" />
+	            <bean p:attributeName="contactAdminPersonId" parent="FieldDefinition" />
+	            <bean p:attributeName="subAwardOrganizationId" parent="FieldDefinition" />
+            </list>
+          </property>
+        </bean>
+      </list>
+    </property>
+  </bean>
+  
+  
+  <!-- Business Object Lookup Definition -->
+	<bean id="NegotiationUnassociatedDetail-lookupDefinition" parent="NegotiationUnassociatedDetail-lookupDefinition-parentBean" />
+  	<bean id="NegotiationUnassociatedDetail-lookupDefinition-parentBean" abstract="true" parent="LookupDefinition">
+		<property name="title" value="Negotiation Unassociated Detail Lookup" />
+		<!-- <property name="lookupableID" value="negotiationLookupable" />  -->
+		<property name="menubar" value="&lt;a href=&quot;index.jsp&quot;&gt;Main&lt;/a&gt;" />
+
+		<property name="defaultSort" >
+		  <bean parent="SortDefinition">
+		  </bean>
+		</property>
+		<property name="lookupFields" >
+		  <list>
+		  	<bean p:attributeName="negotiationUnassociatedDetailId" parent="FieldDefinition" />
+            <bean p:attributeName="negotiationId" parent="FieldDefinition" />
+		    
+		  </list>
+		</property>
+		<property name="resultFields" >
+		  <list>
+            <bean p:attributeName="negotiationUnassociatedDetailId" parent="FieldDefinition" />
+            <bean p:attributeName="negotiationId" parent="FieldDefinition" />
+            <bean p:attributeName="title" parent="FieldDefinition" />
+            <bean p:attributeName="piPersonId" parent="FieldDefinition" />
+            <bean p:attributeName="piRolodexId" parent="FieldDefinition" />
+            <bean p:attributeName="leadUnitNumber" parent="FieldDefinition" />
+            <bean p:attributeName="sponsorCode" parent="FieldDefinition" />
+            <bean p:attributeName="primeSponsorCode" parent="FieldDefinition" />
+            <bean p:attributeName="sponsorAwardNumber" parent="FieldDefinition" />
+            <bean p:attributeName="contactAdminPersonId" parent="FieldDefinition" />
+            <bean p:attributeName="subAwardOrganizationId" parent="FieldDefinition" />
+
+		  </list>
+		</property>
+		<property name="resultSetLimit" value="50" />
+	</bean>
+    
+</beans>

--- a/src/main/resources/org/kuali/kra/datadictionary/NegotiationUnassociatedDetail.xml
+++ b/src/main/resources/org/kuali/kra/datadictionary/NegotiationUnassociatedDetail.xml
@@ -68,7 +68,7 @@
     <property name="label" value="Title" />
     <property name="shortLabel" value="Title" />
     <property name="required" value="false" />
-    <property name="maxLength" value="45" />
+    <property name="maxLength" value="200" />
 	<property name="control" >
 		<bean parent="TextControlDefinition" p:size="45" />
 	</property>    


### PR DESCRIPTION
UAR-993 Negotiation Log migration is dependent on this fix.
Tech Note: updated the Negotiation Unassociated Detail  maintenance document to allow maxLength on the title field to be 200 chars and added liquibase script to increase this field accordingly in the negotiation_unassoc_detail table.