### PR TITLE
UAR-1329 Add REGENERATE_ACTION_REQUESTS_ON_CHANGE=false policy to Pro…

### DIFF
--- a/src/main/resources/edu/arizona/kc/db/changelog/changesets/db.changelog-UAR-1329.xml
+++ b/src/main/resources/edu/arizona/kc/db/changelog/changesets/db.changelog-UAR-1329.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ 
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog 
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+ 
+    <changeSet id="UAR-1329" author="Natalia Costea Ibanez">
+        <comment>
+        	Protocol Document Type - add REGENERATE_ACTION_REQUESTS_ON_CHANGE=false policy to both active document types (docTypId=77092 and 4403690).
+        </comment>
+        <sql>
+			insert into krew_doc_typ_plcy_reln_t (DOC_TYP_ID, DOC_PLCY_NM, PLCY_NM, VER_NBR, OBJ_ID)
+            values ('77092','REGENERATE_ACTION_REQUESTS_ON_CHANGE', 0, 2, SYS_GUID());
+            
+            insert into krew_doc_typ_plcy_reln_t (DOC_TYP_ID, DOC_PLCY_NM, PLCY_NM, VER_NBR, OBJ_ID)
+            values ('440360','REGENERATE_ACTION_REQUESTS_ON_CHANGE', 0, 1, SYS_GUID());
+            
+		</sql>
+		<rollback>
+			delete from krew_doc_typ_plcy_reln_t where DOC_PLCY_NM='REGENERATE_ACTION_REQUESTS_ON_CHANGE';
+		</rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/edu/arizona/kc/db/changelog/changesets/db.changelog-UAR-1329.xml
+++ b/src/main/resources/edu/arizona/kc/db/changelog/changesets/db.changelog-UAR-1329.xml
@@ -11,15 +11,14 @@
         	Protocol Document Type - add REGENERATE_ACTION_REQUESTS_ON_CHANGE=false policy to both active document types (docTypId=77092 and 4403690).
         </comment>
         <sql>
-			insert into krew_doc_typ_plcy_reln_t (DOC_TYP_ID, DOC_PLCY_NM, PLCY_NM, VER_NBR, OBJ_ID)
+            insert into krew_doc_typ_plcy_reln_t (DOC_TYP_ID, DOC_PLCY_NM, PLCY_NM, VER_NBR, OBJ_ID)
             values ('77092','REGENERATE_ACTION_REQUESTS_ON_CHANGE', 0, 2, SYS_GUID());
             
             insert into krew_doc_typ_plcy_reln_t (DOC_TYP_ID, DOC_PLCY_NM, PLCY_NM, VER_NBR, OBJ_ID)
             values ('440360','REGENERATE_ACTION_REQUESTS_ON_CHANGE', 0, 1, SYS_GUID());
-            
 		</sql>
 		<rollback>
-			delete from krew_doc_typ_plcy_reln_t where DOC_PLCY_NM='REGENERATE_ACTION_REQUESTS_ON_CHANGE';
+			delete from krew_doc_typ_plcy_reln_t where DOC_PLCY_NM='REGENERATE_ACTION_REQUESTS_ON_CHANGE' and DOC_TYP_ID in ('77092','440360');
 		</rollback>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/edu/arizona/kc/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/edu/arizona/kc/db/changelog/db.changelog-master.xml
@@ -16,5 +16,6 @@
   <include file="changesets/db.changelog-UAR-1049.xml" />
   <include file="changesets/db.changelog-UAR-481.xml" />
   <include file="changesets/db.changelog-UAR-1070.xml" />
+  <include file="changesets/db.changelog-UAR-1329.xml" />
 </databaseChangeLog>
 


### PR DESCRIPTION
…tocolDocument Type
This will prevent IRB Protocols that are not final to get additional approval stops when IRB roles are edited.
Tech Note: the change is done for both 'active' versions of the Protocol Document Type