### PR TITLE
UAR-1122 adjust custom data sort to use custom_attribute.name instead of custom_attribute.label

### DIFF
--- a/src/main/java/org/kuali/kra/common/customattributes/CustomDataHelperBase.java
+++ b/src/main/java/org/kuali/kra/common/customattributes/CustomDataHelperBase.java
@@ -108,7 +108,7 @@ public abstract class CustomDataHelperBase<T extends DocumentCustomData> impleme
             customAttributeGroups.put(groupName, customAttributeDocumentList);
         }
         customAttributeDocumentList.add(customAttributeDocument.getValue());
-        Collections.sort(customAttributeDocumentList, new LabelComparator() ); 
+        Collections.sort(customAttributeDocumentList, new NameComparator() ); 
     }
 
     protected boolean isMatch(T documentCustomData, Entry<String, CustomAttributeDocument> customAttributeDocumentEntry) {
@@ -137,7 +137,7 @@ public abstract class CustomDataHelperBase<T extends DocumentCustomData> impleme
                 
             }
             customAttributeDocumentList.add(getCustomAttributeDocuments().get(customAttributeDocumentEntry.getValue().getCustomAttributeId().toString()));
-            Collections.sort(customAttributeDocumentList, new LabelComparator());
+            Collections.sort(customAttributeDocumentList, new NameComparator());
         }
     }
     
@@ -235,25 +235,25 @@ public abstract class CustomDataHelperBase<T extends DocumentCustomData> impleme
     /**
      * Sorts custom data attributes by label for alphabetical order on custom data panels.
      */
