### PR TITLE
UAR-973_2 - Allow bulk add and delete for unit administrator unit number

### DIFF
--- a/src/main/java/edu/arizona/kra/global/unit/create/UnitAdministratorCreateGlobalRule.java
+++ b/src/main/java/edu/arizona/kra/global/unit/create/UnitAdministratorCreateGlobalRule.java
@@ -1,0 +1,32 @@
+package edu.arizona.kra.global.unit.create;
+
+import java.util.Map;
+
+import org.kuali.kra.bo.UnitAdministrator;
+import org.kuali.kra.infrastructure.KeyConstants;
+import org.kuali.kra.rules.KraMaintenanceDocumentRuleBase;
+import org.kuali.rice.kns.document.MaintenanceDocument;
+import org.kuali.rice.krad.util.GlobalVariables;
+
+@SuppressWarnings("deprecation")
+public class UnitAdministratorCreateGlobalRule extends KraMaintenanceDocumentRuleBase {
+	
+	@Override
+	protected boolean processCustomSaveDocumentBusinessRules(MaintenanceDocument document) {
+		
+		UnitAdministratorCreateGlobal unitAdministratorCreateGlobal = (UnitAdministratorCreateGlobal) super.getNewBo();
+		
+        int errorCount = 0;
+        for (Map<String, Object> primaryKeyMap : unitAdministratorCreateGlobal.getAllUnitAdministratorPrimaryKeys()) {
+        		// Check to ensure this record doesn't exist
+        		UnitAdministrator unitAdministrator = unitAdministratorCreateGlobal.getUnitAdministratorByPrimaryKey(primaryKeyMap);        		
+        		if(unitAdministrator != null) {
+        			GlobalVariables.getMessageMap().putError("unitAdministratorCreateGlobal", KeyConstants.ERROR_UNIT_ADMIN_DUPLICATE, primaryKeyMap.toString());
+        			errorCount++;
+        		}
+        }
+		
+		return errorCount > 0 ? false : true;
+	}
+	
+}

--- a/src/main/java/edu/arizona/kra/global/unit/delete/UnitAdministratorDeleteGlobal.java
+++ b/src/main/java/edu/arizona/kra/global/unit/delete/UnitAdministratorDeleteGlobal.java
@@ -79,7 +79,7 @@ public class UnitAdministratorDeleteGlobal extends PersistableBusinessObjectBase
 	}
 
 
