### PR TITLE
UAR-1122_2 - Widening the regex to catch all CustomData AudiClusters.

### DIFF
--- a/src/main/java/org/kuali/kra/web/struts/action/AuditMapSorter.java
+++ b/src/main/java/org/kuali/kra/web/struts/action/AuditMapSorter.java
@@ -38,7 +38,7 @@ final class AuditMapSorter {
             = new LinkedHashMap<String, Comparator<AuditError>>();
         
         tempComparators.put(".*ynq.*", YNQuestionByNumber.Q_NUM_ZERO_POSITION);
-        tempComparators.put("CustomDataInternalUseOnlyErrors|CustomDataProjectInformationErrors", NameComparator.CUSTOM_DATA_NAME);
+        tempComparators.put("CustomData.*", NameComparator.CUSTOM_DATA_NAME);
         DEFAULT_PATTERN_COMPARATOR_MAP = Collections.unmodifiableMap(tempComparators);
     }
     


### PR DESCRIPTION
Changing regex from:
"CustomDataInternalUseOnlyErrors|CustomDataProjectInformationErrors"

to:
"CustomData.*"