-    public class LabelComparator implements Comparator
+    public class NameComparator implements Comparator
     {    
-        public LabelComparator(){}
+        public NameComparator(){}
         
         public int compare(Object cad1, Object cad2 )
         {    
             try
             {
-                String label1 = ((CustomAttributeDocument)cad1).getCustomAttribute().getLabel();
-                String label2 = ((CustomAttributeDocument)cad2).getCustomAttribute().getLabel();
-                if (label1 == null)
+                String name1 = ((CustomAttributeDocument)cad1).getCustomAttribute().getName();
+                String name2 = ((CustomAttributeDocument)cad2).getCustomAttribute().getName();
+                if (name1 == null)
                 {
-                    label1 = "";
+                	name1 = "";
                 }
-                if (label2 == null)
+                if (name2 == null)
                 {
-                    label2 = "";
+                	name2 = "";
                 }
-                return label1.compareTo(label2);  
+                return name1.compareTo(name2);  
             }
             catch (Exception e)
             {

--- a/src/main/java/org/kuali/kra/proposaldevelopment/web/struts/action/ProposalDevelopmentAction.java
+++ b/src/main/java/org/kuali/kra/proposaldevelopment/web/struts/action/ProposalDevelopmentAction.java
@@ -1167,7 +1167,8 @@ public class ProposalDevelopmentAction extends BudgetParentActionBase {
 			proposalPersonQuestionnaireHelpers.add( helper );
 		}
 		pdform.setProposalPersonQuestionnaireHelpers( proposalPersonQuestionnaireHelpers );
-
+		pdform.getCustomDataHelper().prepareCustomData();
+		
 		pdform.getProposalDevelopmentParameters().put( PROPOSAL_SUMMARY_INDICATOR, this.getParameterService().getParameter( Constants.MODULE_NAMESPACE_PROPOSAL_DEVELOPMENT, ParameterConstants.DOCUMENT_COMPONENT, PROPOSAL_SUMMARY_INDICATOR ) );
 		pdform.getProposalDevelopmentParameters().put( BUDGET_SUMMARY_INDICATOR, this.getParameterService().getParameter( Constants.MODULE_NAMESPACE_PROPOSAL_DEVELOPMENT, ParameterConstants.DOCUMENT_COMPONENT, BUDGET_SUMMARY_INDICATOR ) );
 		pdform.getProposalDevelopmentParameters().put( KEY_PERSONNEL_INDICATOR, this.getParameterService().getParameter( Constants.MODULE_NAMESPACE_PROPOSAL_DEVELOPMENT, ParameterConstants.DOCUMENT_COMPONENT, KEY_PERSONNEL_INDICATOR ) );

--- a/src/main/java/org/kuali/kra/rules/CustomDataRule.java
+++ b/src/main/java/org/kuali/kra/rules/CustomDataRule.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2005-2014 The Kuali Foundation
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.osedu.org/licenses/ECL-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kuali.kra.rules;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kra.bo.*;
+import org.kuali.kra.infrastructure.Constants;
+import org.kuali.kra.infrastructure.KeyConstants;
+import org.kuali.kra.infrastructure.KraServiceLocator;
+import org.kuali.kra.lookup.keyvalue.ArgValueLookupValuesFinder;
+import org.kuali.kra.rule.BusinessRuleInterface;
+import org.kuali.kra.rule.event.SaveCustomDataEvent;
+import org.kuali.kra.service.CustomAttributeService;
+import org.kuali.kra.service.KcPersonService;
+import org.kuali.rice.core.api.util.KeyValue;
+import org.kuali.rice.core.api.util.RiceKeyConstants;
+import org.kuali.rice.kns.datadictionary.validation.charlevel.AnyCharacterValidationPattern;
+import org.kuali.rice.kns.datadictionary.validation.charlevel.NumericValidationPattern;
+import org.kuali.rice.krad.datadictionary.validation.ValidationPattern;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.util.*;
+
+/**
+ * Validates the rules for a Custom Attribute save action.
+ */
+public class CustomDataRule extends ResearchDocumentRuleBase implements BusinessRuleInterface<SaveCustomDataEvent> {
+
+    private static final String STRING = "String";
+    private static final String DATE = "Date";
+    private static final String NUMBER = "Number";
+    private static String CUSTOMATTRIBUTE_ERROR_START = "[";
+    private static String CUSTOMATTRIBUTE_ERROR_END = "].value";   
+    private static DateFormat dateFormat;
+    private static final String DATE_REGEX = "(0?[1-9]|1[012])/(0?[1-9]|[12][0-9]|3[01])/(19|2[0-9])[0-9]{2}";
+    private static Map<String, ValidationPattern> VALIDATION_CLASSES = new HashMap<String, ValidationPattern>();
+
+
+    
+    private CustomAttributeService customAttributeService;
+    
+    static {
+        final Map<String, ValidationPattern> tempPatterns = new HashMap<String, ValidationPattern>();
+        
+        final AnyCharacterValidationPattern anyCharVal = new AnyCharacterValidationPattern();
+        anyCharVal.setAllowWhitespace(true);
+        
+        tempPatterns.put(STRING, anyCharVal);
+        tempPatterns.put(NUMBER, new NumericValidationPattern());
+        
+        VALIDATION_CLASSES = Collections.unmodifiableMap(tempPatterns);
+        
+        dateFormat = DateFormat.getDateInstance(DateFormat.SHORT);
+        dateFormat.setLenient(false);
+    }
+    
+    /**
+     * {@inheritDoc}
+     * @see org.kuali.kra.rule.BusinessRuleInterface#processRules(org.kuali.kra.rule.event.KraDocumentEventBaseExtension)
+     */
+    public boolean processRules(SaveCustomDataEvent event) {
+        boolean rulePassed = true;
+        Map<String, CustomAttributeDocument> customAttributeDocuments = event.getCustomAttributeDocuments();
+        for (Map.Entry<String, CustomAttributeDocument> customAttributeDocumentEntry : customAttributeDocuments.entrySet()) {
+            CustomAttributeDocument customAttributeDocument = customAttributeDocumentEntry.getValue();
+
+            CustomAttribute customAttribute = customAttributeDocument.getCustomAttribute();
+            List<? extends DocumentCustomData> customDataList = event.getCustomDataList();
+            int index = 0;
+            for (DocumentCustomData data : customDataList) {
+                if (data.getCustomAttributeId() == customAttribute.getId().longValue()) {
+                    customAttribute.setValue(data.getValue());
+                    break;
+                }
+                index++;
+            }
+            String errorKey = event.getErrorPathPrefix() + CUSTOMATTRIBUTE_ERROR_START + index + CUSTOMATTRIBUTE_ERROR_END;
+            if (StringUtils.isNotBlank(customAttribute.getValue())) {
+                CustomAttributeDataType customAttributeDataType = customAttribute.getCustomAttributeDataType();
+                if (customAttributeDataType == null && customAttribute.getDataTypeCode() != null) {
+                    customAttributeDataType = getCustomAttributeService().getCustomAttributeDataType(customAttribute.getDataTypeCode());
+                }
+
+                if (customAttributeDataType != null) {
+                    rulePassed &= validateAttributeFormat(customAttribute, errorKey, event);
+                }
+            }
+            if (event.isValidateRequiredFields() && customAttributeDocument.isRequired() && StringUtils.isBlank(customAttribute.getValue())) {
+                event.reportError(customAttribute, errorKey, RiceKeyConstants.ERROR_REQUIRED, 
+                        customAttribute.getLabel(),customAttribute.getValue(), getValidFormat(customAttribute.getCustomAttributeDataType().getDescription()));
+                 rulePassed = false;
+            }
+            
+        }
+
+        return rulePassed;
+    }
+
+
+    /**
+     * 
+     * This method is to validate the format/length of custom attribute
+     * @param customAttribute
+     * @param errorKey
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    protected boolean validateAttributeFormat(CustomAttribute customAttribute, String errorKey, SaveCustomDataEvent event) {
+
+        boolean isValid = true;
+        CustomAttributeDataType customAttributeDataType = customAttribute.getCustomAttributeDataType();
+        String attributeValue = customAttribute.getValue();
+        if (customAttributeDataType == null && customAttribute.getDataTypeCode() != null) {
+            customAttributeDataType = getCustomAttributeService().getCustomAttributeDataType(
+                    customAttribute.getDataTypeCode());
+        }
+        if (customAttributeDataType != null) {
+            Integer maxLength = customAttribute.getDataLength();
+            if ((maxLength != null) && (maxLength.intValue() < attributeValue.length())) {
+                event.reportError(customAttribute, errorKey, RiceKeyConstants.ERROR_MAX_LENGTH, customAttribute.getLabel(), maxLength.toString());
+                isValid = false;
+            }
+                
+            ValidationPattern validationPattern = VALIDATION_CLASSES.get(customAttributeDataType.getDescription());
+            String validFormat = getValidFormat(customAttributeDataType.getDescription());
+            if (validationPattern != null) {
+                if (!validationPattern.matches(attributeValue)) {
+                    event.reportError(customAttribute, errorKey, KeyConstants.ERROR_INVALID_FORMAT_WITH_FORMAT, customAttribute.getLabel(), attributeValue, validFormat);
+                    isValid = false;
+                }
+            } else if (DATE.equals(customAttributeDataType.getDescription())) {
+                if (attributeValue != null && !attributeValue.matches(DATE_REGEX)) {
+                    event.reportError(customAttribute, errorKey, RiceKeyConstants.ERROR_INVALID_FORMAT, customAttribute.getLabel(), attributeValue, validFormat);
+                    isValid = false;
+                } else {
+                    try {
+                        dateFormat.parse(attributeValue);
+                    }
+                    catch (ParseException e) {
+                        event.reportError(customAttribute, errorKey, KeyConstants.ERROR_DATE, attributeValue, customAttribute.getLabel());
+                        isValid = false;
+                    }
+                }
+            }
+            
+            // validate BO data against the database contents 
+            String lookupClass = customAttribute.getLookupClass();
+            if (lookupClass != null && lookupClass.equals("org.kuali.kra.bo.KcPerson"))
+            {
+                if (customAttribute.getDataTypeCode().equals("1") && customAttribute.getLookupReturn().equals("userName"))
+                {
+                    validFormat = getValidFormat(customAttributeDataType.getDescription());
+                    KcPersonService kps = getKcPersonService();
+                    KcPerson customPerson = kps.getKcPersonByUserName(customAttribute.getValue());
+                    if (customPerson == null)
+                    {
+                        event.reportError(customAttribute, errorKey, RiceKeyConstants.ERROR_EXISTENCE, 
+                            customAttribute.getLabel(), attributeValue, validFormat);
+                        isValid = false;
+                    }
+                }
+            } else if (lookupClass != null && lookupClass.equals("org.kuali.kra.bo.ArgValueLookup"))
+            {
+                    ArgValueLookupValuesFinder finder = new  ArgValueLookupValuesFinder();
+                    finder.setArgName(customAttribute.getLookupReturn());
+                    List<KeyValue> kv = finder.getKeyValues();
+                    Iterator<KeyValue> i = kv.iterator();
+                    boolean found = false;
+                    while (i.hasNext())
+                    {
+                        KeyValue element = (KeyValue) i.next();
+                        String label = element.getKey().toLowerCase();
+                        if (label.equals(attributeValue.toLowerCase()))
+                        {
+                            found = true;
+                        }      
+                    }
+                    if (!found) {
+                        validFormat = getValidFormat(customAttributeDataType.getDescription());
+                        event.reportError(customAttribute, errorKey, RiceKeyConstants.ERROR_EXISTENCE, 
+                              customAttribute.getLabel(), attributeValue, validFormat);
+                        isValid = false;
+                    }
+                        
+            }
+            else if (lookupClass != null)
+            {    
+                Class boClass = null;
+                try
+                {
+                    boClass = Class.forName(lookupClass);
+                }
+                catch (ClassNotFoundException cnfE) {/* Do nothing, checked on input */ }
+
+                if (isInvalid(boClass, keyValue(customAttribute.getLookupReturn(), customAttribute.getValue() ) ) )         
+                {
+                    validFormat = getValidFormat(customAttributeDataType.getDescription());
+                    event.reportError(customAttribute, errorKey, RiceKeyConstants.ERROR_EXISTENCE, 
+                             customAttribute.getLabel(), attributeValue, validFormat);
+                    return false;
+                }
+            }                 
+        }
+        return isValid;
+    }
+    
+    private String getValidFormat(String dataType) {
+        String validFormat = Constants.DATA_TYPE_STRING;
+        if (dataType.equalsIgnoreCase(NUMBER)) {
+            validFormat = Constants.DATA_TYPE_NUMBER;
+        } else if (dataType.equalsIgnoreCase(DATE)) {
+            validFormat = Constants.DATA_TYPE_DATE;
+        }
+        return validFormat;
+    }
+    
+    /**
+     * Gets the Custom Attribute Service.
+     * @return the Custom Attribute Service
+     */
+    public CustomAttributeService getCustomAttributeService() {
+        if (customAttributeService == null) {
+            customAttributeService = KraServiceLocator.getService(CustomAttributeService.class);
+        }
+        return customAttributeService;
+    }
+    
+    /**
+     * Sets the Custom Attribute Service.
+     * @param customAttributeService the Custom Attribute Service
+     */
+    public void setCustomAttributeService(CustomAttributeService customAttributeService) {
+        this.customAttributeService = customAttributeService;
+    }
+
+    /**
+     * 
+     * This method is a helper method to retrieve KcPersonService.
+     * @return
+     */
+    protected KcPersonService getKcPersonService() {
+        return KraServiceLocator.getService(KcPersonService.class);    
+    }
+
+    
+}

