### PR TITLE
UAR-1167 KC Person lookup with return value returns null on Unit Admin Create Global and Unit Admin Delete Global

### DIFF
--- a/src/main/java/edu/arizona/kra/global/unit/create/UnitAdminCreateGlobalMaintainableImpl.java
+++ b/src/main/java/edu/arizona/kra/global/unit/create/UnitAdminCreateGlobalMaintainableImpl.java
@@ -2,8 +2,11 @@ package edu.arizona.kra.global.unit.create;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.kuali.kra.bo.UnitAdministrator;
+import org.kuali.rice.kim.api.KimConstants;
+import org.kuali.rice.kns.document.MaintenanceDocument;
 import org.kuali.rice.kns.maintenance.KualiGlobalMaintainableImpl;
 import org.kuali.rice.krad.bo.GlobalBusinessObjectDetail;
 import org.kuali.rice.krad.bo.PersistableBusinessObject;
@@ -21,6 +24,19 @@ import edu.arizona.kra.global.unit.UnitAdministratorPrimaryKey;
 public class UnitAdminCreateGlobalMaintainableImpl extends KualiGlobalMaintainableImpl {
 	private static final long serialVersionUID = -5289542451038756040L;
 	
+	private static final String KIM_PERSON_LOOKUPABLE_REFRESH_CALLER = "kimPersonLookupable";
+	
+	@SuppressWarnings( { "rawtypes", "unchecked" } )
+	@Override
+    public void refresh(String refreshCaller, Map fieldValues, MaintenanceDocument document) {
+        super.refresh(refreshCaller, fieldValues, document);
+        if (KIM_PERSON_LOOKUPABLE_REFRESH_CALLER.equals(refreshCaller)) {
+            String principalId = (String) fieldValues.get(KimConstants.PrimaryKeyConstants.PRINCIPAL_ID);
+
+    		fieldValues.put("unitAdminTypeAndPersonGlobalDetails.personId" , principalId);
+    		document.getNewMaintainableObject().populateNewCollectionLines(fieldValues, document, (String) fieldValues.get("methodToCall"));
+        }
+    }
 	
 	/**
 	 * Build a lock key of the form:

--- a/src/main/java/edu/arizona/kra/global/unit/create/UnitAdminTypeAndPersonGlobalDetail.java
+++ b/src/main/java/edu/arizona/kra/global/unit/create/UnitAdminTypeAndPersonGlobalDetail.java
@@ -53,7 +53,11 @@ public class UnitAdminTypeAndPersonGlobalDetail extends GlobalBusinessObjectDeta
 	
 	
 	public KcPerson getPerson() {
-		if(person == null && personId != null) {
+		if(personId != null) {
+			//Same person, avoid retrieving it
+			if (person != null && personId.equals(person.getPersonId())) {
+				return person;
+			}
 			person = getKcPersonService().getKcPersonByPersonId(personId);
 		}
         return person;

--- a/src/main/java/edu/arizona/kra/global/unit/delete/UnitAdminDeleteGlobalMaintainableImpl.java
+++ b/src/main/java/edu/arizona/kra/global/unit/delete/UnitAdminDeleteGlobalMaintainableImpl.java
@@ -2,8 +2,11 @@ package edu.arizona.kra.global.unit.delete;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.kuali.kra.bo.UnitAdministrator;
+import org.kuali.rice.kim.api.KimConstants;
+import org.kuali.rice.kns.document.MaintenanceDocument;
 import org.kuali.rice.kns.maintenance.KualiGlobalMaintainableImpl;
 import org.kuali.rice.krad.bo.GlobalBusinessObjectDetail;
 import org.kuali.rice.krad.bo.PersistableBusinessObject;
@@ -21,6 +24,19 @@ import edu.arizona.kra.global.unit.UnitAdministratorPrimaryKey;
 public class UnitAdminDeleteGlobalMaintainableImpl extends KualiGlobalMaintainableImpl {
 	private static final long serialVersionUID = -5289542451038756040L;
 	
+	private static final String KIM_PERSON_LOOKUPABLE_REFRESH_CALLER = "kimPersonLookupable";
+	
+	@SuppressWarnings( { "rawtypes", "unchecked" } )
+	@Override
+    public void refresh(String refreshCaller, Map fieldValues, MaintenanceDocument document) {
+        super.refresh(refreshCaller, fieldValues, document);
+        if (KIM_PERSON_LOOKUPABLE_REFRESH_CALLER.equals(refreshCaller)) {
+        	String principalId = (String) fieldValues.get(KimConstants.PrimaryKeyConstants.PRINCIPAL_ID);
+
+        	fieldValues.put("unitAdministratorGlobalDetails.personId" , principalId);
+    		document.getNewMaintainableObject().populateNewCollectionLines(fieldValues, document, (String) fieldValues.get("methodToCall"));
+        }
+    }
 	
 	/**
 	 * Build a lock key of the form:

--- a/src/main/java/edu/arizona/kra/global/unit/delete/UnitAdministratorGlobalDetail.java
+++ b/src/main/java/edu/arizona/kra/global/unit/delete/UnitAdministratorGlobalDetail.java
@@ -45,7 +45,11 @@ public class UnitAdministratorGlobalDetail extends GlobalBusinessObjectDetailBas
 	
 	
 	public KcPerson getPerson() {
-		if(person == null && personId != null) {
+		if(personId != null) {
+			//Same person, avoid retrieving it
+			if (person != null && personId.equals(person.getPersonId())) {
+				return person;
+			}
 			person = getKcPersonService().getKcPersonByPersonId(personId);
 		}
         return person;


### PR DESCRIPTION
Added a refresh method to UnitAdminCreateGlobalMaintainableImpl.java and UnitAdminDeleteGlobalMaintainableImpl.java set the personId and to add it into the field upon returning the value from the person lookup.  Adjusted the getPerson method in UnitAdminTypeAndPersonGlobalDetail.java and UnitAdministratorGlobalDetail.java to check if personId is not null and if so, check to make sure person was not null and compare the person.personId to personId and if they are the same, just return person, otherwise do a new getKcPersonByPersonId lookup to return the new person information.

Changed getPerson() conditions in the IF statement for UnitAdminTypeAndPersonGlobalDetail.java and UnitAdministratorGlobalDetail.java.  Removed two unnecessary lines from the refresh() method in UnitAdminCreateGlobalMaintainableImpl.java and UnitAdminDeleteGlobalMaintainableImpl.java.