### PR TITLE
UAR-263: Avoiding null pointer exceptions for QuestionnaireHeader

### DIFF
--- a/src/main/java/edu/arizona/kra/irb/actions/print/CustomProtocolXmlStream.java
+++ b/src/main/java/edu/arizona/kra/irb/actions/print/CustomProtocolXmlStream.java
@@ -102,11 +102,12 @@ public class CustomProtocolXmlStream extends ProtocolXmlStream {
 		fieldValues.put( MODULE_ITEM_CODE, CoeusModule.IRB_MODULE_CODE );
 		fieldValues.put( MODULE_ITEM_KEY, protocolNumber );
 		List<AnswerHeader> answerHeaders = (List<AnswerHeader>) getBusinessObjectService().findMatching( AnswerHeader.class, fieldValues );
-		if ( answerHeaders == null ) {
+		if ( answerHeaders == null || answerHeaders.isEmpty()) {
 			AnswerHeader ah = new AnswerHeader();
 			ah.setAnswerHeaderId( 0L );
 			List<Answer> answers = new ArrayList<Answer>();
 			ah.setAnswers( answers );
+			return ah;
 		}
 		Collections.sort( answerHeaders, ANSWER_HEADER_SORT );
 		return answerHeaders.get( answerHeaders.size() - 1 );


### PR DESCRIPTION
Fix CustomProtocolXmlStream.getQuestionnaireAnswerHeader to return an empty answer header instead of null.