--- a/src/main/java/org/kuali/kra/rules/CustomDataRule.java
+++ b/src/main/java/org/kuali/kra/rules/CustomDataRule.java
@@ -101,7 +101,7 @@ public class CustomDataRule extends ResearchDocumentRuleBase implements Business
             }
             if (event.isValidateRequiredFields() && customAttributeDocument.isRequired() && StringUtils.isBlank(customAttribute.getValue())) {
                 event.reportError(customAttribute, errorKey, RiceKeyConstants.ERROR_REQUIRED, 
-                        customAttribute.getLabel(),customAttribute.getValue(), getValidFormat(customAttribute.getCustomAttributeDataType().getDescription()));
+                        customAttribute.getLabel(),customAttribute.getValue(), customAttribute.getName(), getValidFormat(customAttribute.getCustomAttributeDataType().getDescription()));
                  rulePassed = false;
             }
             

--- a/src/main/java/org/kuali/kra/web/struts/action/AuditMapSorter.java
+++ b/src/main/java/org/kuali/kra/web/struts/action/AuditMapSorter.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2005-2014 The Kuali Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.osedu.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kuali.kra.web.struts.action;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.math.NumberUtils;
+import org.kuali.rice.kns.util.AuditCluster;
+import org.kuali.rice.kns.util.AuditError;
+
+import java.io.Serializable;
+import java.util.*;
+
+/**
+ * Contains methods to sort an AuditMap's {@link AuditError AuditError's}.
+ */
+final class AuditMapSorter {
+
+    /**
+     * Default pattern/comparator map.  Currently supports sorting y/n questions by question number.
+     * @see #sort(Map). This map in not modifiable.
+     */
+    public static final Map<String, Comparator<AuditError>> DEFAULT_PATTERN_COMPARATOR_MAP;
+    static {
+        final Map<String, Comparator<AuditError>> tempComparators
+            = new LinkedHashMap<String, Comparator<AuditError>>();
+        
+        tempComparators.put(".*ynq.*", YNQuestionByNumber.Q_NUM_ZERO_POSITION);
+        DEFAULT_PATTERN_COMPARATOR_MAP = Collections.unmodifiableMap(tempComparators);
+    }
+    
+    private final Map<String, AuditCluster> auditErrorsMap;
+    
+    /**
+     * Sets the audit map to sort.
+     * @throws NullPointerException if the audit map is null
+     */
+    public AuditMapSorter(final Map<String, AuditCluster> auditErrorsMap) {
+        
+        if (auditErrorsMap == null) {
+            throw new NullPointerException("the auditErrorsMap is null");
+        }
+        
+        this.auditErrorsMap = auditErrorsMap;
+    }
+    
+    /**
+     * <p>
+     * Sorts the AuditMap's {@link AuditError AuditError's} based on comparison rules.  The passed in
+     * Audit Map will be directly modified by the method.
+     * </p>
+     * 
+     * <p>
+     * These comparison rules are in the form of a {@link Map Map} of regex patterns with associated
+     * {@link Comparator Comparators}. Each key for an audit map entry will be matched against the regex
+     * patterns contained in the comparatorsForAuditErrors.  When a match is found the associated
+     * comparator will be used to sort the AuditErrors.  In the case of multiple matches the first match
+     * will be used.  If a predictable match order is desired a {@link LinkedHashMap LinkedHashMap}
+     * should be used.
+     * </p>
+     * 
+     * <p>
+     * A default map is provided at {@link #DEFAULT_PATTERN_COMPARATOR_MAP DEFAULT_PATTERN_COMPARATOR_MAP}
+     * </p>
+     *
+     * @throws NullPointerException if the pattern map is null or if it contains a null Comparator
+     * @throws IllegalArgumentException if the pattern map is empty
+     */
+    public void sort(final Map<String, Comparator<AuditError>> patternComparatorMap) {
+        
+        if (patternComparatorMap == null) {
+            throw new NullPointerException("the comparatorsForAuditErrors is null");
+        }
+        
+        if (patternComparatorMap.isEmpty()) {
+            throw new IllegalArgumentException("no comparator entries provided");
+        }
+
+        for (Map.Entry<String, AuditCluster> entryError : this.auditErrorsMap.entrySet()) {
+            final AuditCluster cluster = entryError.getValue();
+            
+            for (Map.Entry<String, Comparator<AuditError>> compEntry : patternComparatorMap.entrySet()) {
+                
+                if (entryError.getKey().matches(compEntry.getKey())) {
+                    @SuppressWarnings("unchecked")
+                    List<AuditError> errors = cluster.getAuditErrorList();
+                    
+                    final Comparator<AuditError> comp = this.getComparator(compEntry.getValue());
+                    Collections.sort(errors, comp);
+                }
+            }
+        }
+    }
+    
+    /**
+     * This methods returns the comparator passed in if not null.
+     * Used to prevent {@link Collections#sort(List, Comparator)} from falling back
+     * to natural ordering.
+     * 
+     * @param comp The Comparator
+     * @return The Comparator
+     * @throws NullPointerException comp is null
+     */
+    private Comparator<AuditError> getComparator(final Comparator<AuditError> comp) {
+        
+        if (comp == null) {
+            throw new NullPointerException("the comparator was null");
+        }
+        
+        return comp;
+    }
+        
+    /**
+     * A Comparator that sorts Y/N questions in question number order.  Currently this class is nested
+     * as it is only used by this class.  Feel free to refactor as needed.
+     * 
+     * <p>
+     * This Comparator is not consistent with {@link AuditError#equals(Object) AuditError#equals(Object)}.
+     * </p>
+     */
+    private static final class YNQuestionByNumber implements Comparator<AuditError>, Serializable {
+        
+        /** convenience instance that looks for the question number in the zero position. */
+        public static final Comparator<AuditError> Q_NUM_ZERO_POSITION = new YNQuestionByNumber(0);
+        
+        private static final long serialVersionUID = 7978642168434892454L;
+        
+        private final int questionNumberParamPosition;
+        
+        /**
+         * Sets the parameter position to find the question number.
+         * 
+         * @param questionNumberParamPosition parameter position
+         * @throws IllegalArgumentException if questionNumberParamPosition is < 0
+         */
+        public YNQuestionByNumber(final int questionNumberParamPosition) {
+            
+            if (questionNumberParamPosition < 0) {
+                throw new IllegalArgumentException(questionNumberParamPosition + " is < 0");
+            }
+            
+            this.questionNumberParamPosition = questionNumberParamPosition;
+        }
+        
+        /**
+         * {@inheritDoc}
+         * @throws NullPointerException if o1 or o2 is null
+         */
+        public int compare(AuditError o1, AuditError o2) {
+            
+            if (o1 == null) {
+                throw new NullPointerException("o1 is null");
+            }
+            
+            if (o2 == null) {
+                throw new NullPointerException("o2 is null");
+            }
+            
+            final String qNumber1 = this.getQuestonNumber(o1.getParams());
+            final String qNumber2 = this.getQuestonNumber(o2.getParams());
+            
+            if (!NumberUtils.isNumber(qNumber1)) {
+                return -1;
+            }
+
+            if (!NumberUtils.isNumber(qNumber2)) {
+                return 1;
+            }
+
+            return Integer.valueOf(qNumber1).compareTo(Integer.valueOf(qNumber2));
+        }
+        
+        /**
+         * This method returns the question number from a parameter array (ex: array[0]).
+         * @param array the parameter array holding the question number.  It can be null.
+         * @return returns question number.
+         * If array is null or question number is null this method will return null.
+         * (i.e. (array[questionNumberParamPosition] == null || array == null) then returns null)
+         */
+        private String getQuestonNumber(String[] array) {
+            if (ArrayUtils.getLength(array) > this.questionNumberParamPosition) {
+                return array[this.questionNumberParamPosition];
+            }
+            return null;
+        }
+    }
+        
+}