-	private List<Map<String, Object>> getAllUnitAdministratorPrimaryKeys() {
+	protected List<Map<String, Object>> getAllUnitAdministratorPrimaryKeys() {
 		List<Map<String, Object>> primaryKeysList = new ArrayList<Map<String, Object>>();
 		for(GlobalBusinessObjectDetail adminDetail : getUnitAdministratorGlobalDetails()) {
 			UnitAdministratorGlobalDetail unitAdminDetail = (UnitAdministratorGlobalDetail)adminDetail;

--- a/src/main/java/edu/arizona/kra/global/unit/delete/UnitAdministratorDeleteGlobalRule.java
+++ b/src/main/java/edu/arizona/kra/global/unit/delete/UnitAdministratorDeleteGlobalRule.java
@@ -1,0 +1,32 @@
+package edu.arizona.kra.global.unit.delete;
+
+import java.util.Map;
+
+import org.kuali.kra.bo.UnitAdministrator;
+import org.kuali.kra.infrastructure.KeyConstants;
+import org.kuali.kra.rules.KraMaintenanceDocumentRuleBase;
+import org.kuali.rice.kns.document.MaintenanceDocument;
+import org.kuali.rice.krad.util.GlobalVariables;
+
+@SuppressWarnings("deprecation")
+public class UnitAdministratorDeleteGlobalRule extends KraMaintenanceDocumentRuleBase {
+	
+	@Override
+	protected boolean processCustomSaveDocumentBusinessRules(MaintenanceDocument document) {
+		
+		UnitAdministratorDeleteGlobal unitAdministratorDeleteGlobal = (UnitAdministratorDeleteGlobal) super.getNewBo();
+		
+        int errorCount = 0;
+        for (Map<String, Object> primaryKeyMap : unitAdministratorDeleteGlobal.getAllUnitAdministratorPrimaryKeys()) {
+        		// Check to ensure this record doesn't exist
+        		UnitAdministrator unitAdministrator = unitAdministratorDeleteGlobal.getUnitAdministratorByPrimaryKey(primaryKeyMap);        		
+        		if(unitAdministrator == null) {
+        			GlobalVariables.getMessageMap().putError("unitAdministratorDeleteGlobal", KeyConstants.ERROR_UNIT_ADMIN_NONEXISTENT, primaryKeyMap.toString());
+        			errorCount++;
+        		}
+        }
+
+		return errorCount > 0 ? false : true;
+	}
+	
+}

--- a/src/main/java/org/kuali/kra/infrastructure/KeyConstants.java
+++ b/src/main/java/org/kuali/kra/infrastructure/KeyConstants.java
@@ -1103,6 +1103,10 @@ public final class KeyConstants {
     public static final String S2S_USER_ATTACHED_FORM_WRONG_FILE_TYPE = "error.s2s.userattachedform.wrong.filetype";
     public static final String S2S_USER_ATTACHED_FORM_NOT_VALID = "error.s2s.userattachedform.invalid";
     public static final String S2S_USER_ATTACHED_FORM_NOT_PDF = "error.s2s.userattachedform.not.pdf";
+    
+    // UnitAdministrator Global Create/Delete errors
+    public static final String ERROR_UNIT_ADMIN_DUPLICATE = "error.unit.admin.global.create.duplicate";
+    public static final String ERROR_UNIT_ADMIN_NONEXISTENT = "error.unit.admin.global.delete.nonexistent";
 
     /**
      * private utility class ctor.

--- a/src/main/resources/ApplicationResources.properties
+++ b/src/main/resources/ApplicationResources.properties
@@ -1089,3 +1089,6 @@ question.iacuc.procedure.study.group.delete.confirmation=This action will remove
 error.iacuc.procedure.study.group.species.painCategory.required=Pain Category for {0} is required.
 error.iacuc.procedure.study.group.species.count.required=Count for {0} is required.
 error.required.subaward.templateinfo.carryForwardRequestsSentTo=Carry Forward Requests Sent To is required.
+
+error.unit.admin.global.create.duplicate=Record already exists for UnitAdministrator: {0}
+error.unit.admin.global.delete.nonexistent=Record does not exist for UnitAdministrator: {0}

--- a/src/main/resources/edu/arizona/kra/datadictionary/UnitAdminTypeAndPersonGlobalDetail.xml
+++ b/src/main/resources/edu/arizona/kra/datadictionary/UnitAdminTypeAndPersonGlobalDetail.xml
@@ -41,11 +41,8 @@
     <bean id="UnitAdminTypeAndPersonGlobalDetail-personId" parent="UnitAdminTypeAndPersonGlobalDetail-personId-parentBean" />
     <bean id="UnitAdminTypeAndPersonGlobalDetail-personId-parentBean" abstract="true" parent="KcPerson-personId-parentBean">
         <property name="name" value="personId" />
-        <property name="label" value="KC Person" />
-        <property name="shortLabel" value="KC Person ID" />
-        <property name="required" value="true" />
-        <property name="validationPattern" >
-            <bean parent="AnyCharacterValidationPattern" />
+        <property name="control">
+            <ref bean="HiddenControl" />
         </property>
     </bean>
 

--- a/src/main/resources/edu/arizona/kra/datadictionary/docs/UnitAdministratorCreateGlobalMaintenanceDocument.xml
+++ b/src/main/resources/edu/arizona/kra/datadictionary/docs/UnitAdministratorCreateGlobalMaintenanceDocument.xml
@@ -6,6 +6,7 @@
     <property name="documentAuthorizerClass" value="org.kuali.rice.kns.document.authorization.MaintenanceDocumentAuthorizerBase"/>
     <property name="documentTypeName" value="UnitAdministratorCreateGlobalMaintenanceDocument"/>
     <property name="maintainableClass" value="edu.arizona.kra.global.unit.create.UnitAdminCreateGlobalMaintainableImpl"/>
+    <property name="businessRulesClass" value="edu.arizona.kra.global.unit.create.UnitAdministratorCreateGlobalRule"/>
     <property name="allowsRecordDeletion" value="true" />
     <property name="maintainableSections">
       <list>

--- a/src/main/resources/edu/arizona/kra/datadictionary/docs/UnitAdministratorCreateGlobalMaintenanceDocument.xml
+++ b/src/main/resources/edu/arizona/kra/datadictionary/docs/UnitAdministratorCreateGlobalMaintenanceDocument.xml
@@ -43,6 +43,7 @@
             </property>
             <property name="maintainableFields">
                <list>
+                    <bean parent="MaintainableFieldDefinition" p:name="personId" p:template="personId"/>
                     <bean parent="MaintainableFieldDefinition" p:name="person.userName" p:required="true" p:template="person.userName" />
                     <bean parent="MaintainableFieldDefinition" p:name="unitAdministratorTypeCode" p:required="true" p:template="unitAdministratorTypeCode" />
                 </list>

--- a/src/main/resources/edu/arizona/kra/datadictionary/docs/UnitAdministratorDeleteGlobalMaintenanceDocument.xml
+++ b/src/main/resources/edu/arizona/kra/datadictionary/docs/UnitAdministratorDeleteGlobalMaintenanceDocument.xml
@@ -6,6 +6,7 @@
     <property name="documentAuthorizerClass" value="org.kuali.rice.kns.document.authorization.MaintenanceDocumentAuthorizerBase"/>
     <property name="documentTypeName" value="UnitAdministratorDeleteGlobalMaintenanceDocument"/>
     <property name="maintainableClass" value="edu.arizona.kra.global.unit.delete.UnitAdminDeleteGlobalMaintainableImpl"/>
+    <property name="businessRulesClass" value="edu.arizona.kra.global.unit.delete.UnitAdministratorDeleteGlobalRule"/>
     <property name="allowsRecordDeletion" value="true" />
     <property name="maintainableSections">
       <list>

--- a/src/main/resources/repository.xml
+++ b/src/main/resources/repository.xml
@@ -1758,6 +1758,49 @@
 		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
     	<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="false" />
 	</class-descriptor>
+
+     <class-descriptor class="edu.arizona.kra.institutionalproposal.negotiationlog.NegotiationLog" table="NEGOTIATION_LOG">
+        <field-descriptor name="negotiationLogId" column="NEGOTIATION_LOG_ID" jdbc-type="INTEGER" primarykey="true" autoincrement="true" sequence-name="NEGOTIATION_LOG_SEQ" />
+        <field-descriptor name="negotiatorPersonId" column="NEGOTIATOR_ID" jdbc-type="VARCHAR" />
+        <field-descriptor name="negotiatorName" column="NEGOTIATOR_NAME" jdbc-type="VARCHAR" />
+        <field-descriptor name="closed" column="CLOSED_FLAG" jdbc-type="CHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion"/>
+        <field-descriptor name="proposalNumber" column="PROPOSAL_NUMBER" jdbc-type="VARCHAR" />
+        <field-descriptor name="piPersonId" column="PI_ID" jdbc-type="VARCHAR" />
+        <field-descriptor name="piName" column="PI_NAME" jdbc-type="VARCHAR" />
+        <field-descriptor name="unitNumber" column="UNIT_NUMBER" jdbc-type="VARCHAR" />
+        <field-descriptor name="account" column="ACCOUNT" jdbc-type="VARCHAR" />
+        <field-descriptor name="sponsorCode" column="SPONSOR_CODE" jdbc-type="CHAR" />
+        <field-descriptor name="negotiationAgreementType" column="AGREEMENT_TYPE_CODE" jdbc-type="VARCHAR" />
+        <field-descriptor name="awardTypeCode" column="AWARD_TYPE_CODE" jdbc-type="INTEGER" />
+        <field-descriptor name="sponsorAwardNumber" column="SPONSOR_AWARD_NUMBER" jdbc-type="VARCHAR" />
+        <field-descriptor name="modificationNumber" column="MODIFICATION_NUMBER" jdbc-type="VARCHAR" />
+        <field-descriptor name="title" column="TITLE" jdbc-type="VARCHAR" />
+        <field-descriptor name="amount" column="AMOUNT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+        <field-descriptor name="startDate" column="START_DATE" jdbc-type="DATE" />
+        <field-descriptor name="endDate" column="END_DATE" jdbc-type="DATE" />
+        <field-descriptor name="backstop" column="BACKSTOP" jdbc-type="DATE" />
+        <field-descriptor name="location" column="LOCATION" jdbc-type="VARCHAR" />
+        <field-descriptor name="spsPreawardComments" column="SPS_PREAWARD_COMMENTS" jdbc-type="VARCHAR" />
+        <field-descriptor name="orcaComments" column="ORCA_COMMENTS" jdbc-type="VARCHAR" />
+        <field-descriptor name="dateReceived" column="DATE_RECEIVED" jdbc-type="DATE" />
+        <field-descriptor name="negotiationStart" column="NEGOTIATION_START" jdbc-type="DATE" />
+        <field-descriptor name="negotiationComplete" column="NEGOTIATION_COMPLETE" jdbc-type="DATE" />
+        <field-descriptor name="dateClosed" column="DATE_CLOSED" jdbc-type="DATE" />
+        <field-descriptor name="daysOpen" column="DAYS_OPEN" jdbc-type="BIGINT" />
+        <field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+        <field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+        <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="false" />
+        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+        <reference-descriptor name="leadUnit" class-ref="org.kuali.kra.bo.Unit" auto-retrieve="true" auto-update="none" auto-delete="none"> 
+            <foreignkey field-ref="unitNumber"/>
+        </reference-descriptor>
+        <reference-descriptor name="sponsor" class-ref="org.kuali.kra.bo.Sponsor" auto-retrieve="true" auto-update="none" auto-delete="none"> 
+            <foreignkey field-ref="sponsorCode" />
+        </reference-descriptor>
+        <reference-descriptor name="awardType" class-ref="org.kuali.kra.award.home.AwardType" auto-retrieve="true" auto-update="none" auto-delete="none"> 
+            <foreignkey field-ref="awardTypeCode" />
+        </reference-descriptor>
+    </class-descriptor>
 	
 	<class-descriptor class="edu.arizona.kra.global.unit.create.UnitAdministratorCreateGlobal" table="UNIT_ADMIN_CREATE_GBL_T">
        <field-descriptor name="documentNumber" column="DOCUMENT_NUMBER" jdbc-type="VARCHAR" primarykey="true" />


### PR DESCRIPTION
# Summary
* Added "template" attributes to the maintenance xml in order to get values to persist between screen states 
* Implemented Rule classes that enable validation and are responsible for display of any generated error messages 

# Code Additions
* Rule classes to produce validation errors for dupe/missing UnitAdmin
    *src/main/java/edu/arizona/kra/global/unit/create/UnitAdministratorCreateGlobalRule.java
    *src/main/java/edu/arizona/kra/global/unit/delete/UnitAdministratorDeleteGlobalRule.java

# Code Changes
* Change scope of method from public to protected, needed by rules
    * src/main/java/edu/arizona/kra/global/unit/delete/UnitAdministratorDeleteGlobal.java
* Add two error entries, used by rule classes
    * src/main/java/org/kuali/kra/infrastructure/KeyConstants.java
    * src/main/resources/ApplicationResources.properties
* Changed to use template so that values persist between screens, added property to associate new rule classes
    * src/main/resources/edu/arizona/kra/datadictionary/docs/UnitAdministratorCreateGlobalMaintenanceDocument.xml
    * src/main/resources/edu/arizona/kra/datadictionary/docs/UnitAdministratorDeleteGlobalMaintenanceDocument.xml