--- a/src/main/webapp/WEB-INF/tags/summary/proposalDevelopmentCustomDataInformation.tag
+++ b/src/main/webapp/WEB-INF/tags/summary/proposalDevelopmentCustomDataInformation.tag
@@ -1,0 +1,58 @@
+<%--
+ Copyright 2005-2014 The Kuali Foundation
+ 
+ Licensed under the Educational Community License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.osedu.org/licenses/ECL-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+--%>
+
+<%@ include file="/WEB-INF/jsp/kraTldHeader.jsp"%>
+<%@ attribute name="transparentBackground" required="false" %>
+<c:set var="proposalDevelopmentAttributes"
+	value="${DataDictionary.DevelopmentProposal.attributes}" />
+<c:set var="scienceKeywordAttributes"
+	value="${DataDictionary.ScienceKeyword.attributes}" />
+<c:set var="textAreaFieldName"
+	value="document.developmentProposalList[0].mailDescription" />
+<c:set var="action" value="proposalDevelopmentApproverView" />
+<c:set var="className"
+	value="org.kuali.kra.proposaldevelopment.document.ProposalDevelopmentDocument" />
+<c:set var="className"
+	value="org.kuali.kra.proposaldevelopment.document.ProposalDevelopmentDocument" />
+<kul:tab tabTitle="Custom Data Information" defaultOpen="false" transparentBackground="${transparentBackground }"
+	tabErrorKey="">
+	<div class="tab-container" align="center">
+		<h3>
+			<span class="subhead-left">Custom Data Information</span>
+		</h3>
+		<table cellpadding=0 cellspacing="0" summary="">
+			<c:forEach items="${KualiForm.document.customAttributeDocuments}"
+				var="customAttributeDocument1" varStatus="status">
+				<tr>
+					<c:set var="customAttributeLabel"
+						value="${customAttributeDocument1.value.customAttribute.label}" />
+					<c:set var="customAttributeValue"
+						value="${customAttributeDocument1.value.customAttribute.value}" />
+					<th width="50%"><div align="left">
+							<c:out value="${customAttributeLabel}" />
+						</div>
+					</th>
+					<td><div align=center>
+							<c:out value="${customAttributeValue}" />
+						</div>
+					</td>
+				</tr>
+			</c:forEach>
+		</table>
+	</div>
+</kul:tab>
+
+

--- a/src/main/webapp/WEB-INF/tags/summary/proposalDevelopmentCustomDataInformation.tag
+++ b/src/main/webapp/WEB-INF/tags/summary/proposalDevelopmentCustomDataInformation.tag
@@ -16,6 +16,9 @@
 
 <%@ include file="/WEB-INF/jsp/kraTldHeader.jsp"%>
 <%@ attribute name="transparentBackground" required="false" %>
+<%@ attribute name="excludeInactive" required="false" %>
+<%@ attribute name="headerAndFooter" required="false" %>
+
 <c:set var="proposalDevelopmentAttributes"
 	value="${DataDictionary.DevelopmentProposal.attributes}" />
 <c:set var="scienceKeywordAttributes"
@@ -27,31 +30,78 @@
 	value="org.kuali.kra.proposaldevelopment.document.ProposalDevelopmentDocument" />
 <c:set var="className"
 	value="org.kuali.kra.proposaldevelopment.document.ProposalDevelopmentDocument" />
+	
+<c:set var="customAttributeGroups"
+	value="${KualiForm.customDataHelper.customAttributeGroups}" />
+<c:set var="customDataList"
+	value="${KualiForm.customDataHelper.customDataList}" />
+<c:set var="customDataListPrefix"
+	value="customDataHelper.customDataList" />
+
+<c:if test="${empty excludeInactive}" >
+	<c:set var="excludeInactive" value="false" />
+</c:if>
+<c:if test="${empty headerAndFooter}" >
+	<c:set var="headerAndFooter" value="true" />
+</c:if>	
+	
 <kul:tab tabTitle="Custom Data Information" defaultOpen="false" transparentBackground="${transparentBackground }"
 	tabErrorKey="">
 	<div class="tab-container" align="center">
 		<h3>
 			<span class="subhead-left">Custom Data Information</span>
 		</h3>
-		<table cellpadding=0 cellspacing="0" summary="">
-			<c:forEach items="${KualiForm.document.customAttributeDocuments}"
-				var="customAttributeDocument1" varStatus="status">
-				<tr>
-					<c:set var="customAttributeLabel"
-						value="${customAttributeDocument1.value.customAttribute.label}" />
-					<c:set var="customAttributeValue"
-						value="${customAttributeDocument1.value.customAttribute.value}" />
-					<th width="50%"><div align="left">
-							<c:out value="${customAttributeLabel}" />
-						</div>
-					</th>
-					<td><div align=center>
-							<c:out value="${customAttributeValue}" />
-						</div>
-					</td>
-				</tr>
+		<c:set var="fieldCount" value="0" />
+			<c:forEach items="${customAttributeGroups}" var="customAttributeGroup" varStatus="groupStatus">
+				<c:set var="fullName" value="${customAttributeGroup.key}" />
+				<c:set var="tabErrorKey" value=""/>
+				<c:choose>
+					<c:when test="${fn:length(fullName) > 90}">
+		 				<c:set var="tabTitleName" value="${fn:substring(fullName, 0, 90)}..."/>
+					</c:when>
+					<c:otherwise>
+		 				<c:set var="tabTitleName" value="${fullName}"/>
+					</c:otherwise> 
+				</c:choose>
+  
+			<c:forEach items="${customAttributeGroup.value}" var="customAttributeDocument" varStatus="status">
+				<c:forEach var="customAttribute" items="${customDataList}" varStatus="status"> 
+						<c:if test="${customAttribute.customAttributeId == customAttributeDocument.customAttributeId}">
+							<c:set var="customAttributeId" value="${customDataListPrefix}[${status.index}].value" />
+						</c:if>
+				</c:forEach>
 			</c:forEach>
-		</table>
+			<kul:tab tabTitle="${tabTitleName}" spanForLongTabTitle="true" defaultOpen="true" transparentBackground="${groupStatus.first && headerAndFooter}">
+				<table cellpadding=0 cellspacing="0" class="result-table">
+					<c:forEach items="${customAttributeGroups[fullName]}" var="customAttributeDocument" varStatus="status">
+						<c:if test="${(excludeInactive eq false) or (excludeInactive eq true && customAttributeDocument.active eq true)}">
+							<tr class="datatable">
+								<th><div align="center">
+									<c:out value="${customAttributeDocument.customAttribute.label}" />
+								</div>
+								</th>
+								<td width="50%">
+									<c:forEach var="customAttribute" items="${customDataList}" varStatus="status"> 
+										<c:if test="${customAttribute.customAttributeId == customAttributeDocument.customAttributeId}">
+											<c:set var="customAttributeIndex" value="${status.index}" />
+											<c:set var="customAttributeValue" value="${customAttribute.value}" />
+											<c:set var="customAttributeId" value="${customDataListPrefix}[${customAttributeIndex}].value" />
+										</c:if>
+									</c:forEach>
+									<div align="center">
+			           					<c:out value="${customAttributeValue}" />
+			           				</div>
+								</td>
+							</tr>
+						</c:if>
+					</c:forEach>
+				</table>
+	    	</kul:tab>
+	    		<c:set var="fieldCount" value="${fieldCount + fn:length(customAttributeGroup.value)}" />
+			</c:forEach>
+		<c:if test="${fn:length(customAttributeGroups) > 0 && headerAndFooter}">
+	   		<kul:panelFooter />
+		</c:if>
 	</div>
 </kul:tab>
 


### PR DESCRIPTION
Refactored propsalDevelopmentCustomDataInformation.tag, added keys for comparator regex, added logic so that custom data validation errors get sorted by name, not label, yet still displays the label in the UI, updated and renamed the comparator to compare by names rather than labels for the custom data fields, added code to populate the custom data information panel on the summary tab when a document is loaded.