### PR TITLE
UAR-1497 Fix for Versioning issues around Award and linked SubAwards through SubAwardFundingSources.

### DIFF
--- a/src/main/java/org/kuali/kra/award/web/struts/action/AwardAction.java
+++ b/src/main/java/org/kuali/kra/award/web/struts/action/AwardAction.java
@@ -1822,16 +1822,11 @@ public class AwardAction extends BudgetParentActionBase {
         return reportTrackingService;
     }
     /**
-     * This method will populate the subawards  if award is added as a funding source to perticular subaward
+     * This method will populate the subawards  if award is added as a funding source to particular subaward
      * @param award
      */
     protected void setSubAwardDetails(Award award){
-		List<SubAward> subAwardsForAllAwardVersions = new ArrayList<SubAward>();
-		List<Award> awardVersions = getAwardService().findAwardsForAwardNumber( award.getAwardNumber() );
-		for ( Award currentAward : awardVersions ) {
-			subAwardsForAllAwardVersions.addAll( getSubAwardService().getLinkedSubAwards( currentAward ) );
-		}
-		award.setSubAwardList( subAwardsForAllAwardVersions );
+        award.setSubAwardList((List<SubAward>) getSubAwardService().getLinkedSubAwards(award));
     }
 
     protected KcNotificationService getNotificationService() {

--- a/src/main/java/org/kuali/kra/lookup/keyvalue/SubAwardFundingSourceValuesFinder.java
+++ b/src/main/java/org/kuali/kra/lookup/keyvalue/SubAwardFundingSourceValuesFinder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2005-2014 The Kuali Foundation
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.opensource.org/licenses/ecl1.php
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kuali.kra.lookup.keyvalue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.kuali.kra.bo.FundingSourceType;
+import org.kuali.kra.infrastructure.KraServiceLocator;
+import org.kuali.kra.krad.migration.FormViewAwareUifKeyValuesFinderBase;
+import org.kuali.kra.subaward.bo.SubAwardFundingSource;
+import org.kuali.kra.subaward.document.SubAwardDocument;
+import org.kuali.rice.core.api.util.ConcreteKeyValue;
+import org.kuali.rice.core.api.util.KeyValue;
+import org.kuali.rice.krad.service.BusinessObjectService;
+import org.kuali.rice.krad.uif.control.UifKeyValuesFinderBase;
+
+public class SubAwardFundingSourceValuesFinder extends FormViewAwareUifKeyValuesFinderBase {
+    
+    @Override
+    public List<KeyValue> getKeyValues() {
+        SubAwardDocument doc = (SubAwardDocument)getDocument();
+        StringBuffer fundingValues = new StringBuffer();
+        Long subawardID = doc.getSubAward().getSubAwardId();
+        List<KeyValue> keyValues = new ArrayList<KeyValue>();
+        Collection<SubAwardFundingSource> fundingSource = (Collection<SubAwardFundingSource>) KraServiceLocator
+                .getService(BusinessObjectService.class).findAll(SubAwardFundingSource.class);
+        for (SubAwardFundingSource subAwardFunding : fundingSource) {
+            if (subAwardFunding.getSubAwardId().equals(subawardID)) {
+                fundingValues.append(subAwardFunding.getAward().getAwardNumber());
+                keyValues.add(new ConcreteKeyValue(subAwardFunding.getSubAwardFundingSourceId().toString(),"Award:"+subAwardFunding.getAward().getAwardNumber()));
+            }
+        }
+        if(fundingValues.length() == 0){
+            keyValues.add(0, new ConcreteKeyValue("", "No Funding Source has been added to this Subaward"));
+        }
+        return keyValues;
+    }
+
+}

--- a/src/main/java/org/kuali/kra/lookup/keyvalue/SubAwardFundingSourceValuesFinder.java
+++ b/src/main/java/org/kuali/kra/lookup/keyvalue/SubAwardFundingSourceValuesFinder.java
@@ -19,33 +19,29 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.kuali.kra.bo.FundingSourceType;
 import org.kuali.kra.infrastructure.KraServiceLocator;
 import org.kuali.kra.krad.migration.FormViewAwareUifKeyValuesFinderBase;
+import org.kuali.kra.subaward.bo.SubAward;
 import org.kuali.kra.subaward.bo.SubAwardFundingSource;
 import org.kuali.kra.subaward.document.SubAwardDocument;
+import org.kuali.kra.subaward.service.SubAwardService;
 import org.kuali.rice.core.api.util.ConcreteKeyValue;
 import org.kuali.rice.core.api.util.KeyValue;
-import org.kuali.rice.krad.service.BusinessObjectService;
-import org.kuali.rice.krad.uif.control.UifKeyValuesFinderBase;
+
 
 public class SubAwardFundingSourceValuesFinder extends FormViewAwareUifKeyValuesFinderBase {
     
     @Override
     public List<KeyValue> getKeyValues() {
-        SubAwardDocument doc = (SubAwardDocument)getDocument();
-        StringBuffer fundingValues = new StringBuffer();
-        Long subawardID = doc.getSubAward().getSubAwardId();
+        SubAward subaward = ((SubAwardDocument)getDocument()).getSubAward();
+        
+        Collection<SubAwardFundingSource> fundingSources = (Collection<SubAwardFundingSource>) KraServiceLocator
+                .getService(SubAwardService.class).getActiveSubAwardFundingSources(subaward);
         List<KeyValue> keyValues = new ArrayList<KeyValue>();
-        Collection<SubAwardFundingSource> fundingSource = (Collection<SubAwardFundingSource>) KraServiceLocator
-                .getService(BusinessObjectService.class).findAll(SubAwardFundingSource.class);
-        for (SubAwardFundingSource subAwardFunding : fundingSource) {
-            if (subAwardFunding.getSubAwardId().equals(subawardID)) {
-                fundingValues.append(subAwardFunding.getAward().getAwardNumber());
-                keyValues.add(new ConcreteKeyValue(subAwardFunding.getSubAwardFundingSourceId().toString(),"Award:"+subAwardFunding.getAward().getAwardNumber()));
-            }
+        for (SubAwardFundingSource sfs : fundingSources) {
+                keyValues.add(new ConcreteKeyValue(subaward.getSubAwardCode()+":"+sfs.getAwardNumber(),"Award:"+sfs.getAwardNumber()));
         }
-        if(fundingValues.length() == 0){
+        if(keyValues.size() == 0){
             keyValues.add(0, new ConcreteKeyValue("", "No Funding Source has been added to this Subaward"));
         }
         return keyValues;

--- a/src/main/java/org/kuali/kra/medusa/service/MedusaServiceImpl.java
+++ b/src/main/java/org/kuali/kra/medusa/service/MedusaServiceImpl.java
@@ -1,0 +1,972 @@
+/*
+ * Copyright 2005-2014 The Kuali Foundation
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.opensource.org/licenses/ecl1.php
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kuali.kra.medusa.service;
+
+import org.apache.commons.lang.ObjectUtils;
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kra.SequenceOwner;
+import org.kuali.kra.award.AwardAmountInfoService;
+import org.kuali.kra.award.home.Award;
+import org.kuali.kra.award.home.AwardAmountInfo;
+import org.kuali.kra.award.home.fundingproposal.AwardFundingProposal;
+import org.kuali.kra.bo.FundingSourceType;
+import org.kuali.kra.bo.NsfCode;
+import org.kuali.kra.bo.SpecialReviewApprovalType;
+import org.kuali.kra.bo.SpecialReviewType;
+import org.kuali.kra.bo.versioning.VersionHistory;
+import org.kuali.kra.bo.versioning.VersionStatus;
+import org.kuali.kra.common.specialreview.bo.SpecialReview;
+import org.kuali.kra.iacuc.IacucProtocol;
+import org.kuali.kra.infrastructure.Constants;
+import org.kuali.kra.infrastructure.KraServiceLocator;
+import org.kuali.kra.institutionalproposal.home.InstitutionalProposal;
+import org.kuali.kra.institutionalproposal.proposaladmindetails.ProposalAdminDetails;
+import org.kuali.kra.irb.Protocol;
+import org.kuali.kra.medusa.MedusaNode;
+import org.kuali.kra.negotiations.bo.Negotiation;
+import org.kuali.kra.negotiations.service.NegotiationService;
+import org.kuali.kra.proposaldevelopment.bo.DevelopmentProposal;
+import org.kuali.kra.protocol.protocol.funding.ProtocolFundingSourceBase;
+import org.kuali.kra.service.VersionHistoryService;
+import org.kuali.kra.subaward.bo.SubAward;
+import org.kuali.kra.subaward.bo.SubAwardFundingSource;
+import org.kuali.kra.subaward.service.SubAwardService;
+import org.kuali.rice.coreservice.framework.parameter.ParameterService;
+import org.kuali.rice.krad.bo.BusinessObject;
+import org.kuali.rice.krad.service.BusinessObjectService;
+
+import java.util.*;
+
+/**
+ * Medusa Service provides the methods to get MedusaNodes that describe the tree-like structure that describes
+ * the nodes and provides a method of retrieving related BOs for summary display.
+ */
+public class MedusaServiceImpl implements MedusaService {
+
+    private static final int INST_PROPOSAL_STATUS_FUNDED = 2;
+
+    private BusinessObjectService businessObjectService;
+    private AwardAmountInfoService awardAmountInfoService;
+    private VersionHistoryService versionHistoryService;
+    private NegotiationService negotiationService;
+    private SubAwardService subAwardService;
+    private ParameterService parameterService;
+    
+    /**
+     * 
+     * @see org.kuali.kra.medusa.service.MedusaService#getMedusaNode(java.lang.String, java.lang.Long)
+     */
+    public MedusaNode getMedusaNode(String moduleName, Long moduleId) {
+        MedusaNode curNode = new MedusaNode();
+        curNode.setType(moduleName);
+        if (StringUtils.equalsIgnoreCase(Constants.AWARD_MODULE, moduleName)) {
+            Award award = (Award) businessObjectService.findByPrimaryKey(Award.class, getFieldValues("awardId", moduleId));
+            curNode.setBo(award);
+            curNode.setExtraInfo(awardAmountInfoService.fetchAwardAmountInfoWithHighestTransactionId(award.getAwardAmountInfos()));
+        } else if (StringUtils.equalsIgnoreCase(Constants.INSTITUTIONAL_PROPOSAL_MODULE, moduleName)) {
+            InstitutionalProposal proposal = 
+                (InstitutionalProposal) businessObjectService.findByPrimaryKey(InstitutionalProposal.class, getFieldValues("proposalId", moduleId));
+            proposal.setNsfCodeBo(getNsfCode(proposal.getNsfCode()));
+            curNode.setBo(proposal);
+        } else if (StringUtils.equalsIgnoreCase(Constants.DEVELOPMENT_PROPOSAL_MODULE , moduleName)) {
+            DevelopmentProposal devProp = 
+                (DevelopmentProposal) businessObjectService.findByPrimaryKey(DevelopmentProposal.class, getFieldValues("proposalNumber", moduleId));
+            devProp.setNsfCodeBo(getNsfCode(devProp.getNsfCode()));
+            curNode.setBo(devProp);
+        } else if (StringUtils.equalsIgnoreCase(Constants.NEGOTIATION_MODULE, moduleName)) {
+            Negotiation negotiation = getNegotiation(moduleId);
+            curNode.setBo(negotiation);
+        } else if (StringUtils.equalsIgnoreCase(Constants.SUBAWARD_MODULE, moduleName)) {
+            SubAward subaward = getSubAward(moduleId);
+            curNode.setBo(subaward);
+        } else if (StringUtils.equalsIgnoreCase(Constants.IRB_MODULE, moduleName)) {
+            Protocol protocol = getProtocol(moduleId);
+            curNode.setBo(protocol);
+        } else if (StringUtils.equalsIgnoreCase(Constants.IACUC_MODULE, moduleName)) {
+            IacucProtocol protocol = getIacuc(moduleId);
+            curNode.setBo(protocol);
+        }
+        return curNode;
+    }
+    
+    /**
+     * 
+     * Helper function as nsfCode has been wired up such that it needs
+     * outside help getting the actual BO loaded.
+     * @param nsfCode
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    protected NsfCode getNsfCode(String nsfCode) {
+        Collection<NsfCode> bos = businessObjectService.findMatching(NsfCode.class, getFieldValues("nsfCode", nsfCode));
+        for (NsfCode nsfBo : bos) {
+            return nsfBo;
+        }
+        return null;
+    }
+    
+    /**
+     * 
+     * @see org.kuali.kra.medusa.service.MedusaService#getMedusaByProposal(java.lang.String, java.lang.Long)
+     */
+    public List<MedusaNode> getMedusaByProposal(String moduleName, Long moduleIdentifier) {
+        String preferredModule = Constants.INSTITUTIONAL_PROPOSAL_MODULE;
+        return getMedusaTree(moduleName, moduleIdentifier, preferredModule);
+    }
+    
+    /**
+     * 
+     * @see org.kuali.kra.medusa.service.MedusaService#getMedusaByAward(java.lang.String, java.lang.Long)
+     */
+    public List<MedusaNode> getMedusaByAward(String moduleName, Long moduleIdentifier) {
+        String preferredModule = Constants.AWARD_MODULE;
+        return getMedusaTree(moduleName, moduleIdentifier, preferredModule);
+    }
+    
+    /**
+     * 
+     * Builds the tree-like structure of MedusaNode objects using the module name and identifier
+     * @param moduleName name of the module to be looked up (ie. award, IP, DP)
+     * @param moduleIdentifier the primary key of the object to be looked up in the specified module
+     * @param preferredModule defines the object type that should be placed at the top level when possible
+     * @return
+     */
+    protected List<MedusaNode> getMedusaTree(String moduleName, Long moduleIdentifier, String preferredModule) {
+        List<MedusaNode> nodes = new ArrayList<MedusaNode>();
+        HashMap<BusinessObject, List<BusinessObject>> graph = new HashMap<BusinessObject, List<BusinessObject>>();
+        if (StringUtils.equals(moduleName, Constants.AWARD_MODULE)) {
+            Award award = getAward(moduleIdentifier);
+            addVertex(graph, award);
+            buildGraph(graph, award);
+            nodes = getParentNodes(graph, new String[]{preferredModule, Constants.AWARD_MODULE});
+        } else if (StringUtils.equals(moduleName, Constants.INSTITUTIONAL_PROPOSAL_MODULE)) {
+            InstitutionalProposal proposal = getInstitutionalProposal(moduleIdentifier);
+            addVertex(graph, proposal);
+            buildGraph(graph, proposal);
+            nodes = getParentNodes(graph, new String[]{preferredModule, Constants.INSTITUTIONAL_PROPOSAL_MODULE});
+        } else if (StringUtils.equals(moduleName, Constants.DEVELOPMENT_PROPOSAL_MODULE)) {
+            DevelopmentProposal proposal = getDevelopmentProposal(moduleIdentifier.toString());
+            addVertex(graph, proposal);
+            buildGraph(graph, proposal);
+            nodes = getParentNodes(graph, new String[]{preferredModule, Constants.DEVELOPMENT_PROPOSAL_MODULE});
+        } else if (StringUtils.equals(moduleName, Constants.NEGOTIATION_MODULE)) {
+            Negotiation negotiation = getNegotiation(moduleIdentifier);
+            if (negotiation != null) {
+                addVertex(graph, negotiation);
+                buildGraph(graph, negotiation);
+                nodes = getParentNodes(graph, new String[]{preferredModule, Constants.NEGOTIATION_MODULE});
+            }
+        } else if (StringUtils.equals(moduleName, Constants.SUBAWARD_MODULE)) {
+            SubAward subAward = getSubAward(moduleIdentifier);
+            if (subAward != null) {
+                addVertex(graph, subAward);
+                buildGraph(graph, subAward);
+                nodes = getParentNodes(graph, new String[]{preferredModule, Constants.SUBAWARD_MODULE});
+            }
+        } else if (StringUtils.equals(moduleName, Constants.IRB_MODULE)) {
+            Protocol protocol = getProtocol(moduleIdentifier);
+            if (protocol != null) {
+                addVertex(graph, protocol);
+                buildGraph(graph, protocol);
+                nodes = getParentNodes(graph, new String[]{preferredModule, Constants.IRB_MODULE});
+            }
+        } else if (StringUtils.equals(moduleName, Constants.IACUC_MODULE)) {
+            IacucProtocol protocol = getIacuc(moduleIdentifier);
+            if (protocol != null) {
+                addVertex(graph, protocol);
+                buildGraph(graph, protocol);
+                nodes = getParentNodes(graph, new String[]{preferredModule, Constants.IACUC_MODULE});
+            }
+        }
+        return nodes;
+    }
+    
+    /**
+     * 
+     * Adds a new bo to the graph like hash after checking to make sure the same bo is not already added.
+     * This is done outside of the typical hash uniqueness due to the fact the BOs do not all defined equals and hash
+     * code so we do the checks here
+     * @param graph
+     * @param bo
+     * @return the bo that was already in the graph or was added to the graph
+     */
+    protected BusinessObject addVertex(HashMap<BusinessObject, List<BusinessObject>> graph, BusinessObject bo) {
+        BusinessObject graphBo = findMatchingBo(graph.keySet(), bo);
+        if (graphBo == null) {
+            graph.put(bo, new ArrayList<BusinessObject>());
+            return bo;
+        } else {
+            return graphBo;
+        }
+        
+    }
+    
+    /**
+     * 
+     * First adds both bos into the graph as vertexes(using addVertex) and then if the links do not already
+     * exist, adds a bi-directional link to the graph.
+     * @param graph
+     * @param bo1
+     * @param bo2
+     */
+    protected void addEdge(HashMap<BusinessObject, List<BusinessObject>> graph, BusinessObject bo1, BusinessObject bo2) {
+        BusinessObject graphBo1 = addVertex(graph, bo1);
+        BusinessObject graphBo2 = addVertex(graph, bo2);
+        if (findMatchingBo(graph.get(graphBo1), graphBo2) == null) {
+            graph.get(graphBo1).add(graphBo2);
+        }
+        if (findMatchingBo(graph.get(graphBo2), graphBo1) == null) {
+            graph.get(graphBo2).add(graphBo1);
+        }
+    }
+    
+    /**
+     * 
+     * Searches through the graph using the preferred order for Bos to occupy the top level(or parent nodes)
+     * and then populates all child nodes of each top level node.
+     * @param graph
+     * @param preferedOrder an array of module names (ie. award, DP, IP)
+     * @return
+     */
+    protected List<MedusaNode> getParentNodes(HashMap<BusinessObject, List<BusinessObject>> graph, String[] preferedOrder) {
+        List<MedusaNode> parentNodes = new ArrayList<MedusaNode>();
+        
+        for (String prefType : preferedOrder) {
+            for (BusinessObject bo : graph.keySet()) {
+                MedusaNode node = getNode(bo);
+                if (StringUtils.equals(node.getType(), prefType)) {
+                    parentNodes.add(node);
+                }
+            }
+            if (!parentNodes.isEmpty()) { break; }
+        }
+        
+        //while adding in child nodes make sure the top-level nodes are not duplicated in the tree structure
+        for (MedusaNode node : parentNodes) {
+            List<MedusaNode> seenNodes = new ArrayList<MedusaNode>(parentNodes);
+            populateChildNodes(graph, node, seenNodes);
+        }
+
+        return parentNodes;
+    }
+    
+    /**
+     * 
+     * Using the links defined in the graph hash, add all nodes linked to the current node
+     * @param graph
+     * @param node
+     * @param parentNodes
+     */
+    protected void populateChildNodes(HashMap<BusinessObject, List<BusinessObject>> graph, MedusaNode node, List<MedusaNode> parentNodes) {
+        Collection<BusinessObject> links = graph.get(node.getBo());
+        for (BusinessObject bo : links) {
+            MedusaNode nextNode = getNode(bo);
+            if (parentNodes == null || !isBoInList(parentNodes, bo)) {
+                node.getChildNodes().add(nextNode);
+                parentNodes.add(node);
+                populateChildNodes(graph, nextNode, parentNodes);
+            }
+        }
+    }
+    
+    /**
+     * 
+     * Looks through the list of MedusaNodes to see if the BO is equal to the BO of one of the nodes.
+     * @param nodes
+     * @param bo
+     * @return
+     */
+    protected boolean isBoInList(List<MedusaNode> nodes, BusinessObject bo) {
+        for (MedusaNode node : nodes) {
+            if (areBusinessObjectsEqual(node.getBo(), bo)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    protected void buildGraph(HashMap<BusinessObject, List<BusinessObject>> graph, SubAward subAward) {
+        
+        Collection<Award> awards = getAwards(subAward);
+        for (Award award : awards) {
+            addToGraph(graph, award, subAward);
+        }
+        Collection<Negotiation> negotiations = getNegotiations(subAward);
+        for (Negotiation negotiation : negotiations) {
+            addToGraph(graph, negotiation, subAward);
+        }        
+    }
+    
+    protected void buildGraph(HashMap<BusinessObject, List<BusinessObject>> graph, Protocol protocol) {
+        for (ProtocolFundingSourceBase fundingSource : protocol.getProtocolFundingSources()) {
+            if (StringUtils.equals(fundingSource.getFundingSourceTypeCode(), FundingSourceType.AWARD)) {
+                addToGraph(graph, getAward(fundingSource.getFundingSourceNumber()), protocol);
+            } else if (StringUtils.equals(fundingSource.getFundingSourceTypeCode(), FundingSourceType.INSTITUTIONAL_PROPOSAL)) {
+                addToGraph(graph, getInstitutionalProposal(fundingSource.getFundingSourceNumber()), protocol);
+            } else if (StringUtils.equals(fundingSource.getFundingSourceTypeCode(), FundingSourceType.PROPOSAL_DEVELOPMENT)) {
+                addToGraph(graph, getDevelopmentProposal(fundingSource.getFundingSourceNumber()), protocol);
+            }
+        }       
+    }
+    
+    protected void buildGraph(HashMap<BusinessObject, List<BusinessObject>> graph, IacucProtocol protocol) {
+        for (org.kuali.kra.protocol.protocol.funding.ProtocolFundingSourceBase fundingSource : protocol.getProtocolFundingSources()) {
+            if (StringUtils.equals(fundingSource.getFundingSourceTypeCode(), FundingSourceType.AWARD)) {
+                addToGraph(graph, getAward(fundingSource.getFundingSourceNumber()), protocol);
+            } else if (StringUtils.equals(fundingSource.getFundingSourceTypeCode(), FundingSourceType.INSTITUTIONAL_PROPOSAL)) {
+                addToGraph(graph, getInstitutionalProposal(fundingSource.getFundingSourceNumber()), protocol);
+            } else if (StringUtils.equals(fundingSource.getFundingSourceTypeCode(), FundingSourceType.PROPOSAL_DEVELOPMENT)) {
+                addToGraph(graph, getDevelopmentProposal(fundingSource.getFundingSourceNumber()), protocol);
+            }
+        }       
+    }    
+    
+    protected void addSpecialReviewLinksToGraph(HashMap<BusinessObject, List<BusinessObject>> graph, List<? extends SpecialReview> specialReviews, BusinessObject existingBo) {
+        Map<String, Boolean> specialReviewLinking = getSpecialReviewLinkingEnabled(existingBo);
+        for (SpecialReview specialReview : specialReviews) {
+            if (StringUtils.equals(specialReview.getSpecialReviewTypeCode(), SpecialReviewType.HUMAN_SUBJECTS)
+                    && specialReviewLinking.get(SpecialReviewType.HUMAN_SUBJECTS)
+                    && !StringUtils.equals(specialReview.getApprovalTypeCode(), SpecialReviewApprovalType.NOT_YET_APPLIED)) {
+                Protocol protocol = getProtocol(specialReview.getProtocolNumber());
+                addToGraph(graph, protocol, existingBo);
+            } else if (StringUtils.equals(specialReview.getSpecialReviewTypeCode(), SpecialReviewType.ANIMAL_USAGE)
+                    && specialReviewLinking.get(SpecialReviewType.ANIMAL_USAGE)
+                    && !StringUtils.equals(specialReview.getApprovalTypeCode(), SpecialReviewApprovalType.NOT_YET_APPLIED)) {
+                IacucProtocol protocol = getIacuc(specialReview.getProtocolNumber());
+                addToGraph(graph, protocol, existingBo);
+            }
+        }
+    }
+    
+    protected Map<String, Boolean> getSpecialReviewLinkingEnabled(BusinessObject existingBo) {
+        Map<String, Boolean> result = new HashMap<String, Boolean>();
+        String irbLinkingName = null;
+        String iacucLinkingName = null;
+        if (existingBo instanceof DevelopmentProposal) {
+            irbLinkingName = Constants.ENABLE_PROTOCOL_TO_DEV_PROPOSAL_LINK;
+            iacucLinkingName = Constants.IACUC_PROTOCOL_PROPOSAL_DEVELOPMENT_LINKING_ENABLED_PARAMETER;
+        } else if (existingBo instanceof InstitutionalProposal) {
+            irbLinkingName = Constants.ENABLE_PROTOCOL_TO_PROPOSAL_LINK;
+            iacucLinkingName = Constants.IACUC_PROTOCOL_INSTITUTE_PROPOSAL_LINKING_ENABLED_PARAMETER;
+        } else if (existingBo instanceof Award) {
+            irbLinkingName = Constants.ENABLE_PROTOCOL_TO_AWARD_LINK;
+            iacucLinkingName = Constants.IACUC_PROTOCOL_AWARD_LINKING_ENABLED_PARAMETER;
+        }
+        if (irbLinkingName != null) {
+            result.put(SpecialReviewType.HUMAN_SUBJECTS, 
+                    getParameterService().getParameterValueAsBoolean(Constants.MODULE_NAMESPACE_PROTOCOL, Constants.PARAMETER_COMPONENT_DOCUMENT, irbLinkingName));
+        } else {
+            result.put(SpecialReviewType.HUMAN_SUBJECTS, Boolean.FALSE);
+        }
+        if (iacucLinkingName != null) {
+            result.put(SpecialReviewType.ANIMAL_USAGE, 
+                    getParameterService().getParameterValueAsBoolean(Constants.MODULE_NAMESPACE_IACUC, Constants.PARAMETER_COMPONENT_DOCUMENT, iacucLinkingName));
+        } else {
+            result.put(SpecialReviewType.ANIMAL_USAGE, Boolean.FALSE);
+        }
+        return result;
+    }
+    
+    /**
+     * 
+     * Builds the graph recursively by finding links from the Award.
+     * @param graph
+     * @param award
+     */
+    protected void buildGraph(HashMap<BusinessObject, List<BusinessObject>> graph, Award award) {
+        Collection<InstitutionalProposal> proposals = getProposals(award);
+        for (InstitutionalProposal proposal : proposals) {
+            addToGraph(graph, proposal, award);
+        }
+        Collection<Negotiation> negotiations = getNegotiations(award);
+        for (Negotiation negotiation : negotiations) {
+            addToGraph(graph, negotiation, award);
+        }
+        Collection<SubAward> subAwards = getSubAwards(award);
+        for (SubAward subAward : subAwards) {
+            addToGraph(graph, subAward, award);
+        }
+        addSpecialReviewLinksToGraph(graph, award.getSpecialReviews(), award);
+    }
+    
+    /**
+     * 
+     * Builds the graph using links found from the institutional proposal.
+     * @param graph
+     * @param proposal
+     */
+    protected void buildGraph(HashMap<BusinessObject, List<BusinessObject>> graph, InstitutionalProposal proposal) {
+        Collection<Award> awards = getAwards(proposal);
+        for (Award award : awards) {
+            addToGraph(graph, award, proposal);
+        }
+        Collection<DevelopmentProposal> proposals = getDevelopmentProposals(proposal);
+        for (DevelopmentProposal devProp : proposals) {
+            addToGraph(graph, devProp, proposal);
+        }
+        Collection<Negotiation> negotiations = getNegotiations(proposal);
+        for (Negotiation negotiation : negotiations) {
+            addToGraph(graph, negotiation, proposal);
+        }
+        addSpecialReviewLinksToGraph(graph, proposal.getSpecialReviews(), proposal);
+    }
+    
+    /**
+     * 
+     * Continues to build the graph finding links from the development proposal
+     * @param graph
+     * @param devProp
+     */
+    protected void buildGraph(HashMap<BusinessObject, List<BusinessObject>> graph, DevelopmentProposal devProp) {
+        Collection<InstitutionalProposal> proposals = getProposals(devProp);
+        for (InstitutionalProposal proposal : proposals) {
+            addToGraph(graph, proposal, devProp);
+        } 
+        addSpecialReviewLinksToGraph(graph, devProp.getPropSpecialReviews(), devProp);
+    }
+    
+    protected void buildGraph(HashMap<BusinessObject, List<BusinessObject>> graph, Negotiation negotiation) {
+        BusinessObject bo = (BusinessObject)getNegotiationService().getAssociatedObject(negotiation);
+        if (bo instanceof Award || bo instanceof InstitutionalProposal || bo instanceof SubAward) {
+            addToGraph(graph, bo, negotiation);
+        }
+    }
+    
+    protected void addToGraph(HashMap<BusinessObject, List<BusinessObject>> graph, BusinessObject newBo, BusinessObject existingBo) {
+        if (newBo == null || existingBo == null) {
+            throw new RuntimeException("Inavlid or null Medusa link found");
+        }
+        if (findMatchingBo(graph.keySet(), newBo) == null) {
+            addEdge(graph, existingBo, newBo);
+            if (newBo instanceof Award) {
+                buildGraph(graph, (Award)newBo);
+            } else if (newBo instanceof InstitutionalProposal) {
+                buildGraph(graph, (InstitutionalProposal) newBo);
+            } else if (newBo instanceof DevelopmentProposal) {
+                buildGraph(graph, (DevelopmentProposal) newBo);
+            } else if (newBo instanceof Negotiation) {
+                buildGraph(graph, (Negotiation) newBo);
+            } else if (newBo instanceof SubAward) {
+                buildGraph(graph, (SubAward) newBo);
+            } else if (newBo instanceof Protocol) {
+                buildGraph(graph, (Protocol) newBo);
+            } else if (newBo instanceof IacucProtocol) {
+                buildGraph(graph, (IacucProtocol) newBo);
+            }
+        } else {
+            addEdge(graph, existingBo, newBo);            
+        }
+    }
+    
+    /**
+     * 
+     * Looks through the boSet for a matching medusa BO.
+     * @param boSet
+     * @param bo
+     * @return
+     */
+    protected BusinessObject findMatchingBo(Collection<BusinessObject> boSet, BusinessObject bo) {
+        for (BusinessObject curBo : boSet) {
+            if (areBusinessObjectsEqual(bo, curBo)) {
+                return curBo;
+            }
+        }
+        return null;
+    } 
+    
+    /**
+     * 
+     * Checks the buisness objects for equality assuming they are medusa supported BOs
+     * (Development Proposal, Institutional Proposal or Award), this is because the current
+     * BOs do not support equality checking.
+     * @param bo1
+     * @param bo2
+     * @return
+     */
+    protected boolean areBusinessObjectsEqual(BusinessObject bo1, BusinessObject bo2) {
+        if (bo1 instanceof DevelopmentProposal
+                && bo2 instanceof DevelopmentProposal) {
+            if (ObjectUtils.equals(((DevelopmentProposal)bo1).getProposalNumber(),
+                    ((DevelopmentProposal)bo2).getProposalNumber())) {
+                return true;
+            }
+        } else if (bo1 instanceof InstitutionalProposal
+                && bo2 instanceof InstitutionalProposal) {
+            if (ObjectUtils.equals(((InstitutionalProposal)bo1).getProposalId(),
+                    ((InstitutionalProposal)bo2).getProposalId())) {
+                return true;
+            }
+        } else if (bo1 instanceof Award && bo2 instanceof Award) {
+            if (ObjectUtils.equals(((Award)bo1).getAwardId(),
+                    ((Award)bo2).getAwardId())) {
+                return true;
+            }
+        } else if (bo1 instanceof Negotiation && bo2 instanceof Negotiation) {
+            if (ObjectUtils.equals(((Negotiation) bo1).getNegotiationId(),
+                    ((Negotiation) bo2).getNegotiationId())) {
+                return true;
+            }
+        } else if (bo1 instanceof SubAward && bo2 instanceof SubAward) {
+            if (ObjectUtils.equals(((SubAward) bo1).getSubAwardId(),
+                    ((SubAward) bo2).getSubAwardId())) {
+                return true;
+            }
+        } else if (bo1 instanceof Protocol && bo2 instanceof Protocol) {
+            if (ObjectUtils.equals(((Protocol) bo1).getProtocolId(),
+                    ((Protocol) bo2).getProtocolId()))
+                return true;
+        } else if (bo1 instanceof IacucProtocol && bo2 instanceof IacucProtocol) {
+            if (ObjectUtils.equals(((IacucProtocol) bo1).getProtocolId(),
+                    ((IacucProtocol) bo2).getProtocolId()))
+                return true;
+        }
+        return false;
+    }
+    
+    protected DevelopmentProposal getDevelopmentProposal(String proposalNumber) {
+        return (DevelopmentProposal)businessObjectService.findByPrimaryKey(DevelopmentProposal.class, getFieldValues("proposalNumber", proposalNumber));
+    }
+    
+    /**
+     * 
+     * Returns the newest active institutional proposal if its available otherwise the newest pending and then archived proposal is returned.
+     * @param proposalId
+     * @return
+     */
+    protected InstitutionalProposal getInstitutionalProposal(Long proposalId) {
+        InstitutionalProposal proposal = (InstitutionalProposal) businessObjectService.findByPrimaryKey(InstitutionalProposal.class, getFieldValues("proposalId", proposalId));
+        if (proposal == null) {
+            return null;
+        }
+        InstitutionalProposal currentProposal = getInstitutionalProposal(proposal.getProposalNumber());
+        return currentProposal == null ? proposal : currentProposal;
+    }
+    
+    protected InstitutionalProposal getInstitutionalProposal(String proposalNumber) {
+        InstitutionalProposal currentProposal = null;
+        for (VersionStatus status : new VersionStatus[]{VersionStatus.ACTIVE, VersionStatus.PENDING, VersionStatus.ARCHIVED}) {
+            currentProposal = getNewestProposalByStatus(proposalNumber, status);
+            if (currentProposal != null) {
+                break;
+            }
+        }
+        return currentProposal;
+    }
+    
+    /**
+     * 
+     * Returns the newest active if available or the newest no cancelled award if it is not
+     * @param awardId
+     * @return
+     */
+    protected Award getAward(Long awardId) {
+        Award award = (Award)businessObjectService.findByPrimaryKey(Award.class, getFieldValues("awardId", awardId));
+        if (award == null) {
+            return null;
+        }
+        Award currentAward = (Award) getActiveOrCurrentVersion(Award.class, award.getAwardNumber());
+        return currentAward == null ? award : currentAward;
+    }
+    
+    protected Award getAward(String awardNumber) {
+        Award currentAward = (Award) getActiveOrCurrentVersion(Award.class, awardNumber);
+        return currentAward;
+    }
+    
+    protected Negotiation getNegotiation(Long negotiationId) {
+        Negotiation negotiation = negotiationId == null ? null : (Negotiation) businessObjectService.findBySinglePrimaryKey(Negotiation.class, negotiationId);
+        return negotiation;
+    }
+    
+    protected SubAward getSubAward(Long subAwardId) {
+        SubAward subAward = (SubAward) businessObjectService.findBySinglePrimaryKey(SubAward.class, subAwardId);
+        if (subAward == null) {
+            return null;
+        }
+        SubAward currentSubAward = (SubAward) getActiveOrCurrentVersion(SubAward.class, subAward.getSubAwardCode());
+        if (currentSubAward != null) {
+            KraServiceLocator.getService(SubAwardService.class).getAmountInfo(currentSubAward);
+        }
+        return currentSubAward == null ? subAward : currentSubAward;
+    }
+    
+    protected Protocol getProtocol(Long protocolId) {
+        Protocol protocol = (Protocol)businessObjectService.findBySinglePrimaryKey(Protocol.class, protocolId);
+        return protocol;
+    }
+    protected Protocol getProtocol(String protocolNumber) {
+        Map<String, Object> values = new HashMap<String, Object>();
+        values.put("protocolNumber", protocolNumber);
+        List<Protocol> versions = (List<Protocol>) businessObjectService.findMatching(Protocol.class, values);
+        Protocol newest = null;
+        for (Protocol version : versions) {
+            if (newest == null || version.getSequenceNumber() > newest.getSequenceNumber()) {
+                newest = version;
+            }
+        }
+        return newest;
+    }
+    
+    protected IacucProtocol getIacuc(Long protocolId) {
+        IacucProtocol protocol = (IacucProtocol) businessObjectService.findBySinglePrimaryKey(IacucProtocol.class, protocolId);
+        return protocol;
+    }
+    protected IacucProtocol getIacuc(String protocolNumber) {
+        Map<String, Object> values = new HashMap<String, Object>();
+        values.put("protocolNumber", protocolNumber);
+        List<IacucProtocol> versions = (List<IacucProtocol>) businessObjectService.findMatching(IacucProtocol.class, values);
+        IacucProtocol newest = null;
+        for (IacucProtocol version : versions) {
+            if (newest == null || version.getSequenceNumber() > newest.getSequenceNumber()) {
+                newest = version;
+            }
+        }
+        return newest;
+    }
+    /**
+     * 
+     * Gets the active or if not available the most current, not cancelled version of a 
+     * versioned BO. Currently only Awards use the Version History framework though
+     * @param clazz
+     * @param sequenceName
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    protected SequenceOwner getActiveOrCurrentVersion(Class clazz, String sequenceName) {
+        VersionHistory activeVersion = versionHistoryService.findActiveVersion(clazz, sequenceName);
+        SequenceOwner bestVersion = null;
+        if (activeVersion != null) {
+            bestVersion = (SequenceOwner)activeVersion.getSequenceOwner();
+        } else {
+            List<VersionHistory> history = versionHistoryService.loadVersionHistory(clazz, sequenceName);
+            if (history != null && !history.isEmpty()) {
+                VersionHistory best = history.get(0);
+                for (VersionHistory curVersion : history) {
+                    if (curVersion.getVersionNumber() > best.getVersionNumber()) {
+                        if (curVersion.getStatus() != VersionStatus.CANCELED) {
+                            best = curVersion;
+                        }
+                    }
+                }
+                bestVersion = (SequenceOwner)best.getSequenceOwner();
+            } 
+        }
+        return bestVersion;  
+    }
+    
+    /**
+     * 
+     * Creates a MedusaNode for the BO given the BO is supported by Medusa(Award, Dev Prop or Inst Prop).
+     * @param bo
+     * @return
+     */
+    protected MedusaNode getNode(BusinessObject bo) {
+        if (bo instanceof Award) {
+            return getNode((Award)bo);
+        } else if (bo instanceof InstitutionalProposal) {
+            return getNode((InstitutionalProposal)bo);
+        } else if (bo instanceof DevelopmentProposal) {
+            return getNode((DevelopmentProposal)bo);
+        } else if (bo instanceof Negotiation) {
+            return getNode((Negotiation)bo);
+        } else if (bo instanceof SubAward) {
+            return getNode((SubAward)bo);
+        } else if (bo instanceof Protocol) {
+            return getNode((Protocol) bo);
+        } else if (bo instanceof IacucProtocol) {
+            return getNode((IacucProtocol) bo);
+        } else {
+            return null;
+        }
+    }
+    
+    protected MedusaNode getNode(Award award) {
+        AwardAmountInfo awardAmountInfo = awardAmountInfoService.fetchAwardAmountInfoWithHighestTransactionId(award.getAwardAmountInfos());
+        MedusaNode node = new MedusaNode();
+        node.setBo(award);
+        node.setType(Constants.AWARD_MODULE);
+        node.setExtraInfo(awardAmountInfo);
+        return node;
+    }
+    
+    protected MedusaNode getNode(InstitutionalProposal proposal) {
+        MedusaNode node = new MedusaNode();
+        node.setBo(proposal);
+        node.setType(Constants.INSTITUTIONAL_PROPOSAL_MODULE);
+        return node;
+    }
+    
+    protected MedusaNode getNode(DevelopmentProposal proposal) {
+        MedusaNode node = new MedusaNode();
+        node.setBo(proposal);
+        node.setType(Constants.DEVELOPMENT_PROPOSAL_MODULE);
+        return node;
+    }
+    
+    protected MedusaNode getNode(Negotiation negotiation) {
+        MedusaNode node = new MedusaNode();
+        node.setBo(negotiation);
+        node.setType(Constants.NEGOTIATION_MODULE);
+        return node;
+    }
+    protected MedusaNode getNode(SubAward subAward) {
+        MedusaNode node = new MedusaNode();
+        node.setBo(subAward);
+        node.setType(Constants.SUBAWARD_MODULE);
+        return node;
+    }
+    protected MedusaNode getNode(Protocol protocol) {
+        MedusaNode node = new MedusaNode();
+        node.setBo(protocol);
+        node.setType(Constants.IRB_MODULE);
+        return node;
+    }
+    protected MedusaNode getNode(IacucProtocol protocol) {
+        MedusaNode node = new MedusaNode();
+        node.setBo(protocol);
+        node.setType(Constants.IACUC_MODULE);
+        return node;
+    }
+    
+    
+    /**
+     * 
+     * Returns a list of the Development Proposals linked to the institutional proposal.
+     * This will involve a search through all institutional proposal versions for a matching ProposalAdminDetails object
+     * as the admin details are not versioned with the institutional proposal.
+     * @param instProposal
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    protected Collection<DevelopmentProposal> getDevelopmentProposals(InstitutionalProposal instProposal) {
+        //find any dev prop linked to any version of this inst prop
+        Collection<DevelopmentProposal> devProposals = new ArrayList<DevelopmentProposal>();
+        Collection<InstitutionalProposal> proposalVersions = 
+            businessObjectService.findMatching(InstitutionalProposal.class, getFieldValues("proposalNumber", instProposal.getProposalNumber()));
+        for (InstitutionalProposal ip : proposalVersions) {
+            Collection<ProposalAdminDetails> proposalAdminDetails = 
+                businessObjectService.findMatching(ProposalAdminDetails.class, getFieldValues("instProposalId", ip.getProposalId()));
+            for (ProposalAdminDetails proposalAdminDetail : proposalAdminDetails) {
+                proposalAdminDetail.refreshReferenceObject("developmentProposal");
+                devProposals.add(proposalAdminDetail.getDevelopmentProposal());
+            }
+        }
+        return devProposals;
+    }
+    
+    @SuppressWarnings("unchecked")
+    protected Collection<Award> getAwards(SubAward subAward) {
+        
+        Collection<Award> awards = new ArrayList<Award>();
+        SubAward newestSubAaward = getSubAward(subAward.getSubAwardCode());
+
+        Collection<SubAwardFundingSource> subAwardFundingSources = newestSubAaward.getSubAwardFundingSourceList();
+        for (SubAwardFundingSource subAwardFundingSource : subAwardFundingSources){
+            awards.add(getAward(subAwardFundingSource.getAwardId()));
+        }
+        return awards;
+    }
+    
+    protected SubAward getSubAward(String subAwardCode) {
+        SubAward subAward = (SubAward) getActiveOrCurrentVersion(SubAward.class, subAwardCode);
+        return subAward;
+    }
+    
+    protected Collection<SubAward> getSubAwards(Award award) {
+        Collection<SubAward> subAwards = getSubAwardService().getLinkedSubAwards(award);
+        return subAwards;
+    }
+    
+    /**
+     * 
+     * Generates and returns a collection of all awards linked to the 
+     * institutional proposal
+     * @param ip
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    protected Collection<Award> getAwards(InstitutionalProposal ip) {
+        Collection<Award> awards = new ArrayList<Award>();
+        Collection<InstitutionalProposal> institutionalProposalVersions = businessObjectService.findMatching(InstitutionalProposal.class, getFieldValues("proposalNumber", ip.getProposalNumber()));
+        for (InstitutionalProposal curIp : institutionalProposalVersions) {
+            Collection<AwardFundingProposal> awardFundingProposals = curIp.getAwardFundingProposals();
+            for (AwardFundingProposal awardFunding : awardFundingProposals) {
+                /*
+                 * KRACOEUS-6539: Medusa needs to check that this awardFundingProposal is STILL active in the current active IP version
+                 * before displaying it. Currently, awards from cancelled IPs are also appearing in the list.
+                 */
+                if (awardFunding.isActive() && !curIp.isCancelled()) {
+                    awards.add(getAward(awardFunding.getAwardId()));
+                }
+            }
+        }
+        InstitutionalProposal activeProposal = getNewestProposalByStatus(ip.getProposalNumber(), VersionStatus.ACTIVE);
+        if (activeProposal != null && StringUtils.isNotBlank(activeProposal.getCurrentAwardNumber()) 
+                && activeProposal.getStatusCode() != INST_PROPOSAL_STATUS_FUNDED) {
+            Collection<Award> proposalCurrentAwards = 
+                businessObjectService.findMatching(Award.class, getFieldValues("awardNumber", activeProposal.getCurrentAwardNumber()));
+            for (Award curAward : proposalCurrentAwards) {
+                awards.add(getAward(curAward.getAwardId()));
+            }
+        }
+        return awards;
+    }
+  
+    /**
+     * 
+     * Gets and returns the newest active proposal version for the proposal number.
+     * @param proposalNumber
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    protected InstitutionalProposal getNewestProposalByStatus(String proposalNumber, VersionStatus status) {
+        Collection<InstitutionalProposal> versions = getBusinessObjectService().findMatching(InstitutionalProposal.class, getFieldValues("proposalNumber", proposalNumber));
+        InstitutionalProposal newestProposal = null;
+        for (InstitutionalProposal curProposal : versions) {
+            if (newestProposal == null && curProposal.isActiveVersion()) {
+                newestProposal = curProposal;
+            } else if (curProposal.isActiveVersion() && curProposal.getSequenceNumber() > newestProposal.getSequenceNumber()) {
+                newestProposal = curProposal;
+            }
+        }
+        return newestProposal;
+    }
+    
+    /**
+     * 
+     * Returns all institutional proposals linked to this award. This will involve a search through 
+     * all award versions as award funding proposals are not versioned with the award. It will also
+     * look through all institutional proposals to see if the institutional proposal lists the award id
+     * and it not funded and the currently active version.
+     * @param award
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    protected Collection<InstitutionalProposal> getProposals(Award award) {
+        Collection<InstitutionalProposal> ips = new ArrayList<InstitutionalProposal>();
+        Collection<Award> awardVersions = businessObjectService.findMatching(Award.class, getFieldValues("awardNumber", award.getAwardNumber()));
+        for (Award curAward : awardVersions) {
+            Collection<AwardFundingProposal> awardFundingProposals = curAward.getFundingProposals();
+            for (AwardFundingProposal awardFunding : awardFundingProposals) {
+                InstitutionalProposal curProposal = businessObjectService.findByPrimaryKey(InstitutionalProposal.class, getFieldValues("proposalId", awardFunding.getProposalId()));
+                boolean proposalNotCancelled = !curProposal.isCancelled();
+                if (proposalNotCancelled && awardFunding.isActive()) {
+                    ips.add(getInstitutionalProposal(awardFunding.getProposalId()));
+                }
+            }
+        }
+        
+        Collection <InstitutionalProposal> curAwardIps = businessObjectService.findMatching(InstitutionalProposal.class, getFieldValues("currentAwardNumber", award.getAwardNumber()));
+        for (InstitutionalProposal proposal : curAwardIps) {
+            if (proposal.getStatusCode() != INST_PROPOSAL_STATUS_FUNDED && proposal.isActiveVersion()) {
+                ips.add(getInstitutionalProposal(proposal.getProposalId()));
+            }
+        }
+        return ips;
+    }
+    
+    /**
+     * 
+     * Gets all institutional proposals linked to this development proposal via the ProposalAdminDetails. 
+     * @param devProposal
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    protected Collection<InstitutionalProposal> getProposals(DevelopmentProposal devProposal) {
+        Collection<ProposalAdminDetails> proposalAdminDetails = businessObjectService.findMatching(ProposalAdminDetails.class, getFieldValues("devProposalNumber", devProposal.getProposalNumber()));
+        Collection<InstitutionalProposal> instProposals = new ArrayList<InstitutionalProposal>();
+        for (ProposalAdminDetails proposalAdminDetail : proposalAdminDetails) {
+            //find the newest version of the institutional proposal that is linked
+            instProposals.add(getInstitutionalProposal(proposalAdminDetail.getInstProposalId()));
+        }
+        return instProposals;        
+    }
+    
+    protected Collection<Negotiation> getNegotiations(BusinessObject bo) {
+        return getNegotiationService().getAssociatedNegotiations(bo);
+    }
+
+    /**
+     * Gets the businessObjectService attribute. 
+     * @return Returns the businessObjectService.
+     */
+    public BusinessObjectService getBusinessObjectService() {
+        return businessObjectService;
+    }
+
+    /**
+     * Sets the businessObjectService attribute value.
+     * @param businessObjectService The businessObjectService to set.
+     */
+    public void setBusinessObjectService(BusinessObjectService businessObjectService) {
+        this.businessObjectService = businessObjectService;
+    }
+    
+    protected Map<String, Object> getFieldValues(String key, Object value) {
+        Map<String, Object> fieldValues = new HashMap<String, Object>();
+        fieldValues.put(key, value);
+        return fieldValues;
+    }
+    
+    /**
+     * Gets the awardAmountInfoService attribute. 
+     * @return Returns the awardAmountInfoService.
+     */
+    protected AwardAmountInfoService getAwardAmountInfoService() {
+        return awardAmountInfoService;
+    }
+
+    /**
+     * Sets the awardAmountInfoService attribute value.
+     * @param awardAmountInfoService The awardAmountInfoService to set.
+     */
+    public void setAwardAmountInfoService(AwardAmountInfoService awardAmountInfoService) {
+        this.awardAmountInfoService = awardAmountInfoService;
+    }
+
+    protected VersionHistoryService getVersionHistoryService() {
+        return versionHistoryService;
+    }
+
+    public void setVersionHistoryService(VersionHistoryService versionHistoryService) {
+        this.versionHistoryService = versionHistoryService;
+    }
+
+    protected NegotiationService getNegotiationService() {
+        return negotiationService;
+    }
+
+    public void setNegotiationService(NegotiationService negotiationService) {
+        this.negotiationService = negotiationService;
+    }
+
+    protected SubAwardService getSubAwardService() {
+        return subAwardService;
+    }
+
+    public void setSubAwardService(SubAwardService subAwardService) {
+        this.subAwardService = subAwardService;
+    }
+
+    protected ParameterService getParameterService() {
+        return parameterService;
+    }
+
+    public void setParameterService(ParameterService parameterService) {
+        this.parameterService = parameterService;
+    } 
+    
+}

--- a/src/main/java/org/kuali/kra/service/VersionHistoryService.java
+++ b/src/main/java/org/kuali/kra/service/VersionHistoryService.java
@@ -71,6 +71,16 @@ public interface VersionHistoryService {
      * @return
      */
     VersionHistory findPendingVersion(Class<? extends SequenceOwner> klass, String versionName);
+
+    
+    /**
+     * Find the active - if any, if not the pending version for a given SequenceOwner
+     * @param klass
+     * @param versionName
+     * @return null if no active/pending version found
+     */
+    VersionHistory findActiveOrPendingVersion(Class<? extends SequenceOwner> klass, String versionName);
+    
     
     /**
      * Find version histories without fetching the sequence owner. If you need sequence owner included in history list, use loadVersionHistory() method.
@@ -94,6 +104,18 @@ public interface VersionHistoryService {
      * @return
      */
     VersionHistory getActiveOrNewestVersion(Class<? extends SequenceOwner> klass, String versionName);
+    
+
+    /**
+     * Gets the active or if not available the most current, not cancelled version of a versioned BO. 
+     * Note: Currently only Awards and Subawards use the Version History framework
+     * @param klass - extends SequenceOwner
+     * @param versionName
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    public SequenceOwner getActiveOrCurrentVersion(Class<? extends SequenceOwner> klass, String versionName);
+    
     
 	/**
 	 * Find the VersionHistory for a given SequenceOwner type, version name and sequence number

--- a/src/main/java/org/kuali/kra/service/impl/VersionHistoryServiceImpl.java
+++ b/src/main/java/org/kuali/kra/service/impl/VersionHistoryServiceImpl.java
@@ -157,6 +157,22 @@ public class VersionHistoryServiceImpl implements VersionHistoryService {
         return pendingVersionHistory;
     }
     
+    
+    /**
+     * @see org.kuali.kra.service.VersionHistoryService#findActiveOrPendingVersion(java.lang.Class, java.lang.String)
+     */
+    public VersionHistory findActiveOrPendingVersion(Class<? extends SequenceOwner> klass, String versionName) {       
+        VersionHistory result = findActiveVersion(klass, versionName);
+        if (result == null) {
+            result = findPendingVersion(klass, versionName);
+        }
+        return result;
+    }
+    
+    
+    /**
+     * @see org.kuali.kra.service.VersionHistoryService#findPendingVersion(java.lang.Class, java.lang.String)
+     */
     public VersionHistory findPendingVersion(Class<? extends SequenceOwner> klass, String versionName) {
         VersionHistory pendingVersionHistory = null;
         
@@ -263,4 +279,32 @@ public class VersionHistoryServiceImpl implements VersionHistoryService {
         }
         return history;
     }
+    
+    
+    /**
+     *  @see org.kuali.kra.service.VersionHistoryService#getActiveOrCurrentVersion(java.lang.Class, java.lang.String)
+     */
+    public SequenceOwner getActiveOrCurrentVersion(Class<? extends SequenceOwner> clazz, String versionName) {
+       
+        VersionHistory activeVersion = findActiveVersion(clazz, versionName);
+        SequenceOwner bestVersion = null;
+        if (activeVersion != null) {
+            bestVersion = (SequenceOwner)activeVersion.getSequenceOwner();
+        } else {
+            List<VersionHistory> history = loadVersionHistory(clazz, versionName);
+            if (history != null && !history.isEmpty()) {
+                VersionHistory best = history.get(0);
+                for (VersionHistory curVersion : history) {
+                    if (curVersion.getVersionNumber() > best.getVersionNumber()) {
+                        if (curVersion.getStatus() != VersionStatus.CANCELED) {
+                            best = curVersion;
+                        }
+                    }
+                }
+                bestVersion = (SequenceOwner)best.getSequenceOwner();
+            } 
+        }
+        return bestVersion;  
+    }
+    
 }

--- a/src/main/java/org/kuali/kra/subaward/SubAwardForm.java
+++ b/src/main/java/org/kuali/kra/subaward/SubAwardForm.java
@@ -1,0 +1,504 @@
+/*.
+ * Copyright 2005-2014 The Kuali Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.opensource.org/licenses/ecl1.php
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kuali.kra.subaward;
+
+import org.apache.struts.upload.FormFile;
+import org.kuali.kra.award.home.Award;
+import org.kuali.kra.award.printing.AwardPrintNotice;
+import org.kuali.kra.bo.Rolodex;
+import org.kuali.kra.bo.SponsorFormTemplateList;
+import org.kuali.kra.bo.versioning.VersionHistory;
+import org.kuali.kra.common.notification.web.struts.form.NotificationHelper;
+import org.kuali.kra.common.permissions.web.struts.form.PermissionsForm;
+import org.kuali.kra.common.permissions.web.struts.form.PermissionsHelperBase;
+import org.kuali.kra.infrastructure.Constants;
+import org.kuali.kra.infrastructure.KraServiceLocator;
+import org.kuali.kra.infrastructure.TaskName;
+import org.kuali.kra.medusa.MedusaBean;
+import org.kuali.kra.service.TaskAuthorizationService;
+import org.kuali.kra.service.VersionHistoryService;
+import org.kuali.kra.subaward.bo.*;
+import org.kuali.kra.subaward.customdata.CustomDataHelper;
+import org.kuali.kra.subaward.document.SubAwardDocument;
+import org.kuali.kra.subaward.document.authorization.SubAwardTask;
+import org.kuali.kra.subaward.notification.SubAwardNotificationContext;
+import org.kuali.kra.subaward.service.SubAwardService;
+import org.kuali.kra.subaward.templateAttachments.SubAwardAttachmentFormBean;
+import org.kuali.kra.web.struts.form.Auditable;
+import org.kuali.kra.web.struts.form.CustomDataDocumentForm;
+import org.kuali.kra.web.struts.form.KraTransactionalDocumentFormBase;
+import org.kuali.rice.core.api.CoreApiServiceLocator;
+import org.kuali.rice.core.api.config.property.ConfigurationService;
+import org.kuali.rice.kew.api.KewApiConstants;
+import org.kuali.rice.kew.api.WorkflowDocument;
+import org.kuali.rice.kns.util.ActionFormUtilMap;
+import org.kuali.rice.kns.web.ui.ExtraButton;
+import org.kuali.rice.kns.web.ui.HeaderField;
+import org.kuali.rice.krad.util.GlobalVariables;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+/**
+ * This class represents the SubAward Form Struts class....
+ */
+public class SubAwardForm extends KraTransactionalDocumentFormBase
+implements PermissionsForm, Auditable, CustomDataDocumentForm {
+
+    private static final long serialVersionUID = -1452575757578523254L;
+
+
+    public static final String COLUMN = ":";
+    private String lookupResultsSequenceNumber;
+    private String lookupResultsBOClassName;
+    private SubAwardCloseout newSubAwardCloseout;
+    private SubAwardFundingSource newSubAwardFundingSource;
+    private SubAwardAmountInfo newSubAwardAmountInfo;
+    private SubAwardContact newSubAwardContact;
+    private SubAwardAmountReleased newSubAwardAmountReleased;
+    private CustomDataHelper customDataHelper = new CustomDataHelper(this);
+    private NotificationHelper<SubAwardNotificationContext> notificationHelper;
+    private boolean auditActivated;
+    private MedusaBean medusaBean;
+    private FormFile newFile;
+    private int defaultFollowUpDayDifference = 0;
+    private SubAwardAttachmentFormBean subAwardAttachmentFormBean;
+    private SubAwardReports newSubAwardReport;
+    private SubAwardPrintAgreement subAwardPrintAgreement;
+    private SubAwardForms subAwardForms;
+    
+   
+    
+
+
+
+    /**
+     * Gets the subAwardForms attribute. 
+     * @return Returns the subAwardForms.
+     */
+    public SubAwardForms getSubAwardForms() {
+        return subAwardForms;
+    }
+
+    /**
+     * Sets the subAwardForms attribute value.
+     * @param subAwardForms The subAwardForms to set.
+     */
+    public void setSubAwardForms(SubAwardForms subAwardForms) {
+        this.subAwardForms = subAwardForms;
+    }
+
+    /**
+     * Gets the subAwardPrintAgreement attribute. 
+     * @return Returns the subAwardPrintAgreement.
+     */
+    public SubAwardPrintAgreement getSubAwardPrintAgreement() {
+        return subAwardPrintAgreement;
+    }
+
+    /**
+     * Sets the subAwardPrintAgreement attribute value.
+     * @param subAwardPrintAgreement The subAwardPrintAgreement to set.
+     */
+    public void setSubAwardPrintAgreement(SubAwardPrintAgreement subAwardPrintAgreement) {
+        this.subAwardPrintAgreement = subAwardPrintAgreement;
+    }
+
+    /**
+     * Gets the newSubAwardReport attribute. 
+     * @return Returns the newSubAwardReport.
+     */
+    public SubAwardReports getNewSubAwardReport() {
+        return newSubAwardReport;
+    }
+
+    /**
+     * Sets the newSubAwardReport attribute value.
+     * @param newSubAwardReport The newSubAwardReport to set.
+     */
+    public void setNewSubAwardReport(SubAwardReports newSubAwardReport) {
+        this.newSubAwardReport = newSubAwardReport;
+    }
+
+    public SubAwardAttachmentFormBean getSubAwardAttachmentFormBean() {
+        return subAwardAttachmentFormBean;
+    }
+
+    public void setSubAwardAttachmentFormBean(SubAwardAttachmentFormBean subAwardAttachmentFormBean) {
+        this.subAwardAttachmentFormBean = subAwardAttachmentFormBean;
+    }
+
+    /**.
+    * This is the Getter Method for newFile
+    * @return Returns the newFile.
+    */
+	public FormFile getNewFile() {
+		return newFile;
+	}
+
+	/**.
+	 * This is the Setter Method for newFile
+	 * @param newFile The newFile to set.
+	 */
+	public void setNewFile(FormFile newFile) {
+		this.newFile = newFile;
+	}
+
+	/**.
+	 * This is the Getter Method for auditActivated
+	 * @return Returns the auditActivated.
+	 */
+	public boolean isAuditActivated() {
+		return auditActivated;
+	}
+
+	/**.
+	 * This is the Setter Method for auditActivated
+	 * @param auditActivated The auditActivated to set.
+	 */
+	public void setAuditActivated(boolean auditActivated) {
+		this.auditActivated = auditActivated;
+	}
+
+	/**.
+	 * This is the Getter Method for newSubAwardFundingSource
+	 * @return Returns the newSubAwardFundingSource.
+	 */
+	public SubAwardFundingSource getNewSubAwardFundingSource() {
+		return newSubAwardFundingSource;
+	}
+
+	/**.
+	 * This is the Setter Method for newSubAwardFundingSource
+	 * @param newSubAwardFundingSource The newSubAwardFundingSource to set.
+	 */
+	public void setNewSubAwardFundingSource(
+			SubAwardFundingSource newSubAwardFundingSource) {
+		this.newSubAwardFundingSource = newSubAwardFundingSource;
+	}
+
+	 /**.
+	 * This is the Getter Method for newSubAwardAmountInfo
+	 * @return Returns the newSubAwardAmountInfo.
+	 */
+	public SubAwardAmountInfo getNewSubAwardAmountInfo() {
+		return newSubAwardAmountInfo;
+	}
+
+	/**.
+	 * This is the Setter Method for newSubAwardAmountInfo
+	 * @param newSubAwardAmountInfo The newSubAwardAmountInfo to set.
+	 */
+	public void setNewSubAwardAmountInfo(SubAwardAmountInfo newSubAwardAmountInfo) {
+		this.newSubAwardAmountInfo = newSubAwardAmountInfo;
+	}
+
+	/**.
+	 * This is the Getter Method for newSubAwardAmountReleased
+	 * @return Returns the newSubAwardAmountReleased.
+	 */
+	public SubAwardAmountReleased getNewSubAwardAmountReleased() {
+		return newSubAwardAmountReleased;
+	}
+
+	/**.
+	 * This is the Setter Method for newSubAwardAmountReleased
+	 * @param newSubAwardAmountReleased
+	 *  The newSubAwardAmountReleased to set.
+	 */
+	public void setNewSubAwardAmountReleased(
+			SubAwardAmountReleased newSubAwardAmountReleased) {
+		this.newSubAwardAmountReleased = newSubAwardAmountReleased;
+	}
+
+	/**.
+	 * This is the Getter Method for customDataHelper
+	 * @return Returns the customDataHelper.
+	 */
+	public CustomDataHelper getCustomDataHelper() {
+		return customDataHelper;
+	}
+
+	/**.
+	 * This is the Setter Method for customDataHelper
+	 * @param customDataHelper The customDataHelper to set.
+	 */
+	public void setCustomDataHelper(CustomDataHelper customDataHelper) {
+		this.customDataHelper = customDataHelper;
+	}
+
+	
+	public NotificationHelper<SubAwardNotificationContext> getNotificationHelper() {
+        return notificationHelper;
+    }
+
+    public void setNotificationHelper(NotificationHelper<SubAwardNotificationContext> notificationHelper) {
+        this.notificationHelper = notificationHelper;
+    }
+
+    public void setSubAward(SubAward subAward) {
+        this.subAward = subAward;
+    }
+
+    /**
+	 * Constructs a SubAwardForm.java.
+	 */
+	public SubAwardForm() {
+        super();
+        initialize();
+    }
+
+   /**.
+   * this method for subAward
+   */
+   private SubAward subAward;
+
+
+    /**.
+     *
+     * This method initialize all form variables
+     */
+    public void initialize() {
+        medusaBean = new MedusaBean();
+        newSubAwardFundingSource = new SubAwardFundingSource(new Award());
+        newSubAwardContact = new SubAwardContact(new Rolodex());
+        newSubAwardCloseout = new SubAwardCloseout();
+        newSubAwardAmountReleased = new SubAwardAmountReleased();
+        newSubAwardAmountInfo = new SubAwardAmountInfo();
+        notificationHelper = new NotificationHelper<SubAwardNotificationContext>();
+        subAwardAttachmentFormBean = new SubAwardAttachmentFormBean(this);
+        subAwardPrintAgreement = new SubAwardPrintAgreement();
+    }
+
+    /**
+     *
+     * This method returns the SubAwardDocument object.
+     * @return SubAwardDocument
+     */
+    public SubAwardDocument getSubAwardDocument() {
+        return (SubAwardDocument) super.getDocument();
+    }
+    /**.
+     * This method returns a string representation of the document type
+     * @return SubAwardDocument
+     */
+    public String getDocumentTypeName() {
+        return "SubAwardDocument";
+    }
+
+    @Override
+    public void populateHeaderFields(WorkflowDocument workflowDocument) {
+         super.populateHeaderFields(workflowDocument);
+
+        SubAwardDocument subAwardDocument = getSubAwardDocument();
+        getDocInfo().clear();
+        String docIdAndStatus = COLUMN;
+        if (workflowDocument != null) {
+            docIdAndStatus = getDocument().getDocumentNumber()
+            + COLUMN + workflowDocument.getStatus().getLabel();
+        }
+        String lastUpdated ="";
+        if (subAwardDocument.getSubAward().getUpdateTimestamp() != null
+        && subAwardDocument.getSubAward().getUpdateUser() != null) {
+
+            lastUpdated = subAwardDocument.getSubAward().getUpdateTimestamp().
+            toString() + " By " +  subAwardDocument.getSubAward().
+            getUpdateUser();
+        }
+
+        getDocInfo().add(new HeaderField(
+        "DataDictionary.SubAward.attributes.requisitionerId",
+        subAwardDocument.getSubAward().getRequisitionerUserName()));
+        getDocInfo().add(new HeaderField(
+        "DataDictionary.SubAward.attributes.docIdStatus", docIdAndStatus));
+        if (subAwardDocument.getSubAward().getUnit() != null) {
+            getDocInfo().add(new HeaderField(""
+          +  "DataDictionary.SubAward.attributes.requisitionerUnit",
+          subAwardDocument.getSubAward().getUnit().getUnitName()));
+        } else {
+            getDocInfo().add(new HeaderField(
+            "DataDictionary.SubAward.attributes.requisitionerUnit", ""));
+
+        }
+        getDocInfo().add(new HeaderField(""
+        + "DataDictionary.SubAward.attributes.subAwardId",
+        subAwardDocument.getSubAward().getSubAwardCode()));
+        getDocInfo().add(new HeaderField(""
+      + "DataDictionary.SubAward.attributes.organizationId",
+       subAwardDocument.getSubAward().getOrganizationName()));
+        getDocInfo().add(new HeaderField(""
+       + "DataDictionary.SubAward.attributes.lastUpdate", lastUpdated));
+
+
+    }
+
+    /**
+     * 
+     * This method initializes either the document
+     *  or the form based on the command value.
+     */
+    public void initializeFormOrDocumentBasedOnCommand(){
+        if (KewApiConstants.INITIATE_COMMAND.equals(getCommand())) {
+            getSubAwardDocument().initialize();
+        } else {
+            initialize();
+        }
+    }
+
+
+    @Override
+    protected String getLockRegion() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    protected void setSaveDocumentControl(Map editMode) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    protected String getDefaultDocumentTypeName() {
+        return "SubAwardDocument";
+    }
+
+    public SubAward getSubAward() {
+        return getSubAwardDocument().getSubAward();
+    }
+
+    public void setLookupResultsSequenceNumber(String lookupResultsSequenceNumber) {
+        this.lookupResultsSequenceNumber = lookupResultsSequenceNumber;
+    }
+
+    public String getLookupResultsSequenceNumber() {
+        return lookupResultsSequenceNumber;
+    }
+
+    public void setLookupResultsBOClassName(String lookupResultsBOClassName) {
+        this.lookupResultsBOClassName = lookupResultsBOClassName;
+    }
+
+    public String getLookupResultsBOClassName() {
+        return lookupResultsBOClassName;
+    }
+
+    public PermissionsHelperBase getPermissionsHelper() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    public void setNewSubAwardCloseout(SubAwardCloseout newSubAwardCloseout) {
+        this.newSubAwardCloseout = newSubAwardCloseout;
+    }
+
+    public SubAwardCloseout getNewSubAwardCloseout() {
+        return newSubAwardCloseout;
+    }
+
+   
+
+    public void setNewSubAwardContact(SubAwardContact newSubAwardContact) {
+        this.newSubAwardContact = newSubAwardContact;
+    }
+
+    public SubAwardContact getNewSubAwardContact() {
+        return newSubAwardContact;
+    }
+
+    /**
+     * Gets the medusaBean attribute. 
+     * @return Returns the medusaBean.
+     */
+    public MedusaBean getMedusaBean() {
+        return medusaBean;
+    }
+
+    /**
+     * Sets the medusaBean attribute value.
+     * @param medusaBean The medusaBean to set.
+     */
+    public void setMedusaBean(MedusaBean medusaBean) {
+        this.medusaBean = medusaBean;
+    }
+
+    /**.
+     * 
+     * This returns the value of subawardservice.
+     * getFollowupDateDefaultLengthInDays()
+     * to be used on subAwardCloseout.tag
+     * @return
+     */
+    public int getDefaultFollowUpDayDifference() {
+        if (defaultFollowUpDayDifference == 0) {
+            defaultFollowUpDayDifference = KraServiceLocator.
+            getService(SubAwardService.class).getFollowupDateDefaultLengthInDays();
+        }
+        return defaultFollowUpDayDifference;
+    }
+        
+    public List<ExtraButton> getExtraFinancialButtons() {
+        // clear out the extra buttons array
+        extraButtons.clear();
+        extraButtons = super.getExtraButtons();
+        SubAwardDocument doc = this.getSubAwardDocument();
+        String externalImageURL = Constants.KRA_EXTERNALIZABLE_IMAGES_URI_KEY;
+
+        TaskAuthorizationService tas = KraServiceLocator.getService(TaskAuthorizationService.class);
+        ConfigurationService configurationService = CoreApiServiceLocator.getKualiConfigurationService();
+        SubAwardTask task = new SubAwardTask(TaskName.ADD_INVOICE_SUBAWARD, doc);
+        if(tas.isAuthorized(GlobalVariables.getUserSession().getPrincipalId(), task)) {       
+            String submitToGrantsGovImage = configurationService.getPropertyValueAsString(externalImageURL) + "buttonsmall_addinvoice.gif";
+            addExtraButton("methodToCall.addAmountReleased", submitToGrantsGovImage, "Add Invoice");
+        }
+        return extraButtons;
+    }
+    
+    /*
+     * returns flag indicating if edit button should be displayed at bottom of form 
+     * 
+     */
+    public boolean getDisplayEditButton() {
+        boolean displayEditButton = !isViewOnly();
+        VersionHistory activeVersion = getVersionHistoryService().findActiveVersion(SubAward.class, getSubAwardDocument().getSubAward().getSubAwardCode());
+        if (activeVersion != null) {
+            displayEditButton &= activeVersion.getSequenceOwnerSequenceNumber().equals(getSubAwardDocument().getSubAward().getSequenceNumber());
+        }
+        
+        return displayEditButton;
+    }
+    /**
+     * This method disables the caching of drop down lists.  
+     * Subaward Print has a drop down list whose value depends on another drop down list.  With caching enabled the
+     * drop down list will always be empty.  Disabling caching will reload the drop down list whenever the page is posted.
+     * 
+     * @see org.kuali.rice.kns.web.struts.form.KualiMaintenanceForm#populate(javax.servlet.http.HttpServletRequest)
+     */
+    @Override
+    public void populate(HttpServletRequest request) {
+        super.populate(request);
+        if (getActionFormUtilMap() != null && getActionFormUtilMap() instanceof ActionFormUtilMap) {
+            ((ActionFormUtilMap) getActionFormUtilMap()).setCacheValueFinderResults(false);
+        } 
+    }
+    
+    protected VersionHistoryService getVersionHistoryService() {
+        return KraServiceLocator.getService(VersionHistoryService.class);
+    }
+
+}

--- a/src/main/java/org/kuali/kra/subaward/SubAwardForm.java
+++ b/src/main/java/org/kuali/kra/subaward/SubAwardForm.java
@@ -17,9 +17,7 @@ package org.kuali.kra.subaward;
 
 import org.apache.struts.upload.FormFile;
 import org.kuali.kra.award.home.Award;
-import org.kuali.kra.award.printing.AwardPrintNotice;
 import org.kuali.kra.bo.Rolodex;
-import org.kuali.kra.bo.SponsorFormTemplateList;
 import org.kuali.kra.bo.versioning.VersionHistory;
 import org.kuali.kra.common.notification.web.struts.form.NotificationHelper;
 import org.kuali.kra.common.permissions.web.struts.form.PermissionsForm;
@@ -37,6 +35,7 @@ import org.kuali.kra.subaward.document.authorization.SubAwardTask;
 import org.kuali.kra.subaward.notification.SubAwardNotificationContext;
 import org.kuali.kra.subaward.service.SubAwardService;
 import org.kuali.kra.subaward.templateAttachments.SubAwardAttachmentFormBean;
+import org.kuali.kra.subaward.web.SubAwardFundingSourceBean;
 import org.kuali.kra.web.struts.form.Auditable;
 import org.kuali.kra.web.struts.form.CustomDataDocumentForm;
 import org.kuali.kra.web.struts.form.KraTransactionalDocumentFormBase;
@@ -68,6 +67,7 @@ implements PermissionsForm, Auditable, CustomDataDocumentForm {
     private String lookupResultsBOClassName;
     private SubAwardCloseout newSubAwardCloseout;
     private SubAwardFundingSource newSubAwardFundingSource;
+    private List<SubAwardFundingSourceBean> filteredSubAwardFundingSources;
     private SubAwardAmountInfo newSubAwardAmountInfo;
     private SubAwardContact newSubAwardContact;
     private SubAwardAmountReleased newSubAwardAmountReleased;
@@ -82,9 +82,7 @@ implements PermissionsForm, Auditable, CustomDataDocumentForm {
     private SubAwardPrintAgreement subAwardPrintAgreement;
     private SubAwardForms subAwardForms;
     
-   
-    
-
+      
 
 
     /**
@@ -283,6 +281,7 @@ implements PermissionsForm, Auditable, CustomDataDocumentForm {
         notificationHelper = new NotificationHelper<SubAwardNotificationContext>();
         subAwardAttachmentFormBean = new SubAwardAttachmentFormBean(this);
         subAwardPrintAgreement = new SubAwardPrintAgreement();
+        filteredSubAwardFundingSources = new ArrayList<SubAwardFundingSourceBean>();
     }
 
     /**
@@ -495,10 +494,21 @@ implements PermissionsForm, Auditable, CustomDataDocumentForm {
         if (getActionFormUtilMap() != null && getActionFormUtilMap() instanceof ActionFormUtilMap) {
             ((ActionFormUtilMap) getActionFormUtilMap()).setCacheValueFinderResults(false);
         } 
+        
     }
     
     protected VersionHistoryService getVersionHistoryService() {
         return KraServiceLocator.getService(VersionHistoryService.class);
     }
+    
+    public List<SubAwardFundingSourceBean> getFilteredSubAwardFundingSources() {
+        return filteredSubAwardFundingSources;
+    }
+
+    public void setFilteredSubAwardFundingSources(List<SubAwardFundingSourceBean> filteredSubAwardFundingSources) {
+        this.filteredSubAwardFundingSources = filteredSubAwardFundingSources;
+    }
+
+   
 
 }

--- a/src/main/java/org/kuali/kra/subaward/bo/SubAward.java
+++ b/src/main/java/org/kuali/kra/subaward/bo/SubAward.java
@@ -1,0 +1,1599 @@
+/*
+ * Copyright 2005-2014 The Kuali Foundation
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.opensource.org/licenses/ecl1.php
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kuali.kra.subaward.bo;
+
+import org.kuali.kra.SequenceOwner;
+import org.kuali.kra.award.home.AwardType;
+import org.kuali.kra.bo.*;
+import org.kuali.kra.bo.versioning.VersionStatus;
+import org.kuali.kra.common.permissions.Permissionable;
+import org.kuali.kra.infrastructure.Constants;
+import org.kuali.kra.infrastructure.KraServiceLocator;
+import org.kuali.kra.negotiations.bo.Negotiable;
+import org.kuali.kra.negotiations.bo.NegotiationPersonDTO;
+import org.kuali.kra.proposaldevelopment.bo.ProposalType;
+import org.kuali.kra.service.KcPersonService;
+import org.kuali.kra.service.OrganizationService;
+import org.kuali.kra.service.UnitService;
+import org.kuali.kra.subaward.customdata.SubAwardCustomData;
+import org.kuali.kra.subaward.document.SubAwardDocument;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.service.BusinessObjectService;
+import org.springframework.util.AutoPopulatingList;
+
+import java.sql.Date;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 
+ * This class is using for SubAward...
+ */
+public class SubAward extends KraPersistableBusinessObjectBase
+implements Permissionable, SequenceOwner<SubAward>, Negotiable {
+
+    private static final long serialVersionUID = 1L;
+    private static final String ROLODEX_ID_FIELD_NAME = "rolodexId";
+    public static final String NOTIFICATION_TYPE_SUBMIT = "501";
+ 
+    private Long subAwardId;
+    private String subAwardCode;
+
+    private Integer sequenceNumber;
+
+    private String organizationId;
+
+    private Date startDate;
+
+    private Date endDate;
+
+    private Integer subAwardTypeCode;
+
+    private String purchaseOrderNum;
+
+    private String title;
+
+    private Integer statusCode;
+    private String statusDescription;
+    private String accountNumber;
+
+    private String vendorNumber;
+
+    private String requisitionerId;
+
+    private String requisitionerUnit;
+
+    private String archiveLocation;
+
+    private Date closeoutDate;
+
+    private String closeoutIndicator;
+
+    private String fundingSourceIndicator;
+
+    private String comments;
+
+    private Integer siteInvestigator;
+
+    private SubAwardDocument subAwardDocument;
+
+    private SubAwardFundingSource subAwardFundingSource;
+
+    private SubAwardContact subAwardContact;
+
+    private SubAwardCloseout subAwardCloseout;
+    
+    private SubAwardReports subAwardReports;
+
+    private SubAwardAmountInfo subAwardAmountInfo;
+
+    private String organizationName;
+
+    private String requisitionerName;
+    private String requisitionerUnitName;
+    private String requisitionerUserName;
+    private String siteInvestigatorName;
+    private String siteInvestigatorId;
+    private Organization organization;
+    private Unit unit;
+    private Rolodex rolodex;
+    private transient String rolodexFirstName;
+    private SubAwardStatus subAwardStatus;
+    private AwardType subAwardType;
+    private KcPerson kcPerson;
+    private String subAwardSequenceStatus;
+    private static boolean newVersion;
+    private KualiDecimal totalObligatedAmount ;
+    private KualiDecimal totalAnticipatedAmount;
+    private KualiDecimal totalAmountReleased;
+    private KualiDecimal totalAvailableAmount;
+    private transient String docIdStatus;
+    private transient String lastUpdate;
+    private String awardNumber;
+    private transient boolean editSubAward = false;
+    private transient boolean defaultOpen = true;
+    
+    private Integer costType;
+    
+    private Date executionDate;
+    
+    private String requisitionId;
+    
+    private SubAwardCostType subAwardCostType;
+
+    private Date modificationEffectiveDate;
+    private String modificationId;
+    private Date performanceStartDate;
+    private Date performanceEnddate;
+    private List<SubAwardAttachments> subAwardAttachments;
+    private List<SubAwardReports> subAwardReportList;
+    private List<SubAwardTemplateInfo> subAwardTemplateInfo;
+    private List<SubAwardPrintAgreement> subAwardPrintAgreement;
+    private List<SubAwardForms> subAwardForms;
+    
+   
+    
+    /**
+     * Gets the subAwardForms attribute. 
+     * @return Returns the subAwardForms.
+     */
+    public List<SubAwardForms> getSubAwardForms() {
+        return subAwardForms;
+    }
+
+    /**
+     * Sets the subAwardForms attribute value.
+     * @param subAwardForms The subAwardForms to set.
+     */
+    public void setSubAwardForms(List<SubAwardForms> subAwardForms) {
+        this.subAwardForms = subAwardForms;
+    }
+    
+    public void addForms(SubAwardForms subAwardForms) {
+        this.getSubAwardForms().add(subAwardForms);
+       
+    }
+
+    /**
+     * Gets the subAwardPrintAgreement attribute. 
+     * @return Returns the subAwardPrintAgreement.
+     */
+    public List<SubAwardPrintAgreement> getSubAwardPrintAgreement() {
+        if (this.subAwardPrintAgreement == null) {
+            this.subAwardPrintAgreement = new ArrayList<SubAwardPrintAgreement>();
+        }
+        return subAwardPrintAgreement;
+    }
+
+    /**
+     * Sets the subAwardPrintAgreement attribute value.
+     * @param subAwardPrintAgreement The subAwardPrintAgreement to set.
+     */
+    public void setSubAwardPrintAgreement(List<SubAwardPrintAgreement> subAwardPrintAgreement) {
+        this.subAwardPrintAgreement = subAwardPrintAgreement;
+    }
+
+    /**
+         * Gets the subAwardTemplateInfo attribute. 
+         * @return Returns the subAwardTemplateInfo.
+         */
+        public List<SubAwardTemplateInfo> getSubAwardTemplateInfo() {
+            if (this.subAwardTemplateInfo == null) {
+                this.subAwardTemplateInfo = new ArrayList<SubAwardTemplateInfo>();
+            }
+            return subAwardTemplateInfo;
+        }
+
+        /**
+         * Sets the subAwardTemplateInfo attribute value.
+         * @param subAwardTemplateInfo The subAwardTemplateInfo to set.
+         */
+        public void setSubAwardTemplateInfo(List<SubAwardTemplateInfo> subAwardTemplateInfo) {
+            this.subAwardTemplateInfo = subAwardTemplateInfo;
+        }
+    
+    
+    /**
+     * Gets the subAwardReports attribute. 
+     * @return Returns the subAwardReports.
+     */
+    public SubAwardReports getSubAwardReports() {
+        return subAwardReports;
+    }
+
+    /**
+     * Sets the subAwardReports attribute value.
+     * @param subAwardReports The subAwardReports to set.
+     */
+    public void setSubAwardReports(SubAwardReports subAwardReports) {
+        this.subAwardReports = subAwardReports;
+    }
+    
+    /**
+     * Gets the subAwardReportList attribute. 
+     * @return Returns the subAwardReportList.
+     */
+    public List<SubAwardReports> getSubAwardReportList() {
+        if (this.subAwardReportList == null) {
+            this.subAwardReportList = new ArrayList<SubAwardReports>();
+        }
+        return this.subAwardReportList;
+    }
+
+    public List<SubAwardAttachments> getSubAwardAttachments() { 
+        if (this.subAwardAttachments == null) {
+            this.subAwardAttachments = new ArrayList<SubAwardAttachments>();
+        }
+
+        return this.subAwardAttachments;
+    }
+
+    public void setAttachments(List<SubAwardAttachments> attachments) {
+            this.subAwardAttachments = attachments;
+       }
+    
+    public void setReports(List<SubAwardReports> reports) {
+        this.subAwardReportList = reports;
+   }
+    /**
+     * Gets an attachment.
+     * @param index the index
+     * @return an attachment personnel
+     */
+    public SubAwardReports getSubAwardReportList(int index) {
+        return this.subAwardReportList.get(index);
+    }
+    
+    public SubAwardAttachments getSubAwardAttachment(int index) {
+        return this.subAwardAttachments.get(index);
+    }
+    /**
+     * add an attachment.
+     * @param attachment the attachment
+     * @throws IllegalArgumentException if attachment is null
+     */
+    public void addAttachment(SubAwardAttachments attachment) {
+        this.getSubAwardAttachments().add(attachment);
+        attachment.setSubAward(this);
+    }
+    /**
+     * add an attachment.
+     * @param report 
+     * @throws IllegalArgumentException if attachment is null
+     */
+    public void addReport(SubAwardReports report) {
+        this.getSubAwardReportList().add(report);
+        report.setSubAward(this);
+    }
+    /**.
+     * This is the Getter Method for rolodex
+     * @return Returns the rolodex.
+     */
+
+
+    /**.
+	 * This is the Getter Method for rolodex
+	 * @return Returns the rolodex.
+	 */
+	public Rolodex getRolodex() {
+		return rolodex;
+	}
+
+	/**.
+	 * This is the Setter Method for rolodex
+	 * @param rolodex The rolodex to set.
+	 */
+	public void setRolodex(Rolodex rolodex) {
+		this.rolodex = rolodex;
+	}
+
+	/**.
+	 * This is the Getter Method for kcPerson
+	 * @return Returns the kcPerson.
+	 */
+	public KcPerson getKcPerson() {
+		return kcPerson;
+	}
+
+	/**.
+	 * This is the Setter Method for kcPerson
+	 * @param kcPerson The kcPerson to set.
+	 */
+	public void setKcPerson(KcPerson kcPerson) {
+		this.kcPerson = kcPerson;
+	}
+
+	/**.
+	 * This is the Getter Method for subAwardSequenceStatus
+	 * @return Returns the subAwardSequenceStatus.
+	 */
+	public String getSubAwardSequenceStatus() {
+		return subAwardSequenceStatus;
+	}
+
+	/**.
+	 * This is the Setter Method for subAwardSequenceStatus
+	 * @param subAwardSequenceStatus The subAwardSequenceStatus to set.
+	 */
+	public void setSubAwardSequenceStatus(String subAwardSequenceStatus) {
+		this.subAwardSequenceStatus = subAwardSequenceStatus;
+	}
+
+	public String getRolodexFirstName() {
+        if (getRolodex() == null) {
+            return this.rolodexFirstName;
+        } else {
+            return getRolodex().getFirstName();
+        }
+    }
+
+    public void setRolodexFirstName(String rolodexFirstName) {
+        this.rolodexFirstName = rolodexFirstName;
+    }
+
+    /**.
+	 * This is the Getter Method for organization
+	 * @return Returns the organization.
+	 */
+	public Organization getOrganization() {
+		return organization;
+	}
+
+	/**.
+	 * This is the Setter Method for organization
+	 * @param organization The organization to set.
+	 */
+	public void setOrganization(Organization organization) {
+		this.organization = organization;
+	}
+
+	/**.
+	 * This is the Getter Method for unit
+	 * @return Returns the unit.
+	 */
+	public Unit getUnit() {
+		return unit;
+	}
+
+	/**.
+	 * This is the Setter Method for unit
+	 * @param unit The unit to set.
+	 */
+	public void setUnit(Unit unit) {
+		this.unit = unit;
+	}
+	/**.
+	 * This is the Getter Method for OrganizationName
+	 * @return Returns organizationName.
+	 */
+	public String getOrganizationName() {
+        Organization organization = getOrganization();
+        if (organization != null) {
+            return organization.getOrganizationName();
+        } else {
+            return organizationName;
+        }
+    }
+	/**.
+	 * This is the Setter Method for Organizationname
+	 * @param organizationName The organizationName to set.
+	 */
+    public void setOrganizationName(String organizationName) {
+        this.organizationName = organizationName;
+    }
+
+
+
+    /**.
+	 * This is the Getter Method for requisitionerName
+	 * @return Returns the requisitionerName.
+	 */
+	public String getRequisitionerName() {
+	    //calling getRequisitionerUserName() as that function sets the requestionsitioner name
+	    getRequisitionerUserName();
+		return requisitionerName;
+	}
+
+	/**.
+	 * This is the Setter Method for requisitionerName
+	 * @param requisitionerName The requisitionerName to set.
+	 */
+	public void setRequisitionerName(String requisitionerName) {
+		this.requisitionerName = requisitionerName;
+	}
+
+	/**.
+	 * This is the Getter Method for requisitionerUnitName
+	 * @return Returns the requisitionerUnitName.
+	 */
+	public String getRequisitionerUnitName() {
+		return requisitionerUnitName;
+	}
+
+	/**.
+	 * This is the Setter Method for requisitionerUnitName
+	 * @param requisitionerUnitName The requisitionerUnitName to set.
+	 */
+	public void setRequisitionerUnitName(String requisitionerUnitName) {
+		this.requisitionerUnitName = requisitionerUnitName;
+	}
+	/**.
+	 * This is the Getter Method for requisitionerUserName
+	 * @return Returns the requisitionerUserName.
+	 */
+	public String getRequisitionerUserName() {
+        if (requisitionerId != null) {
+            KcPerson requisitioner = getRequisitioner();
+            if (requisitioner != null) {
+                requisitionerName = requisitioner.getFullName();
+                requisitionerUserName = requisitioner.getUserName();
+            }
+        } else {
+            this.requisitionerName = null;
+        }
+        return this.requisitionerUserName;
+    }
+	/**.
+	 * This is the Setter Method for requisitionerUserName
+	 * @param requisitionerUserName The requisitionerUserName to set.
+	 */
+    public void setRequisitionerUserName(String requisitionerUserName) {
+        if (requisitionerUserName != null) {
+            KcPerson requisitioner = KraServiceLocator.
+            getService(KcPersonService.class).getKcPersonByUserName(
+            		requisitionerUserName);
+            if (requisitioner != null) {
+                requisitionerId = requisitioner.getPersonId();
+            }
+        } else {
+            this.requisitionerName = null;
+        }
+        this.requisitionerUserName = requisitionerUserName;
+    }
+    
+    public KcPerson getRequisitioner() {
+        if (requisitionerId != null) {
+            return KraServiceLocator.getService(
+                    KcPersonService.class).getKcPersonByPersonId(requisitionerId);
+        } else {
+            return null;
+        }
+    }
+
+  
+
+    /**.
+	 * This is the Getter Method for siteInvestigatorName
+	 * @return Returns the siteInvestigatorName.
+	 */
+	public String getSiteInvestigatorName() {
+		return siteInvestigatorName;
+	}
+
+	/**.
+	 * This is the Setter Method for siteInvestigatorName
+	 * @param siteInvestigatorName The siteInvestigatorName to set.
+	 */
+	public void setSiteInvestigatorName(String siteInvestigatorName) {
+		this.siteInvestigatorName = siteInvestigatorName;
+	}
+
+
+
+	private List<SubAwardFundingSource> subAwardFundingSourceList;
+
+    private List<SubAwardAmountInfo> subAwardAmountInfoList;
+
+    private List<SubAwardContact> subAwardContactsList;
+
+    private List<SubAwardCloseout> subAwardCloseoutList;
+
+    private List<SubAwardCustomData> subAwardCustomDataList;
+
+    /**.
+	 * This creates subAwardConstructor
+	 */
+    public SubAward() {
+        super();
+        initializeCollections();
+        initialize();
+
+    }
+
+    protected void initialize() {
+        setSequenceNumber(1);
+        subAwardSequenceStatus = VersionStatus.PENDING.name();
+        setNewVersion(false);
+    }
+
+
+    /**.
+	 * This is the Getter Method for subAwardId
+	 * @return Returns the subAwardId.
+	 */
+	public Long getSubAwardId() {
+		return subAwardId;
+	}
+
+	/**.
+	 * This is the Setter Method for subAwardId
+	 * @param subAwardId The subAwardId to set.
+	 */
+	public void setSubAwardId(Long subAwardId) {
+		this.subAwardId = subAwardId;
+	}
+
+	/**.
+	 * This is the Getter Method for subAwardCode
+	 * @return Returns the subAwardCode.
+	 */
+	public String getSubAwardCode() {
+		return subAwardCode;
+	}
+
+	/**.
+	 * This is the Setter Method for subAwardCode
+	 * @param subAwardCode The subAwardCode to set.
+	 */
+	public void setSubAwardCode(String subAwardCode) {
+		this.subAwardCode = subAwardCode;
+	}
+
+	/**.
+	 * This is the Getter Method for sequenceNumber
+	 * @return Returns the sequenceNumber.
+	 */
+	public Integer getSequenceNumber() {
+		return sequenceNumber;
+	}
+
+	/**.
+	 * This is the Setter Method for sequenceNumber
+	 * @param sequenceNumber The sequenceNumber to set.
+	 */
+	public void setSequenceNumber(Integer sequenceNumber) {
+		this.sequenceNumber = sequenceNumber;
+	}
+	/**.
+	 * This is the Getter Method for OrganizationId
+	 * @return Returns the OrganizationId.
+	 */
+	public String getOrganizationId() {
+        OrganizationService organizationService = KraServiceLocator.
+       getService(OrganizationService.class);
+        this.organization = organizationService.getOrganization(organizationId);
+        return organizationId;
+    }
+	/**.
+	 * This is the Setter Method for organizationId
+	 * @param organizationId The organizationId to set.
+	 */
+    public void setOrganizationId(String organizationId) {
+        this.organizationId = organizationId;
+    }
+
+   
+    /**.
+	 * This is the Getter Method for startDate
+	 * @return Returns the startDate.
+	 */
+	public Date getStartDate() {
+		return startDate;
+	}
+
+	/**.
+	 * This is the Setter Method for startDate
+	 * @param startDate The startDate to set.
+	 */
+	public void setStartDate(Date startDate) {
+		this.startDate = startDate;
+	}
+
+	/**.
+	 * This is the Getter Method for endDate
+	 * @return Returns the endDate.
+	 */
+	public Date getEndDate() {
+		return endDate;
+	}
+
+	/**.
+	 * This is the Setter Method for endDate
+	 * @param endDate The endDate to set.
+	 */
+	public void setEndDate(Date endDate) {
+		this.endDate = endDate;
+	}
+
+	/**.
+	 * This is the Getter Method for subAwardTypeCode
+	 * @return Returns the subAwardTypeCode.
+	 */
+	public Integer getSubAwardTypeCode() {
+		return subAwardTypeCode;
+	}
+
+	/**.
+	 * This is the Setter Method for subAwardTypeCode
+	 * @param subAwardTypeCode The subAwardTypeCode to set.
+	 */
+	public void setSubAwardTypeCode(Integer subAwardTypeCode) {
+		this.subAwardTypeCode = subAwardTypeCode;
+	}
+
+	
+
+    /**.
+	 * This is the Getter Method for purchaseOrderNum
+	 * @return Returns the purchaseOrderNum.
+	 */
+	public String getPurchaseOrderNum() {
+		return purchaseOrderNum;
+	}
+
+	/**.
+	 * This is the Setter Method for purchaseOrderNum
+	 * @param purchaseOrderNum The purchaseOrderNum to set.
+	 */
+	public void setPurchaseOrderNum(String purchaseOrderNum) {
+		this.purchaseOrderNum = purchaseOrderNum;
+	}
+
+	/**.
+	 * This is the Getter Method for title
+	 * @return Returns the title.
+	 */
+	public String getTitle() {
+		return title;
+	}
+
+	/**.
+	 * This is the Setter Method for title
+	 * @param title The title to set.
+	 */
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	/**.
+	 * This is the Getter Method for statusCode
+	 * @return Returns the statusCode.
+	 */
+	public Integer getStatusCode() {
+		return statusCode;
+	}
+
+	/**.
+	 * This is the Setter Method for statusCode
+	 * @param statusCode The statusCode to set.
+	 */
+	public void setStatusCode(Integer statusCode) {
+		this.statusCode = statusCode;
+	}
+
+	/**.
+	 * This is the Getter Method for accountNumber
+	 * @return Returns the accountNumber.
+	 */
+	public String getAccountNumber() {
+		return accountNumber;
+	}
+
+	/**.
+	 * This is the Setter Method for accountNumber
+	 * @param accountNumber The accountNumber to set.
+	 */
+	public void setAccountNumber(String accountNumber) {
+		this.accountNumber = accountNumber;
+	}
+
+	/**.
+	 * This is the Getter Method for vendorNumber
+	 * @return Returns the vendorNumber.
+	 */
+	public String getVendorNumber() {
+		return vendorNumber;
+	}
+
+	/**.
+	 * This is the Setter Method for vendorNumber
+	 * @param vendorNumber The vendorNumber to set.
+	 */
+	public void setVendorNumber(String vendorNumber) {
+		this.vendorNumber = vendorNumber;
+	}
+
+	/**.
+	 * This is the Getter Method for requisitionerId
+	 * @return Returns the requisitionerId.
+	 */
+	public String getRequisitionerId() {
+		return requisitionerId;
+	}
+
+	/**.
+	 * This is the Setter Method for requisitionerId
+	 * @param requisitionerId The requisitionerId to set.
+	 */
+	public void setRequisitionerId(String requisitionerId) {
+		this.requisitionerId = requisitionerId;
+	}
+	/**.
+	 * This is the Getter Method for RequisitionerUnit
+	 * @return Returns the requisitionerUnit.
+	 */
+	public String getRequisitionerUnit() {
+        if (this.requisitionerUnit != null) {
+            UnitService unitService = KraServiceLocator.
+            getService(UnitService.class);
+            this.unit = unitService.getUnit(requisitionerUnit);
+        }
+        return requisitionerUnit;
+    }
+	/**.
+	 * This is the Setter Method for requisitionerUnit
+	 * @param requisitionerUnit The requisitionerUnit to set.
+	 */
+
+    public void setRequisitionerUnit(String requisitionerUnit) {
+        this.requisitionerUnit = requisitionerUnit;
+    }
+
+    /**.
+	 * This is the Getter Method for archiveLocation
+	 * @return Returns the archiveLocation.
+	 */
+	public String getArchiveLocation() {
+		return archiveLocation;
+	}
+
+	/**.
+	 * This is the Setter Method for archiveLocation
+	 * @param archiveLocation The archiveLocation to set.
+	 */
+	public void setArchiveLocation(String archiveLocation) {
+		this.archiveLocation = archiveLocation;
+	}
+
+	/**.
+	 * This is the Getter Method for closeoutDate
+	 * @return Returns the closeoutDate.
+	 */
+	public Date getCloseoutDate() {
+		return closeoutDate;
+	}
+
+	/**.
+	 * This is the Setter Method for closeoutDate
+	 * @param closeoutDate The closeoutDate to set.
+	 */
+	public void setCloseoutDate(Date closeoutDate) {
+		this.closeoutDate = closeoutDate;
+	}
+
+	/**.
+	 * This is the Getter Method for closeoutIndicator
+	 * @return Returns the closeoutIndicator.
+	 */
+	public String getCloseoutIndicator() {
+		return closeoutIndicator;
+	}
+
+	/**.
+	 * This is the Setter Method for closeoutIndicator
+	 * @param closeoutIndicator The closeoutIndicator to set.
+	 */
+	public void setCloseoutIndicator(String closeoutIndicator) {
+		this.closeoutIndicator = closeoutIndicator;
+	}
+
+	/**.
+	 * This is the Getter Method for fundingSourceIndicator
+	 * @return Returns the fundingSourceIndicator.
+	 */
+	public String getFundingSourceIndicator() {
+		return fundingSourceIndicator;
+	}
+
+	/**.
+	 * This is the Setter Method for fundingSourceIndicator
+	 * @param fundingSourceIndicator The fundingSourceIndicator to set.
+	 */
+	public void setFundingSourceIndicator(String fundingSourceIndicator) {
+		this.fundingSourceIndicator = fundingSourceIndicator;
+	}
+
+	/**.
+	 * This is the Getter Method for comments
+	 * @return Returns the comments.
+	 */
+	public String getComments() {
+		return comments;
+	}
+
+	/**.
+	 * This is the Setter Method for comments
+	 * @param comments The comments to set.
+	 */
+	public void setComments(String comments) {
+		this.comments = comments;
+	}
+	/**.
+	 * This is the Getter Method for siteinvestigator
+	 * @return Returns the siteInvestigator.
+	 */
+	public Integer getSiteInvestigator() {
+        if (siteInvestigator != null) {
+            BusinessObjectService businessObjectService = KraServiceLocator.
+            getService(BusinessObjectService.class);
+            this.rolodex = (Rolodex) businessObjectService.
+            findByPrimaryKey(Rolodex.class,
+            getIdentifierMap(ROLODEX_ID_FIELD_NAME, siteInvestigator));
+            this.siteInvestigatorId = rolodex.getRolodexId().toString();
+        } else {
+            this.rolodex = null;
+        }
+        return siteInvestigator;
+    }
+	/**.
+	 * This is the Setter Method for siteInvestigator
+	 * @param siteInvestigator The siteInvestigator to set.
+	 */
+    public void setSiteInvestigator(Integer siteInvestigator) {
+        if (siteInvestigator != null) {
+            BusinessObjectService businessObjectService = KraServiceLocator.
+            getService(BusinessObjectService.class);
+            this.rolodex = (NonOrganizationalRolodex) businessObjectService.
+            findByPrimaryKey(NonOrganizationalRolodex.class,
+            getIdentifierMap(ROLODEX_ID_FIELD_NAME, siteInvestigator));
+            this.siteInvestigatorId = rolodex.getRolodexId().toString();
+        }
+        this.siteInvestigator = siteInvestigator;
+    }
+
+    /**.
+	 * This is the Getter Method for subAwardFundingSource
+	 * @return Returns the subAwardFundingSource.
+	 */
+	public SubAwardFundingSource getSubAwardFundingSource() {
+		return subAwardFundingSource;
+	}
+
+	/**.
+	 * This is the Setter Method for subAwardFundingSource
+	 * @param subAwardFundingSource The subAwardFundingSource to set.
+	 */
+	public void setSubAwardFundingSource(SubAwardFundingSource subAwardFundingSource) {
+		this.subAwardFundingSource = subAwardFundingSource;
+	}
+
+	/**.
+	 * This is the Getter Method for subAwardContact
+	 * @return Returns the subAwardContact.
+	 */
+	public SubAwardContact getSubAwardContact() {
+		return subAwardContact;
+	}
+
+	/**.
+	 * This is the Setter Method for subAwardContact
+	 * @param subAwardContact The subAwardContact to set.
+	 */
+	public void setSubAwardContact(SubAwardContact subAwardContact) {
+		this.subAwardContact = subAwardContact;
+	}
+
+	/**.
+	 * This is the Getter Method for subAwardCloseout
+	 * @return Returns the subAwardCloseout.
+	 */
+	public SubAwardCloseout getSubAwardCloseout() {
+		return subAwardCloseout;
+	}
+
+	/**.
+	 * This is the Setter Method for subAwardCloseout
+	 * @param subAwardCloseout The subAwardCloseout to set.
+	 */
+	public void setSubAwardCloseout(SubAwardCloseout subAwardCloseout) {
+		this.subAwardCloseout = subAwardCloseout;
+	}
+
+	/**.
+	 * This is the Getter Method for subAwardAmountInfo
+	 * @return Returns the subAwardAmountInfo.
+	 */
+	public SubAwardAmountInfo getSubAwardAmountInfo() {
+		return subAwardAmountInfo;
+	}
+
+	/**.
+	 * This is the Setter Method for subAwardAmountInfo
+	 * @param subAwardAmountInfo The subAwardAmountInfo to set.
+	 */
+	public void setSubAwardAmountInfo(SubAwardAmountInfo subAwardAmountInfo) {
+		this.subAwardAmountInfo = subAwardAmountInfo;
+	}
+
+    /**.
+	 * This is the Getter Method for subAwardFundingSourceList
+	 * @return Returns the subAwardFundingSourceList.
+	 */
+	public List<SubAwardFundingSource> getSubAwardFundingSourceList() {
+		return subAwardFundingSourceList;
+	}
+
+	/**.
+	 * This is the Setter Method for subAwardFundingSourceList
+	 * @param subAwardFundingSourceList
+	 *  The subAwardFundingSourceList to set.
+	 */
+	public void setSubAwardFundingSourceList(
+			List<SubAwardFundingSource> subAwardFundingSourceList) {
+		this.subAwardFundingSourceList = subAwardFundingSourceList;
+	}
+
+    /**.
+	 * This is the Getter Method for subAwardAmountInfoList
+	 * @return Returns the subAwardAmountInfoList.
+	 */
+	public List<SubAwardAmountInfo> getSubAwardAmountInfoList() {
+		return subAwardAmountInfoList;
+	}
+
+	/**.
+	 * This is the Setter Method for subAwardAmountInfoList
+	 * @param subAwardAmountInfoList The subAwardAmountInfoList to set.
+	 */
+	public void setSubAwardAmountInfoList(
+			List<SubAwardAmountInfo> subAwardAmountInfoList) {
+		this.subAwardAmountInfoList = subAwardAmountInfoList;
+	}
+
+	/**.
+	 * This is the Getter Method for subAwardAmountReleasedList
+	 * @return Returns the subAwardAmountReleasedList.
+	 */
+	public List<SubAwardAmountReleased> getSubAwardAmountReleasedList() {
+	    Map<String, Object> values = new HashMap<String, Object>();
+	    values.put("subAwardCode", this.getSubAwardCode());
+		return (List<SubAwardAmountReleased>) 
+		    KraServiceLocator.getService(BusinessObjectService.class).findMatchingOrderBy(SubAwardAmountReleased.class, values, "createdDate", false);
+	}
+
+	/**.
+	 * This is the Getter Method for subAwardContactsList
+	 * @return Returns the subAwardContactsList.
+	 */
+	public List<SubAwardContact> getSubAwardContactsList() {
+		return subAwardContactsList;
+	}
+
+	/**.
+	 * This is the Setter Method for subAwardContactsList
+	 * @param subAwardContactsList The subAwardContactsList to set.
+	 */
+	public void setSubAwardContactsList(List<SubAwardContact> subAwardContactsList) {
+		this.subAwardContactsList = subAwardContactsList;
+	}
+
+	/**.
+	 * This is the Getter Method for subAwardCloseoutList
+	 * @return Returns the subAwardCloseoutList.
+	 */
+	public List<SubAwardCloseout> getSubAwardCloseoutList() {
+		return subAwardCloseoutList;
+	}
+
+	/**.
+	 * This is the Setter Method for subAwardCloseoutList
+	 * @param subAwardCloseoutList The subAwardCloseoutList to set.
+	 */
+	public void setSubAwardCloseoutList(List<SubAwardCloseout> subAwardCloseoutList) {
+		this.subAwardCloseoutList = subAwardCloseoutList;
+	}
+
+	/**.
+	 * This is the Getter Method for subAwardCustomDataList
+	 * @return Returns the subAwardCustomDataList.
+	 */
+	public List<SubAwardCustomData> getSubAwardCustomDataList() {
+		return subAwardCustomDataList;
+	}
+
+	/**.
+	 * This is the Setter Method for subAwardCustomDataList
+	 * @param subAwardCustomDataList The subAwardCustomDataList to set.
+	 */
+	public void setSubAwardCustomDataList(
+			List<SubAwardCustomData> subAwardCustomDataList) {
+		this.subAwardCustomDataList = subAwardCustomDataList;
+	}
+	/**.
+	 * This is the Getter Method for getStatusDescription
+	 * @return Returns the statusDescription.
+	 */
+	public String getStatusDescription() {
+        SubAwardStatus status = getSubAwardStatus();
+        statusDescription = status != null ? status.getDescription() : null;
+        return statusDescription;
+    }
+	/**.
+	 * This is the Getter Method for initializeCollections
+	 */
+    protected void initializeCollections() {
+        subAwardFundingSourceList = new AutoPopulatingList<
+        SubAwardFundingSource>(SubAwardFundingSource.class);
+        subAwardAmountInfoList = new AutoPopulatingList<
+        SubAwardAmountInfo>(SubAwardAmountInfo.class);
+        subAwardContactsList = new AutoPopulatingList<
+        SubAwardContact>(SubAwardContact.class);
+        subAwardCloseoutList = new AutoPopulatingList<
+        SubAwardCloseout>(SubAwardCloseout.class);
+        subAwardCustomDataList = new AutoPopulatingList<
+        SubAwardCustomData>(SubAwardCustomData.class);
+        subAwardReportList = new AutoPopulatingList<
+        SubAwardReports>(SubAwardReports.class);
+    }
+    /**.
+	 * This is the Setter Method for subAwardDocument
+	 * @param subAwardDocument
+	 *  The subAwardDocument to set.
+	 */
+    public void setSubAwardDocument(SubAwardDocument subAwardDocument) {
+        this.subAwardDocument = subAwardDocument;
+    }
+    /**.
+	 * This is the Getter Method for getSubAwardDocument
+	 * @return Returns the subAwardDocument.
+	 */
+    public SubAwardDocument getSubAwardDocument() {
+        if (subAwardDocument == null) {
+            this.refreshReferenceObject("subAwardDocument");
+        }
+        return subAwardDocument;
+    }
+    /*.
+	 * This is the Setter Method for subAwardStatus
+	 * @param subAwardStatus
+	 *  The subAwardStatus to set.
+	 */
+    public void setSubAwardStatus(SubAwardStatus subAwardStatus) {
+        this.subAwardStatus = subAwardStatus;
+    }
+    /**.
+	 * This is the Getter Method for getSubAwardStatus
+	 * @return Returns the subAwardDocument.
+	 */
+    public SubAwardStatus getSubAwardStatus() {
+        if (subAwardStatus == null && statusCode != null) {
+            refreshReferenceObject("subAwardStatus");
+        }
+        return subAwardStatus;
+    }
+    /*.
+	 * This is the Setter Method for subAwardType
+	 * @param subAwardType
+	 *  The subAwardType to set.
+	 */
+    public void setSubAwardType(AwardType subAwardType) {
+        this.subAwardType = subAwardType;
+    }
+    /**.
+	 * This is the Getter Method for subAwardType
+	 * @return Returns the subAwardType.
+	 */
+    public AwardType getSubAwardType() {
+        return subAwardType;
+    }
+
+    @Override
+    public String getDocumentNumberForPermission() {
+        if (subAwardId != null) {
+            return subAwardId.toString();
+        } else {
+            return null;
+    }
+    }
+
+    @Override
+    public String getDocumentKey() {
+        return Permissionable.SUBAWARD_KEY;
+    }
+
+    @Override
+    public List<String> getRoleNames() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public String getNamespace() {
+        return Constants.MODULE_NAMESPACE_SUBAWARD;
+}
+    @Override
+    public String getLeadUnitNumber() {
+        return this.getUnit() != null ?
+       this.getUnit().getUnitNumber() : EMPTY_STRING;
+    }
+
+    @Override
+    public String getDocumentRoleTypeCode() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void populateAdditionalQualifiedRoleAttributes(Map<String, String> qualifiedRoleAttributes) {
+        if(getSubAwardDocument()!=null)
+            qualifiedRoleAttributes.put("documentNumber", getSubAwardDocument().getDocumentNumber());
+
+    }
+    /**
+     * @see org.kuali.kra.SequenceOwner#incrementSequenceNumber()
+     */
+    public void incrementSequenceNumber() {
+        this.sequenceNumber++;
+    }
+    /**
+     * @see org.kuali.kra.SequenceOwner#getOwnerSequenceNumber()
+     */
+    @Override
+    public void setSequenceOwner(SubAward newlyVersionedOwner) {
+        // TODO Auto-generated method stub
+    }
+    /**
+     * @see org.kuali.kra.SequenceAssociate#getSequenceOwner()
+     */
+    @Override
+    public SubAward getSequenceOwner() {
+        return this;
+    }
+    /**
+     * @see org.kuali.kra.Sequenceable#resetPersistenceState()
+     */
+    @Override
+    public void resetPersistenceState() {
+       this.subAwardId=null;
+    }
+
+    @Override
+    public Integer getOwnerSequenceNumber() {
+        return null;
+    }
+
+    @Override
+    public String getVersionNameField() {
+        return "subAwardCode";
+    }
+
+
+
+    /**.
+     * sets newVersion to specified value
+     * @param newVersion the newVersion to be set
+     */
+    public void setNewVersion (boolean newVersion){
+        this.newVersion = newVersion;
+
+    }
+
+    /**.
+     * Gets the newVersion attribute
+     * @return Returns the newVersion attribute
+     */
+    public boolean getNewVersion( ) {
+        return this.newVersion;
+    }
+    
+
+    /**.
+	 * This is the Getter Method for totalObligatedAmount
+	 * @return Returns the totalObligatedAmount.
+	 */
+	public KualiDecimal getTotalObligatedAmount() {
+		return totalObligatedAmount;
+	}
+
+	/**.
+	 * This is the Getter Method for lastUpdate
+	 * @return Returns the lastUpdate.
+	 */
+	public String getLastUpdate() {
+		return lastUpdate;
+	}
+
+	/**.
+	 * This is the Setter Method for lastUpdate
+	 * @param lastUpdate The lastUpdate to set.
+	 */
+	public void setLastUpdate(String lastUpdate) {
+		this.lastUpdate = lastUpdate;
+	}
+
+	/**.
+	 * This is the Setter Method for totalObligatedAmount
+	 * @param totalObligatedAmount The totalObligatedAmount to set.
+	 */
+	public void setTotalObligatedAmount(KualiDecimal totalObligatedAmount) {
+		this.totalObligatedAmount = totalObligatedAmount;
+	}
+
+	/**.
+	 * This is the Getter Method for totalAnticipatedAmount
+	 * @return Returns the totalAnticipatedAmount.
+	 */
+	public KualiDecimal getTotalAnticipatedAmount() {
+		return totalAnticipatedAmount;
+	}
+
+	/**.
+	 * This is the Setter Method for totalAnticipatedAmount
+	 * @param totalAnticipatedAmount The totalAnticipatedAmount to set.
+	 */
+	public void setTotalAnticipatedAmount(KualiDecimal totalAnticipatedAmount) {
+		this.totalAnticipatedAmount = totalAnticipatedAmount;
+	}
+
+	/**.
+	 * This is the Getter Method for totalAmountReleased
+	 * @return Returns the totalAmountReleased.
+	 */
+	public KualiDecimal getTotalAmountReleased() {
+		return totalAmountReleased;
+	}
+
+	/**.
+	 * This is the Setter Method for totalAmountReleased
+	 * @param totalAmountReleased The totalAmountReleased to set.
+	 */
+	public void setTotalAmountReleased(KualiDecimal totalAmountReleased) {
+		this.totalAmountReleased = totalAmountReleased;
+	}
+
+	/**.
+	 * This is the Getter Method for totalAvailableAmount
+	 * @return Returns the totalAvailableAmount.
+	 */
+	public KualiDecimal getTotalAvailableAmount() {
+		return totalAvailableAmount;
+	}
+
+	/**.
+	 * This is the Setter Method for totalAvailableAmount
+	 * @param totalAvailableAmount The totalAvailableAmount to set.
+	 */
+	public void setTotalAvailableAmount(KualiDecimal totalAvailableAmount) {
+		this.totalAvailableAmount = totalAvailableAmount;
+	}
+
+	/**.
+	 * This is the Getter Method for docIdStatus
+	 * @return Returns the docIdStatus.
+	 */
+	public String getDocIdStatus() {
+		return docIdStatus;
+	}
+
+	/**.
+	 * This is the Setter Method for docIdStatus
+	 * @param docIdStatus The docIdStatus to set.
+	 */
+	public void setDocIdStatus(String docIdStatus) {
+		this.docIdStatus = docIdStatus;
+	}
+	/**.
+	 * This is the Getter Method for SiteInvestigatorId
+	 * @return Returns the siteInvestigatorId.
+	 */
+	public String getSiteInvestigatorId() {
+        if (this.siteInvestigatorId == null && this.siteInvestigator != null) {
+            siteInvestigatorId = this.siteInvestigator.toString();
+        }
+        return siteInvestigatorId;
+    }
+	/**.
+	 * This is the Setter Method for SiteInvestigatorId
+	 * @param siteInvestigatorId The siteInvestigatorId to set.
+	 */
+    public void setSiteInvestigatorId(String siteInvestigatorId) {        
+        this.siteInvestigatorId = siteInvestigatorId;
+    }
+
+    @Override
+    public String getAssociatedDocumentId() {
+        return this.getSubAwardCode();
+    }
+
+    @Override
+    public String getLeadUnitName() {
+        return this.getUnit() != null ? this.getUnit().getUnitName() : EMPTY_STRING;
+    }
+
+    @Override
+    public String getPiName() {
+        return EMPTY_STRING;
+    }
+
+    @Override
+    public String getPiEmployeeName() {
+        return EMPTY_STRING;
+    }
+
+    @Override
+    public String getPiNonEmployeeName() {
+        return EMPTY_STRING;
+    }
+
+    @Override
+    public String getAdminPersonName() {
+        return EMPTY_STRING;
+    }
+
+    @Override
+    public String getSponsorCode() {
+        return EMPTY_STRING;
+    }
+
+    @Override
+    public String getSponsorName() {
+        return EMPTY_STRING;
+    }
+
+    @Override
+    public String getPrimeSponsorCode() {
+        return EMPTY_STRING;
+    }
+
+    @Override
+    public String getPrimeSponsorName() {
+        return EMPTY_STRING;
+    }
+
+    @Override
+    public String getSponsorAwardNumber() {
+        return EMPTY_STRING;
+    }
+
+    @Override
+    public String getSubAwardOrganizationName() {
+        return this.getOrganization() != null ?
+       this.getOrganization().getOrganizationName() : EMPTY_STRING;
+    }
+
+    @Override
+    public List<NegotiationPersonDTO> getProjectPeople() {
+        List<NegotiationPersonDTO> people = new
+        ArrayList<NegotiationPersonDTO>();
+        if (this.getKcPerson() != null) {
+            people.add(new NegotiationPersonDTO(this.getKcPerson(), "admin"));
+        }
+        return people;
+    }
+
+    @Override
+    public String getNegotiableProposalTypeCode() {
+        return EMPTY_STRING;
+    }
+
+    @Override
+    public ProposalType getNegotiableProposalType() {
+        return null;
+    }
+
+    @Override
+    public String getSubAwardRequisitionerName() {
+        return this.getRequisitionerName();
+    }
+
+    @Override
+    public String getSubAwardRequisitionerUnitNumber() {
+        return this.getUnit() != null ? this.getUnit().getUnitNumber() : EMPTY_STRING;
+    }
+
+    @Override
+    public String getSubAwardRequisitionerUnitName() {
+        return this.getUnit() != null ? this.getUnit().
+        		getUnitName() : EMPTY_STRING;
+    }
+
+    @Override
+    public String getSubAwardRequisitionerId() {
+        return this.getRequisitionerId();
+    }
+
+    /**.
+	 * This is the Getter Method for awardNumber
+	 * @return Returns the awardNumber.
+	 */
+	public String getAwardNumber() {
+		return awardNumber;
+	}
+
+	/**.
+	 * This is the Setter Method for awardNumber
+	 * @param awardNumber The awardNumber to set.
+	 */
+	public void setAwardNumber(String awardNumber) {
+		this.awardNumber = awardNumber;
+	}
+
+	/**.
+	 * This is the Getter Method for editSubAward
+	 * @return Returns the editSubAward.
+	 */
+	public boolean isEditSubAward() {
+		return editSubAward;
+	}
+
+	/**.
+	 * This is the Setter Method for editSubAward
+	 * @param editSubAward The editSubAward to set.
+	 */
+	public void setEditSubAward(boolean editSubAward) {
+		this.editSubAward = editSubAward;
+	}
+
+	/**.
+     * Build an identifier map for the BOS lookup
+     * @param identifierField
+     * @param identifierValue
+     * @return
+     */
+    protected Map<String, Object> getIdentifierMap(String identifierField, Object identifierValue) {
+        Map<String, Object> map = new HashMap<String, Object>();
+        map.put(identifierField, identifierValue);
+        return map;
+    }
+
+    public boolean isDefaultOpen() {
+        return defaultOpen;
+    }
+
+    public void setDefaultOpen(boolean defaultOpen) {
+        this.defaultOpen = defaultOpen;
+    }
+
+    /**
+     * Gets the costType attribute. 
+     * @return Returns the costType.
+     */
+    public Integer getCostType() {
+        return costType;
+    }
+
+    /**
+     * Sets the costType attribute value.
+     * @param costType The costType to set.
+     */
+    public void setCostType(Integer costType) {
+        this.costType = costType;
+    }
+
+    /**
+     * Gets the executionDate attribute. 
+     * @return Returns the executionDate.
+     */
+    public Date getExecutionDate() {
+        return executionDate;
+    }
+
+    /**
+     * Sets the executionDate attribute value.
+     * @param executionDate The executionDate to set.
+     */
+    public void setExecutionDate(Date executionDate) {
+        this.executionDate = executionDate;
+    }
+
+    /**
+     * Gets the requisitionId attribute. 
+     * @return Returns the requisitionId.
+     */
+    public String getRequisitionId() {
+        return requisitionId;
+    }
+
+    /**
+     * Sets the requisitionId attribute value.
+     * @param requisitionId The requisitionId to set.
+     */
+    public void setRequisitionId(String requisitionId) {
+        this.requisitionId = requisitionId;
+    }
+
+    /**
+     * Gets the subAwardCostType attribute. 
+     * @return Returns the subAwardCostType.
+     */
+    public SubAwardCostType getSubAwardCostType() {
+        return subAwardCostType;
+    }
+
+    /**
+     * Sets the subAwardCostType attribute value.
+     * @param subAwardCostType The subAwardCostType to set.
+     */
+    public void setSubAwardCostType(SubAwardCostType subAwardCostType) {
+        this.subAwardCostType = subAwardCostType;
+    }
+    
+    /**.
+     * This is the Getter Method for modificationEffectiveDate
+     * @return Returns the modificationEffectiveDate.
+     */
+    public Date getModificationEffectiveDate() {
+        return modificationEffectiveDate;
+    }
+
+    /**.
+     * This is the Setter Method for modificationEffectiveDate
+     * @param modificationEffectiveDate The modificationEffectiveDate to set.
+     */
+    public void setModificationEffectiveDate(Date modificationEffectiveDate) {
+        this.modificationEffectiveDate = modificationEffectiveDate;
+    }
+    
+    /**.
+     * This is the Getter Method for modificationId
+     * @return Returns the modificationId.
+     */
+    public String getModificationId() {
+        return modificationId;
+    }
+
+    /**.
+     * This is the Setter Method for modificationId
+     * @param modificationId The modificationId to set.
+     */
+    public void setModificationId(String modificationId) {
+        this.modificationId = modificationId;
+    }
+
+    /**.
+     * This is the Getter Method for performanceStartDate
+     * @return Returns the performanceStartDate.
+     */
+    public Date getPerformanceStartDate() {
+        return performanceStartDate;
+    }
+
+    /**.
+     * This is the Setter Method for performanceStartDate
+     * @param performanceStartDate The performanceStartDate to set.
+     */
+    public void setPerformanceStartDate(Date performanceStartDate) {
+        this.performanceStartDate = performanceStartDate;
+    }
+
+    /**.
+     * This is the Getter Method for performanceEnddate
+     * @return Returns the performanceEnddate.
+     */
+    public Date getPerformanceEnddate() {
+        return performanceEnddate;
+    }
+
+    /**.
+     * This is the Setter Method for performanceEnddate
+     * @param performanceEnddate The performanceEnddate to set.
+     */
+    public void setPerformanceEnddate(Date performanceEnddate) {
+        this.performanceEnddate = performanceEnddate;
+    }
+}

--- a/src/main/java/org/kuali/kra/subaward/bo/SubAward.java
+++ b/src/main/java/org/kuali/kra/subaward/bo/SubAward.java
@@ -937,7 +937,24 @@ implements Permissionable, SequenceOwner<SubAward>, Negotiable {
 	public List<SubAwardFundingSource> getSubAwardFundingSourceList() {
 		return subAwardFundingSourceList;
 	}
-
+	
+    /**.
+     * This returns only the ACTIVE subAwardFundingSources that link to ACTIVE versions of the award.
+     * @return Returns the subAwardFundingSourceList.
+     */
+    public List<SubAwardFundingSource> getActiveSubAwardFundingSourceList() {
+        List<SubAwardFundingSource> filteredFundingSources = new ArrayList<SubAwardFundingSource>();
+        if ( subAwardFundingSourceList!= null  ){
+            for (SubAwardFundingSource subAwardFundingSource:subAwardFundingSourceList){
+                if ( subAwardFundingSource.isActive() && subAwardFundingSource.getAward().getAwardSequenceStatus().equalsIgnoreCase("ACTIVE") ){
+                    filteredFundingSources.add(subAwardFundingSource);
+                }
+            }
+        }
+        return filteredFundingSources;
+    }
+	
+	
 	/**.
 	 * This is the Setter Method for subAwardFundingSourceList
 	 * @param subAwardFundingSourceList

--- a/src/main/java/org/kuali/kra/subaward/bo/SubAwardFundingSource.java
+++ b/src/main/java/org/kuali/kra/subaward/bo/SubAwardFundingSource.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2005-2014 The Kuali Foundation
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.opensource.org/licenses/ecl1.php
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kuali.kra.subaward.bo;
+
+import org.kuali.kra.award.home.Award;
+import org.kuali.kra.award.home.AwardAmountInfo;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+
+import java.sql.Date;
+
+public class SubAwardFundingSource extends SubAwardAssociate { 
+
+    private static final long serialVersionUID = 1L;
+
+    private Integer subAwardFundingSourceId;
+    private Long subAwardId; 
+    private String subAwardCode;
+    private Long awardId;
+
+    private String accountNumber;
+
+    private Integer statusCode;
+
+    private String sponsorCode;
+    
+    private String sponsorName;
+
+    private Award award;
+
+    private KualiDecimal amountObligatedToDate;
+
+    private Date obligationExpirationDate;
+
+    private String awardNumber;
+
+    private AwardAmountInfo awardAmountInfo;
+    
+    /**
+     * 
+     * Constructs a SubAwardFundingSource.java.
+     */
+    public SubAwardFundingSource() { 
+
+    }
+    
+    /**
+     * 
+     * Constructs a SubAwardFundingSource.java.
+     * @param award
+     */
+    public SubAwardFundingSource(Award award) { 
+        this();
+        this.award = award;
+        this.award.setAwardNumber("");
+    }
+
+
+    /**.
+	 * This is the Getter Method
+	 * for subAwardFundingSourceId
+	 * @return Returns the subAwardFundingSourceId.
+	 */
+	public Integer getSubAwardFundingSourceId() {
+		return subAwardFundingSourceId;
+	}
+
+	/**.
+	 * This is the Setter Method for subAwardFundingSourceId
+	 * @param subAwardFundingSourceId The subAwardFundingSourceId to set.
+	 */
+	public void setSubAwardFundingSourceId(Integer subAwardFundingSourceId) {
+		this.subAwardFundingSourceId = subAwardFundingSourceId;
+	}
+
+	/**.
+	 * This is the Getter Method for subAwardId
+	 * @return Returns the subAwardId.
+	 */
+	public Long getSubAwardId() {
+		return subAwardId;
+	}
+
+	/**.
+	 * This is the Setter Method for subAwardId
+	 * @param subAwardId The subAwardId to set.
+	 */
+	public void setSubAwardId(Long subAwardId) {
+		this.subAwardId = subAwardId;
+	}
+
+	/**.
+	 * This is the Getter Method for subAwardCode
+	 * @return Returns the subAwardCode.
+	 */
+	public String getSubAwardCode() {
+		return subAwardCode;
+	}
+
+	/**.
+	 * This is the Setter Method for subAwardCode
+	 * @param subAwardCode The subAwardCode to set.
+	 */
+	public void setSubAwardCode(String subAwardCode) {
+		this.subAwardCode = subAwardCode;
+	}
+
+	/**.
+	 * This is the Getter Method for awardId
+	 * @return Returns the awardId.
+	 */
+	public Long getAwardId() {
+		return awardId;
+	}
+
+	/**.
+	 * This is the Setter Method for awardId
+	 * @param awardId The awardId to set.
+	 */
+	public void setAwardId(Long awardId) {
+		this.awardId = awardId;
+	}
+
+	/**.
+	 * This is the Getter Method for accountNumber
+	 * @return Returns the accountNumber.
+	 */
+	public String getAccountNumber() {
+		return accountNumber;
+	}
+
+	/**.
+	 * This is the Setter Method for accountNumber
+	 * @param accountNumber The accountNumber to set.
+	 */
+	public void setAccountNumber(String accountNumber) {
+		this.accountNumber = accountNumber;
+	}
+
+	/**.
+	 * This is the Getter Method for statusCode
+	 * @return Returns the statusCode.
+	 */
+	public Integer getStatusCode() {
+		return statusCode;
+	}
+
+	/**.
+	 * This is the Setter Method for statusCode
+	 * @param statusCode The statusCode to set.
+	 */
+	public void setStatusCode(Integer statusCode) {
+		this.statusCode = statusCode;
+	}
+
+	/**.
+	 * This is the Getter Method for sponsorCode
+	 * @return Returns the sponsorCode.
+	 */
+	public String getSponsorCode() {
+		return sponsorCode;
+	}
+
+	/**.
+	 * This is the Setter Method for sponsorCode
+	 * @param sponsorCode The sponsorCode to set.
+	 */
+	public void setSponsorCode(String sponsorCode) {
+		this.sponsorCode = sponsorCode;
+	}
+
+	/**.
+	 * This is the Getter Method for sponsorName
+	 * @return Returns the sponsorName.
+	 */
+	public String getSponsorName() {
+		return sponsorName;
+	}
+
+	/**.
+	 * This is the Setter Method for sponsorName
+	 * @param sponsorName The sponsorName to set.
+	 */
+	public void setSponsorName(String sponsorName) {
+		this.sponsorName = sponsorName;
+	}
+
+
+
+	/**.
+	 * This is the Getter Method for award
+	 * @return Returns the award.
+	 */
+	public Award getAward() {
+		return award;
+	}
+
+	/**.
+	 * This is the Setter Method for award
+	 * @param award The award to set.
+	 */
+	public void setAward(Award award) {
+		this.award = award;
+	}
+
+	/**.
+	 * This is the Getter Method for amountObligatedToDate
+	 * @return Returns the amountObligatedToDate.
+	 */
+	public KualiDecimal getAmountObligatedToDate() {
+		return amountObligatedToDate;
+	}
+
+	/**.
+	 * This is the Setter Method for amountObligatedToDate
+	 * @param amountObligatedToDate The amountObligatedToDate to set.
+	 */
+	public void setAmountObligatedToDate(KualiDecimal amountObligatedToDate) {
+		this.amountObligatedToDate = amountObligatedToDate;
+	}
+
+	/**.
+	 * This is the Getter Method for obligationExpirationDate
+	 * @return Returns the obligationExpirationDate.
+	 */
+	public Date getObligationExpirationDate() {
+		return obligationExpirationDate;
+	}
+
+	/**.
+	 * This is the Setter Method for obligationExpirationDate
+	 * @param obligationExpirationDate The obligationExpirationDate to set.
+	 */
+	public void setObligationExpirationDate(Date obligationExpirationDate) {
+		this.obligationExpirationDate = obligationExpirationDate;
+	}
+
+	/**.
+	 * This is the Getter Method for awardNumber
+	 * @return Returns the awardNumber.
+	 */
+	public String getAwardNumber() {
+		return awardNumber;
+	}
+
+	/**.
+	 * This is the Setter Method for awardNumber
+	 * @param awardNumber The awardNumber to set.
+	 */
+	public void setAwardNumber(String awardNumber) {
+		this.awardNumber = awardNumber;
+	}
+
+	/**.
+	 * This is the Getter Method for awardAmountInfo
+	 * @return Returns the awardAmountInfo.
+	 */
+	public AwardAmountInfo getAwardAmountInfo() {
+		return awardAmountInfo;
+	}
+
+	/**.
+	 * This is the Setter Method for awardAmountInfo
+	 * @param awardAmountInfo The awardAmountInfo to set.
+	 */
+	public void setAwardAmountInfo(AwardAmountInfo awardAmountInfo) {
+		this.awardAmountInfo = awardAmountInfo;
+	}
+
+	@Override
+    public void resetPersistenceState() {
+
+        this.subAwardFundingSourceId = null;
+    }
+}

--- a/src/main/java/org/kuali/kra/subaward/bo/SubAwardFundingSource.java
+++ b/src/main/java/org/kuali/kra/subaward/bo/SubAwardFundingSource.java
@@ -48,6 +48,8 @@ public class SubAwardFundingSource extends SubAwardAssociate {
 
     private AwardAmountInfo awardAmountInfo;
     
+    private boolean active = true;
+    
     /**
      * 
      * Constructs a SubAwardFundingSource.java.
@@ -65,6 +67,17 @@ public class SubAwardFundingSource extends SubAwardAssociate {
         this();
         this.award = award;
         this.award.setAwardNumber("");
+    }
+    
+    /**
+     * 
+     * Constructs a SubAwardFundingSource.java.
+     * @param award and subawad
+     */ 
+    public SubAwardFundingSource(SubAward subAward, Award award) { 
+        this.setSubAward(subAward);
+        this.setAward(award);
+        this.active = true;
     }
 
 
@@ -213,6 +226,10 @@ public class SubAwardFundingSource extends SubAwardAssociate {
 	 */
 	public void setAward(Award award) {
 		this.award = award;
+		if (award != null){
+		    this.setAwardId(award.getAwardId());
+		    this.setAwardNumber(award.getAwardNumber());
+		}
 	}
 
 	/**.
@@ -279,9 +296,53 @@ public class SubAwardFundingSource extends SubAwardAssociate {
 		this.awardAmountInfo = awardAmountInfo;
 	}
 
+	public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+    
 	@Override
     public void resetPersistenceState() {
 
         this.subAwardFundingSourceId = null;
+    }
+	
+	/**
+     * Constructs a new copy of this SubAwardFundingSource with all the attributes (except the id)
+     */
+    public SubAwardFundingSource copy() { 
+        SubAwardFundingSource newSubAwardFundingSource = new SubAwardFundingSource();
+        
+        newSubAwardFundingSource.setAccountNumber(this.accountNumber);
+        newSubAwardFundingSource.setAmountObligatedToDate(this.amountObligatedToDate);    
+        newSubAwardFundingSource.setAward(this.award);
+        newSubAwardFundingSource.setAwardAmountInfo(this.awardAmountInfo);
+       
+        newSubAwardFundingSource.setNewCollectionRecord(true);
+        newSubAwardFundingSource.setObligationExpirationDate(this.obligationExpirationDate);
+        
+        newSubAwardFundingSource.setSubAwardId(this.subAwardId);
+        newSubAwardFundingSource.setSubAwardCode(this.subAwardCode);
+        newSubAwardFundingSource.setAwardId(this.awardId);
+        newSubAwardFundingSource.setStatusCode(this.statusCode);
+        newSubAwardFundingSource.setSponsorCode(this.sponsorCode);
+        newSubAwardFundingSource.setSponsorName(this.sponsorName);
+        
+        if ( this.award != null ){
+            newSubAwardFundingSource.setAward(this.getAward());
+            newSubAwardFundingSource.setAwardId(this.award.getAwardId());
+            newSubAwardFundingSource.setAwardNumber(this.award.getAwardNumber());
+        }
+        
+        newSubAwardFundingSource.setSequenceOwner(this.getSequenceOwner());
+        //this actually holds the SubAward Version Number
+        newSubAwardFundingSource.setVersionNumber(this.getVersionNumber());
+        newSubAwardFundingSource.setAwardNumber(this.getAwardNumber());
+        newSubAwardFundingSource.setActive(this.isActive());
+        
+        return newSubAwardFundingSource;
     }
 }

--- a/src/main/java/org/kuali/kra/subaward/dao/SubAwardFundingSourceDao.java
+++ b/src/main/java/org/kuali/kra/subaward/dao/SubAwardFundingSourceDao.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2005-2014 The Kuali Foundation
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.opensource.org/licenses/ecl1.php
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kuali.kra.subaward.dao;
+
+import java.sql.SQLException;
+import java.util.Collection;
+
+import org.apache.ojb.broker.accesslayer.LookupException;
+import org.kuali.kra.award.home.Award;
+import org.kuali.kra.subaward.bo.SubAward;
+import org.kuali.kra.subaward.bo.SubAwardFundingSource;
+import org.springframework.dao.DataAccessException;
+
+public interface SubAwardFundingSourceDao {
+    
+    /**
+    *
+    * This method finds all the linked Awards through SFS for a SubAward
+    * It returns only the 'Active' versions of the corresponding Awards. 
+    * Each linked Award is returned only once.
+    * @return List<SubAward>
+    */
+    Collection<Award> getLinkedAwards(SubAward subAward) throws SQLException, LookupException;
+    
+    
+    /**
+     * 
+    * This method finds all the linked SubAwards through SubAwardFundingSource for an Award
+    * It returns only the 'Active' versions of the corresponding SubAwards (no 'Pending', 'Archived' etc).
+    * Each linked SubAward is returned only once.
+    * @return List<SubAward>
+    */
+    Collection<SubAward> getLinkedSubAwards(Award award) throws SQLException, LookupException;
+
+    
+    /**
+     * Updates all the SFSs with the same AwardNumber and SubawardCode to be inactive
+     * 
+     * */
+    void deleteSubAwardFundingSource(SubAwardFundingSource sfs) throws SQLException, LookupException;
+
+
+    /**
+     * Updates all the SFSs with the same AwardNumber and SubawardCode to be inactive
+     * 
+     * */
+    void deleteSubAwardFundingSource(String awardNumber, String subAwardcode) throws DataAccessException;
+
+}

--- a/src/main/java/org/kuali/kra/subaward/dao/impl/SubAwardFundingSourceDaoOjb.java
+++ b/src/main/java/org/kuali/kra/subaward/dao/impl/SubAwardFundingSourceDaoOjb.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2005-2014 The Kuali Foundation
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.opensource.org/licenses/ecl1.php
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kuali.kra.subaward.dao.impl;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.ojb.broker.PersistenceBroker;
+import org.apache.ojb.broker.accesslayer.LookupException;
+import org.apache.ojb.broker.query.Criteria;
+import org.apache.ojb.broker.query.QueryFactory;
+import org.kuali.kra.award.home.Award;
+import org.kuali.kra.subaward.bo.SubAward;
+import org.kuali.kra.subaward.bo.SubAwardFundingSource;
+import org.kuali.kra.subaward.dao.SubAwardFundingSourceDao;
+import org.kuali.rice.core.framework.persistence.ojb.dao.PlatformAwareDaoBaseOjb;
+import org.kuali.rice.krad.service.util.OjbCollectionAware;
+import org.springframework.dao.DataAccessException;
+
+
+
+
+public class SubAwardFundingSourceDaoOjb extends PlatformAwareDaoBaseOjb implements OjbCollectionAware, SubAwardFundingSourceDao {
+
+
+    private static final Log LOG = LogFactory.getLog(SubAwardFundingSourceDaoOjb.class);
+
+
+    private static final String SQL_SUBAWARDS =  "select SUBAWARD.SUBAWARD_ID, SUBAWARD.SUBAWARD_CODE, status from SUBAWARD join (select unique SUBAWARD_CODE sc, h.SEQ_OWNER_SEQ_NUMBER seq, h.VERSION_STATUS status from SUBAWARD_FUNDING_SOURCE sfs JOIN VERSION_HISTORY h on sfs.SUBAWARD_CODE = h.SEQ_OWNER_VERSION_NAME_VALUE where AWARD_NUMBER=? and ACTV_IND='Y'and h.SEQ_OWNER_CLASS_NAME='org.kuali.kra.subaward.bo.SubAward' and (h.VERSION_STATUS='ACTIVE' or h.VERSION_STATUS='PENDING')) a on SUBAWARD.SUBAWARD_CODE = a.sc and SUBAWARD.SEQUENCE_NUMBER = a.seq order by SUBAWARD_ID";
+    private static final String SQL_AWARDS =  "select AWARD_ID, AWARD_NUMBER, AWARD_SEQUENCE_STATUS from AWARD join (select unique AWARD_NUMBER an, h.SEQ_OWNER_SEQ_NUMBER seq from SUBAWARD_FUNDING_SOURCE sfs JOIN VERSION_HISTORY h on sfs.AWARD_NUMBER = h.SEQ_OWNER_VERSION_NAME_VALUE where sfs.SUBAWARD_CODE=? and ACTV_IND='Y'and h.SEQ_OWNER_CLASS_NAME='org.kuali.kra.award.home.Award' and  (h.VERSION_STATUS='ACTIVE' or h.VERSION_STATUS='PENDING')) a on AWARD.AWARD_NUMBER = a.an and AWARD.SEQUENCE_NUMBER = a.seq and (AWARD.AWARD_SEQUENCE_STATUS = 'ACTIVE' or AWARD.AWARD_SEQUENCE_STATUS = 'PENDING') order by AWARD_ID";
+    
+    private static final String AWARD_ID = "AWARD_ID";
+    private static final String AWARD_NUMBER = "AWARD_NUMBER";
+    private static final String SUBAWARD_ID = "SUBAWARD_ID";
+    private static final String SUBAWARD_CODE = "SUBAWARD_CODE";
+
+    private static final String ACTIVE = "ACTIVE";
+    private static final String PENDING = "PENDING";    
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Collection<Award> getLinkedAwards(SubAward subAward) throws SQLException, LookupException {
+        
+        List<String> awardIdsList = getLinkedAwardsIds(subAward);
+        if ( !awardIdsList.isEmpty() ){
+            Criteria criteria = new Criteria();
+            criteria.addColumnIn(AWARD_ID, awardIdsList);
+            return (Collection<Award>)getPersistenceBrokerTemplate().getCollectionByQuery(QueryFactory.newQuery(Award.class, criteria));
+        }
+        return new ArrayList<Award>(0);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Collection<SubAward> getLinkedSubAwards(Award award) throws SQLException, LookupException {
+        List<String> subAwardIdsList = getLinkedSubAwardsIds(award);
+        if ( !subAwardIdsList.isEmpty() ){
+            Criteria criteria = new Criteria();
+            criteria.addColumnIn(SUBAWARD_ID, subAwardIdsList);
+            return (Collection<SubAward>)getPersistenceBrokerTemplate().getCollectionByQuery(QueryFactory.newQuery(SubAward.class, criteria));
+        }
+        return new ArrayList<SubAward>(0);
+    }
+
+
+    protected List<String> getLinkedSubAwardsIds(Award award) throws SQLException, LookupException {
+        if ( award == null) {
+            throw new IllegalArgumentException("SubAwardFundingSourceDaoOjb: getLinkedSubAwardsIds with a null Award!");
+        }
+        LOG.debug("getLinkedSubAwardsCodes awardNumber="+award.getAwardNumber()+" awardId="+award.getAwardId());
+        List<String> result = new ArrayList<String>();
+
+        Connection conn = null;
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+        try {
+            //don't create another instance of the PersistenceBroker, just grab existing one
+            PersistenceBroker broker = this.getPersistenceBroker(false);
+
+            conn = broker.serviceConnectionManager().getConnection();
+            ps = conn.prepareStatement(SQL_SUBAWARDS);
+            ps.setString(1, award.getAwardNumber());
+            rs = ps.executeQuery();
+            //eliminate duplicate results
+            List<Row> rows = eliminateDuplicates(rs);
+
+            for ( Row row: rows){
+                result.add(row.getId());
+            }
+
+        } catch (SQLException sqle) {
+            LOG.error("SQLException: " + sqle.getMessage(), sqle);
+            throw sqle;
+        } catch (LookupException le) {
+            LOG.error("LookupException: " + le.getMessage(), le);
+            throw le;
+        } finally {
+            closeDatabaseObjects(rs, ps, conn);
+        }
+
+        return result;
+    }
+
+
+    protected List<String> getLinkedAwardsIds(SubAward subAward) throws SQLException, LookupException {
+        if ( subAward == null) {
+            throw new IllegalArgumentException("SubAwardFundingSourceDaoOjb: getLinkedAwardsIds with a null SubAward!");
+        }
+        LOG.debug("getLinkedAwardsIds subAward code="+subAward.getSubAwardCode()+" subAwardId="+subAward.getSubAwardId());
+        List<String> result = new ArrayList<String>();
+
+        Connection conn = null;
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+        try {
+            //don't create another instance of the PersistenceBroker, just grab existing one
+            PersistenceBroker broker = this.getPersistenceBroker(false);
+
+            conn = broker.serviceConnectionManager().getConnection();
+            ps = conn.prepareStatement(SQL_AWARDS);
+            ps.setString(1, subAward.getSubAwardCode());
+            rs = ps.executeQuery();
+            //eliminate duplicate results
+            List<Row> rows = eliminateDuplicates(rs);
+
+            for ( Row row: rows){
+                result.add(row.getId());
+            }
+
+        } catch (SQLException sqle) {
+            LOG.error("SQLException: " + sqle.getMessage(), sqle);
+            throw sqle;
+        } catch (LookupException le) {
+            LOG.error("LookupException: " + le.getMessage(), le);
+            throw le;
+        } finally {
+            closeDatabaseObjects(rs, ps, conn);
+        }
+
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void deleteSubAwardFundingSource(SubAwardFundingSource sfs) throws DataAccessException {
+        deleteSubAwardFundingSource(sfs.getAwardNumber(), sfs.getSubAwardCode());
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Override
+    public void deleteSubAwardFundingSource(String awardNumber, String subAwardcode) throws DataAccessException {
+        Criteria criteria = new Criteria();
+        criteria.addEqualTo(AWARD_NUMBER, awardNumber);
+        criteria.addEqualTo(SUBAWARD_CODE, subAwardcode);
+
+        Collection<SubAwardFundingSource> results = (Collection<SubAwardFundingSource>) getPersistenceBrokerTemplate().getCollectionByQuery(QueryFactory.newQuery(SubAwardFundingSource.class, criteria));
+        for (SubAwardFundingSource subAwardFS:results){
+            subAwardFS.setActive(false);
+            getPersistenceBrokerTemplate().store(subAwardFS);
+        }
+    }
+
+
+    protected void closeDatabaseObjects(ResultSet rs, PreparedStatement ps, Connection conn) {
+        if (rs != null) {
+            try {
+                rs.close();
+            } catch (SQLException ex) {
+                LOG.warn("Failed to close ResultSet.", ex);
+            }
+        }
+        if ( ps != null ){
+            try {
+                ps.close();
+            } catch (SQLException ex) {
+                LOG.warn("Failed to close PreparedStatement.", ex);
+            }
+        }
+        if ( conn != null ){
+            try {
+                conn.close();
+            } catch (SQLException ex) {
+                LOG.warn("Failed to close Connection.", ex);
+            }
+        }
+    }
+
+    /**
+     * Utility method used internally to eliminate duplicate results from subAward/award queries.
+     * If there is a pending and and active version of the same award/subAward, it will only return the active one
+     * It operates under the assumption that there can only be ONE ACTIVE and/or ONE PENDING version at most of the Award/Subaward
+     * @param rs
+     * @return
+     */
+    private List<Row> eliminateDuplicates(ResultSet rs) throws SQLException{
+        List<Row> rows = new ArrayList<Row>();
+        while (rs.next()) {
+            //Result set structure: 1=ID 2=AwardNumber or SubawardCode 3=Status
+            Row currentRow = new Row(rs.getString(1),rs.getString(2), rs.getString(3));
+
+            //eliminate duplicate results
+            boolean duplicate = false;
+            for ( Row row: rows){
+                if ( currentRow.hasSameIdentifier(row) ){
+                    if ( currentRow.isActive() && row.isPending() ){
+                        //replace the pending version in the results with the actual active version of the award/subaward
+                        row.replaceWith(currentRow);
+                    }
+                    duplicate = true;
+                    break;
+                }
+            }
+            if (!duplicate){
+                rows.add(currentRow);
+            }
+        }
+        return rows;
+    }
+
+    private class Row {
+        private String id;
+        private String identifier;
+        private String status;
+
+        public Row(String id, String identifier, String status){
+            this.id=new String(id);
+            this.identifier=new String(identifier);
+            this.status=new String(status);
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getIdentifier() {
+            return identifier;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+
+        public boolean hasSameIdentifier(Row otherRow){
+            if ( this.identifier == null || otherRow.identifier==null ){
+                return false;
+            }
+            return this.identifier.equalsIgnoreCase(otherRow.getIdentifier());
+        }
+
+        public boolean isActive(){
+            return ACTIVE.equalsIgnoreCase(status);
+        }
+
+        public boolean isPending(){
+            return PENDING.equalsIgnoreCase(status);
+        }
+
+        public void replaceWith(Row otherRow){
+            id=otherRow.getId();
+            identifier=otherRow.getIdentifier();
+            status=otherRow.getStatus();
+        }
+
+    }
+
+}

--- a/src/main/java/org/kuali/kra/subaward/service/SubAwardService.java
+++ b/src/main/java/org/kuali/kra/subaward/service/SubAwardService.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2005-2014 The Kuali Foundation
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.opensource.org/licenses/ecl1.php
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kuali.kra.subaward.service;
+
+import org.kuali.kra.award.home.Award;
+import org.kuali.kra.bo.versioning.VersionStatus;
+import org.kuali.kra.service.VersionException;
+import org.kuali.kra.subaward.bo.SubAward;
+import org.kuali.kra.subaward.document.SubAwardDocument;
+import org.kuali.rice.kew.api.exception.WorkflowException;
+
+import java.sql.Date;
+import java.util.List;
+
+/**
+ * This class represents SubAwardService...
+ */
+public interface SubAwardService {
+
+    /**.
+     * Create new version of the Subaward document
+     * @param subAwardDocument
+     * @return
+     * @throws VersionException
+     */
+    public SubAwardDocument createNewSubAwardVersion(
+    SubAwardDocument subAwardDocument) throws VersionException,
+    WorkflowException;
+
+    /**.
+     * Update the subaward to use the new VersionStatus.
+     *  If the version status is ACTIVE, any other
+     *  active version of this
+     * subAward will be set to ARCHIVED.
+     * @param subAward
+     * @param status
+     */
+    public void updateSubAwardSequenceStatus(
+    SubAward subAward, VersionStatus status);
+
+    /**
+     * This method returns an unused SubAwardCode.
+     * @return
+     */
+    String getNextSubAwardCode();
+
+    /**
+     * This method will add AmountInfo details to subaward.
+     * @param subAward
+     * @return
+     */
+    public SubAward getAmountInfo(SubAward subAward);
+
+     /**.
+      * 
+      * This method returns the value of the parameter 'Subaward Follow Up'.
+      * @return
+      */
+     public String getFollowupDateDefaultLength();
+
+     /**
+      * 
+      * This method calculates a follow date based on
+      * getFollowupDateDefaultLength and the passed in baseDate.
+      * @param baseDate
+      * @return
+      */
+     public Date getCalculatedFollowupDate(Date baseDate);
+     
+     /**
+      * 
+      * This method returns a formatted Date string based on the base date.
+      * @param baseDate
+      * @return
+      */
+     public String getCalculatedFollowupDateForAjaxCall(String baseDate);
+
+     /**
+      *
+      * This method calls getFollowupDateDefaultLength
+      *  translates the value into days or weeks,
+      *   and then returns the value in days.
+      * @return
+      */
+     public int getFollowupDateDefaultLengthInDays();
+     
+     SubAward getActiveSubAward(Long subAwardCode);
+
+     List<SubAward> getLinkedSubAwards(Award award);
+}

--- a/src/main/java/org/kuali/kra/subaward/service/SubAwardService.java
+++ b/src/main/java/org/kuali/kra/subaward/service/SubAwardService.java
@@ -19,10 +19,12 @@ import org.kuali.kra.award.home.Award;
 import org.kuali.kra.bo.versioning.VersionStatus;
 import org.kuali.kra.service.VersionException;
 import org.kuali.kra.subaward.bo.SubAward;
+import org.kuali.kra.subaward.bo.SubAwardFundingSource;
 import org.kuali.kra.subaward.document.SubAwardDocument;
 import org.kuali.rice.kew.api.exception.WorkflowException;
 
 import java.sql.Date;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -97,7 +99,60 @@ public interface SubAwardService {
       */
      public int getFollowupDateDefaultLengthInDays();
      
+     
+     /**
+     *
+     * This method returns the Active Version for the SubAward specified with the subAwardCode
+     * (using the VersionHistory service)
+     */
      SubAward getActiveSubAward(Long subAwardCode);
 
-     List<SubAward> getLinkedSubAwards(Award award);
+     /**
+     *
+     * This method finds all the linked SubAwards through SubAwardFundingSource for an Award
+     * It returns only the 'Active' versions of the corresponding SubAwards. Each linked Subaward is returned only once.
+     * @return List<SubAward>
+     */
+     public Collection<SubAward> getLinkedSubAwards(Award award);
+     
+     /**
+     *
+     * This method finds all the linked Awards through SFS for a SubAward
+     * It returns only the 'Active' versions of the corresponding Awards. Each linked Award is returned only once.
+     * @return List<SubAward>
+     */
+     public Collection<Award> getLinkedAwards(SubAward subAward);
+     
+     /**
+     *
+     * This method finds all the SubAwardFundingSources in the DB marked with the same SubAward code and Award Number and
+     * sets the active flag to false for all of them.
+     * 
+     */
+     public void deleteSubAwardFundingSource(SubAwardFundingSource sfs);
+     
+     /**
+     *
+     * This method finds all the SubAwardFundingSources in the DB marked with the same SubAward code and Award Number and
+     * sets the active flag to false for all of them.
+     * 
+     */
+     public void deleteSubAwardFundingSource(String awardNumber, String subAwardCode);
+     
+     /**
+     *
+     * This method returns all the ACTIVE SubAwardFundingSources related to a certain Award by AwardNumber
+     */
+     public Collection<SubAwardFundingSource> getActiveSubAwardFundingSources(Award award);
+     
+     
+     /**
+     *
+     * This method returns all the ACTIVE SubAwardFundingSources related to a certain SubAward by SubAwardCode
+     * 
+     */
+     public Collection<SubAwardFundingSource> getActiveSubAwardFundingSources(SubAward subAward);
+
+     
+     
 }

--- a/src/main/java/org/kuali/kra/subaward/service/impl/SubAwardServiceImpl.java
+++ b/src/main/java/org/kuali/kra/subaward/service/impl/SubAwardServiceImpl.java
@@ -21,15 +21,15 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.time.DateUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.kuali.kra.award.home.Award;
-import org.kuali.kra.bo.versioning.VersionHistory;
 import org.kuali.kra.bo.versioning.VersionStatus;
 import org.kuali.kra.infrastructure.Constants;
+import org.kuali.kra.protocol.ProtocolDaoOjbBase;
 import org.kuali.kra.service.VersionException;
 import org.kuali.kra.service.VersionHistoryService;
 import org.kuali.kra.service.VersioningService;
@@ -37,6 +37,7 @@ import org.kuali.kra.subaward.bo.SubAward;
 import org.kuali.kra.subaward.bo.SubAwardAmountInfo;
 import org.kuali.kra.subaward.bo.SubAwardAmountReleased;
 import org.kuali.kra.subaward.bo.SubAwardFundingSource;
+import org.kuali.kra.subaward.dao.SubAwardFundingSourceDao;
 import org.kuali.kra.subaward.document.SubAwardDocument;
 import org.kuali.kra.subaward.service.SubAwardService;
 import org.kuali.rice.core.api.util.type.KualiDecimal;
@@ -60,6 +61,10 @@ public class SubAwardServiceImpl implements SubAwardService {
     private DocumentService documentService;
     private SequenceAccessorService sequenceAccessorService;
     private ParameterService parameterService;
+    private SubAwardFundingSourceDao subAwardFundingSourceDao;
+
+    private static final Log LOG = LogFactory.getLog(SubAwardService.class);
+  
 
     /**.
      * This method is for creating new subAward version
@@ -178,9 +183,7 @@ public class SubAwardServiceImpl implements SubAwardService {
 
 	/** {@inheritDoc} */
     public String getNextSubAwardCode() {
- Long nextAwardNumber = sequenceAccessorService.
- getNextAvailableSequenceNumber(Constants.SUBAWARD_SEQUENCE_SUBAWARD_CODE);
-
+        Long nextAwardNumber = sequenceAccessorService.getNextAvailableSequenceNumber(Constants.SUBAWARD_SEQUENCE_SUBAWARD_CODE);
         return nextAwardNumber.toString();
     }
     /**
@@ -291,6 +294,7 @@ public class SubAwardServiceImpl implements SubAwardService {
             } catch (Exception e) {
                 e.printStackTrace();
                 // something wasn't a number or a valid date element;
+                LOG.error(e);
             }
         }
         return empty;
@@ -330,29 +334,73 @@ public class SubAwardServiceImpl implements SubAwardService {
     }
 
     @Override
-    public List<SubAward> getLinkedSubAwards(Award award) {
-        Map<String, Object> values = new HashMap<String, Object>();
-        values.put("awardId", award.getAwardId());
-        Collection<SubAwardFundingSource> subAwardFundingSources = businessObjectService.findMatching(SubAwardFundingSource.class, values);
-        Set<String> subAwardSet = new TreeSet<String>();
-        for(SubAwardFundingSource subAwardFundingSource : subAwardFundingSources){
-            subAwardSet.add(subAwardFundingSource.getSubAward().getSubAwardCode());
+    public Collection<SubAward> getLinkedSubAwards(Award award){
+        try {
+            return getSubAwardFundingSourceDao().getLinkedSubAwards(award);
+        } catch (Exception e){
+            e.printStackTrace();
+            LOG.error(e);
         }
-        List<SubAward> subAwards = new ArrayList<SubAward>();
-        for (String subAwardCode : subAwardSet) {
-            VersionHistory activeVersion = getVersionHistoryService().findActiveVersion(SubAward.class, subAwardCode);
-            if (activeVersion == null) {
-                VersionHistory pendingVersion = getVersionHistoryService().findPendingVersion(SubAward.class, subAwardCode);
-                if (pendingVersion != null) {
-                    subAwards.add((SubAward) pendingVersion.getSequenceOwner());
-                }
-            } else {
-                subAwards.add((SubAward) activeVersion.getSequenceOwner());
-            }
-        }
-        return subAwards;
+        return new ArrayList<SubAward>();
     }
 
+
+    @Override
+    public Collection<Award> getLinkedAwards(SubAward subAward) {
+        try {
+            return getSubAwardFundingSourceDao().getLinkedAwards(subAward);
+        } catch (Exception e){
+            e.printStackTrace();
+            LOG.error(e);
+        }
+        return new ArrayList<Award>();
+    }
+    
+    @Override
+    public void deleteSubAwardFundingSource(String awardNumber, String subAwardCode) {
+        LOG.debug("Deleting SubAwardFundingSource: award="+awardNumber+" subaward="+subAwardCode);
+        try {
+            getSubAwardFundingSourceDao().deleteSubAwardFundingSource(awardNumber, subAwardCode);
+        } catch (Exception e){
+            e.printStackTrace();
+            LOG.error(e);
+        }
+    }
+
+    @Override
+    public void deleteSubAwardFundingSource(SubAwardFundingSource sfs) {
+        LOG.debug("Deleting SubAwardFundingSource:"+sfs.getSubAwardFundingSourceId()+" award="+sfs.getAwardNumber()+" subaward="+sfs.getSubAwardCode());
+        try {
+            getSubAwardFundingSourceDao().deleteSubAwardFundingSource(sfs);
+        } catch (Exception e){
+            e.printStackTrace();
+            LOG.error(e);
+        }
+    }
+    
+    /* (non-Javadoc)
+     * @see org.kuali.kra.subaward.service.SubAwardService#getActiveSubAwardFundingSources(org.kuali.kra.award.home.Award)
+     */
+    @Override
+    public Collection<SubAwardFundingSource> getActiveSubAwardFundingSources(Award award){
+        Map<String, Object> values = new HashMap<String, Object>();
+        values.put("awardNumber", award.getAwardNumber());
+        values.put("active", Boolean.TRUE );
+        return businessObjectService.findMatching(SubAwardFundingSource.class, values); 
+    }
+
+    
+    /* (non-Javadoc)
+     * @see org.kuali.kra.subaward.service.SubAwardService#getActiveSubAwardFundingSources(org.kuali.kra.award.home.Award)
+     */
+    @Override
+    public Collection<SubAwardFundingSource> getActiveSubAwardFundingSources(SubAward subAward){
+        Map<String, Object> values = new HashMap<String, Object>();
+        values.put("subAwardCode", subAward.getSubAwardCode());
+        values.put("active", Boolean.TRUE );
+        return businessObjectService.findMatching(SubAwardFundingSource.class, values);
+    }
+    
     public VersionHistoryService getVersionHistoryService() {
         return versionHistoryService;
     }
@@ -360,4 +408,13 @@ public class SubAwardServiceImpl implements SubAwardService {
     public void setVersionHistoryService(VersionHistoryService versionHistoryService) {
         this.versionHistoryService = versionHistoryService;
     }
+    
+    public SubAwardFundingSourceDao getSubAwardFundingSourceDao() {
+        return subAwardFundingSourceDao;
+    }
+
+    public void setSubAwardFundingSourceDao(SubAwardFundingSourceDao subAwardFundingSourceDao) {
+        this.subAwardFundingSourceDao = subAwardFundingSourceDao;
+    }
+
 }

--- a/src/main/java/org/kuali/kra/subaward/subawardrule/SubAwardDocumentRule.java
+++ b/src/main/java/org/kuali/kra/subaward/subawardrule/SubAwardDocumentRule.java
@@ -74,7 +74,7 @@ AddSubAwardAttachmentRule,SubAwardTemplateInfoRule {
     private static final String DATE_FLLOWUP = "newSubAwardCloseout.dateFollowup";
     private static final String REPORT_TYPE = "subAwardAttachmentFormBean.newReport.subAwardReportTypeCode";
     
-    private static final String AWARD_NUMBER="newSubAwardFundingSource.award.awardNumber";
+    private static final String AWARD_NUMBER="newSubAwardFundingSource.awardNumber";
     private static final String AMOUNT_PERIOD_OF_PERFORMANCE_START_DATE = "newSubAwardAmountInfo.periodofPerformanceStartDate";
     private static final org.apache.commons.logging.Log LOG = org.apache.commons.logging.LogFactory.getLog(SubAwardDocumentRule.class);
     /**.
@@ -283,7 +283,7 @@ AddSubAwardAttachmentRule,SubAwardTemplateInfoRule {
         }  
         else{
             for(SubAwardFundingSource fundingSource : subAward.getSubAwardFundingSourceList()){
-                if(fundingSource.getAwardId().equals(subAwardFundingSource.getAwardId())){
+                if(fundingSource.isActive() && fundingSource.getAwardId().equals(subAwardFundingSource.getAwardId())){
                     rulePassed = false;
                     AwardService awardService = KraServiceLocator.getService(AwardService.class);
                     Award award = awardService.getAward(fundingSource.getAwardId());

--- a/src/main/java/org/kuali/kra/subaward/web/SubAwardFundingSourceBean.java
+++ b/src/main/java/org/kuali/kra/subaward/web/SubAwardFundingSourceBean.java
@@ -1,0 +1,44 @@
+package org.kuali.kra.subaward.web;
+
+import java.io.Serializable;
+
+import org.kuali.kra.award.home.Award;
+import org.kuali.kra.subaward.bo.SubAward;
+
+public class SubAwardFundingSourceBean implements Serializable {
+    private static final long serialVersionUID = -8203046483314128290L;
+    
+    private String subAwardFundingSourceId;
+    private SubAward subaward;
+    private Award award;
+    
+    public SubAwardFundingSourceBean() {
+        super();
+    }
+    
+    public SubAwardFundingSourceBean(String subAwardFundingSourceId, SubAward subaward, Award award) {
+        super();
+        this.subAwardFundingSourceId = subAwardFundingSourceId;
+        this.subaward = subaward;
+        this.award = award;
+    }
+    
+    public String getSubAwardFundingSourceId() {
+        return subAwardFundingSourceId;
+    }
+    public void setSubAwardFundingSourceId(String subAwardFundingSourceId) {
+        this.subAwardFundingSourceId = subAwardFundingSourceId;
+    }
+    public SubAward getSubaward() {
+        return subaward;
+    }
+    public void setSubaward(SubAward subaward) {
+        this.subaward = subaward;
+    }
+    public Award getAward() {
+        return award;
+    }
+    public void setAward(Award award) {
+        this.award = award;
+    }
+}

--- a/src/main/java/org/kuali/kra/subaward/web/struts/action/SubAwardAction.java
+++ b/src/main/java/org/kuali/kra/subaward/web/struts/action/SubAwardAction.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
+import org.kuali.kra.award.home.Award;
 import org.kuali.kra.bo.versioning.VersionStatus;
 import org.kuali.kra.common.notification.service.KcNotificationService;
 import org.kuali.kra.infrastructure.Constants;
@@ -48,6 +49,7 @@ import org.kuali.kra.subaward.document.SubAwardDocument;
 import org.kuali.kra.subaward.notification.SubAwardNotificationContext;
 import org.kuali.kra.subaward.service.SubAwardService;
 import org.kuali.kra.subaward.subawardrule.SubAwardDocumentRule;
+import org.kuali.kra.subaward.web.SubAwardFundingSourceBean;
 import org.kuali.kra.subawardReporting.printing.SubAwardPrintType;
 import org.kuali.kra.subawardReporting.printing.service.SubAwardPrintingService;
 import org.kuali.kra.web.struts.action.AuditActionHelper;
@@ -143,14 +145,13 @@ public class SubAwardAction extends KraTransactionalDocumentActionBase{
             , HttpServletRequest request, HttpServletResponse response) throws Exception {
         SubAwardForm subAwardForm = (SubAwardForm) form;
         ActionForward forward;
-        forward = handleDocument(
-        mapping, form, request, response, subAwardForm);
-        SubAwardDocument subAwardDocument =
-        (SubAwardDocument) subAwardForm.getDocument();
+        forward = handleDocument(mapping, form, request, response, subAwardForm);
+        SubAwardDocument subAwardDocument = (SubAwardDocument) subAwardForm.getDocument();
         subAwardForm.initializeFormOrDocumentBasedOnCommand();
         SubAward subAward = KraServiceLocator.getService(
         SubAwardService.class).getAmountInfo(subAwardDocument.getSubAward());
         subAwardForm.getSubAwardDocument().setSubAward(subAward);
+        subAwardForm.setFilteredSubAwardFundingSources(findSFSForDisplay(subAwardDocument));
         return forward;
     }
 
@@ -657,5 +658,18 @@ protected void checkSubAwardTemplateCode(SubAward subAward){
       
       return  mapping.findForward(Constants.MAPPING_BASIC);
   }
+ 
+     protected List<SubAwardFundingSourceBean> findSFSForDisplay(SubAwardDocument subAwardDocument){
+         List<SubAwardFundingSourceBean> sfs = new ArrayList<SubAwardFundingSourceBean>();
+         SubAward subAward = subAwardDocument.getSubAward();
+         Collection<Award> linkedAwards = getSubAwardService().getLinkedAwards(subAward);
+         int idx=0;
+         for (Award award:linkedAwards){
+             SubAwardFundingSourceBean sfsForDisplay = new SubAwardFundingSourceBean(String.valueOf(idx++),subAward, award);
+             sfs.add(sfsForDisplay);
+         }
+    
+         return sfs;
+     }
 }
 

--- a/src/main/java/org/kuali/kra/subaward/web/struts/action/SubAwardHomeAction.java
+++ b/src/main/java/org/kuali/kra/subaward/web/struts/action/SubAwardHomeAction.java
@@ -1,0 +1,476 @@
+/*
+ * Copyright 2005-2014 The Kuali Foundation
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.opensource.org/licenses/ecl1.php
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kuali.kra.subaward.web.struts.action;
+
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.kuali.kra.award.AwardForm;
+import org.kuali.kra.award.home.ContactType;
+import org.kuali.kra.bo.versioning.VersionHistory;
+import org.kuali.kra.bo.versioning.VersionStatus;
+import org.kuali.kra.infrastructure.Constants;
+import org.kuali.kra.infrastructure.KraServiceLocator;
+import org.kuali.kra.subaward.SubAwardForm;
+import org.kuali.kra.subaward.bo.SubAward;
+import org.kuali.kra.subaward.bo.SubAwardCloseout;
+import org.kuali.kra.subaward.bo.SubAwardContact;
+import org.kuali.kra.subaward.bo.SubAwardForms;
+import org.kuali.kra.subaward.bo.SubAwardFundingSource;
+import org.kuali.kra.subaward.document.SubAwardDocument;
+import org.kuali.kra.subaward.subawardrule.SubAwardDocumentRule;
+import org.kuali.rice.core.api.util.KeyValue;
+import org.kuali.rice.kew.api.exception.WorkflowException;
+import org.kuali.rice.kns.question.ConfirmationQuestion;
+import org.kuali.rice.krad.service.BusinessObjectService;
+import org.kuali.rice.krad.util.GlobalVariables;
+import org.kuali.rice.krad.util.KRADConstants;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * This class is using as SubAwardHomeAction ...
+ */
+public class SubAwardHomeAction extends SubAwardAction{
+
+private static final String DOC_HANDLER_URL_PATTERN =
+"%s/DocHandler.do?command=displayDocSearchView&docId=%s";
+private static final String SUBAWARD_VERSION_EDITPENDING_PROMPT_KEY = "message.subaward.version.editpending.prompt";
+
+    @Override
+    public ActionForward execute(ActionMapping mapping,
+    ActionForm form, HttpServletRequest request, HttpServletResponse response)
+            throws Exception {
+        ActionForward actionForward =
+        super.execute(mapping, form, request, response);
+        SubAwardForm subAwardForm = (SubAwardForm) form;
+        List<SubAwardForms> subAwardList = new ArrayList<SubAwardForms>();
+        Collection<SubAwardForms> subAwardForms = (Collection<SubAwardForms>) KraServiceLocator.getService(BusinessObjectService.class).findAll(SubAwardForms.class);
+        for(SubAwardForms subAwardFormValues : subAwardForms){
+        if(subAwardFormValues.getTemplateTypeCode().equals(2)){
+            subAwardList.add(subAwardFormValues);
+        }
+        }
+        subAwardForm.getSubAward().setSubAwardForms(subAwardList);
+        return actionForward;
+    }
+
+    @Override
+    public ActionForward save(ActionMapping mapping, ActionForm form,
+    HttpServletRequest request, HttpServletResponse response) throws Exception {
+        SubAwardForm subAwardForm = (SubAwardForm) form;
+
+        ActionForward forward = super.save(mapping, form, request, response);
+       return forward;
+    }
+    @SuppressWarnings("unchecked")
+    @Override
+    public ActionForward refresh(ActionMapping mapping, ActionForm form,
+    HttpServletRequest request, HttpServletResponse response)
+            throws Exception {
+        super.refresh(mapping, form, request, response);
+        SubAwardForm subAwardMultiLookupForm = (SubAwardForm)form;
+        String lookupResultsBOClassName =
+        request.getParameter(KRADConstants.LOOKUP_RESULTS_BO_CLASS_NAME);
+        String lookupResultsSequenceNumber =
+        request.getParameter(KRADConstants.LOOKUP_RESULTS_SEQUENCE_NUMBER);
+        subAwardMultiLookupForm.setLookupResultsBOClassName(
+        lookupResultsBOClassName);
+        subAwardMultiLookupForm.
+        setLookupResultsSequenceNumber(lookupResultsSequenceNumber);
+        SubAward subAward = subAwardMultiLookupForm.
+        getSubAwardDocument().getSubAward();
+        return mapping.findForward(Constants.MAPPING_BASIC);
+    }
+
+    /**
+     * This method is used to handle the edit button
+     * action on an ACTIVE Subaward.
+     *  If no Pending version exists for the same
+     * subawardCode, a new Subaward version is created.
+     * If a Pending version exists,
+     * the user is prompted as to whether she would
+     * like to edit the Pending version. Answering Yes results in that Pending
+     * version SubAwardDocument to be opened. Answering No
+     * simply returns the user to the ACTIVE document screen
+     *
+     * @param mapping
+     * @param form
+     * @param request
+     * @param response
+     * @return
+     * @throws Exception
+     */
+    public ActionForward editOrVersion(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+                                        HttpServletResponse response) throws Exception {
+        SubAwardForm subAwardForm = ((SubAwardForm)form);
+        SubAwardDocument subAwardDocument = subAwardForm.getSubAwardDocument();
+        SubAward subaward = subAwardDocument.getSubAward();
+        ActionForward forward = null;
+
+        VersionHistory foundPending = findPendingVersion(subaward);
+        if (foundPending != null) {
+            Object question = request.getParameter(KRADConstants.QUESTION_CLICKED_BUTTON);
+            if (question == null) {
+                forward = showPromptForEditingPendingVersion(mapping, form, request, response);
+            } else {
+                forward = processPromptForEditingPendingVersionResponse(mapping, request, response, subAwardForm, foundPending);
+            }
+        } else {
+            forward = createAndSaveNewSubAwardVersion(response, subAwardForm, subAwardDocument, subaward);
+        }
+
+        return forward;
+    }
+    
+    /**
+     * This method find pending subaward versions.
+     * @param subaward
+     * @return VersionHistory
+     */
+    private VersionHistory findPendingVersion(SubAward subaward) {
+        List<VersionHistory> histories = getVersionHistoryService().loadVersionHistory(SubAward.class, subaward.getSubAwardCode());
+        VersionHistory foundPending = null;
+        for (VersionHistory history: histories) {
+            if (history.getStatus() == VersionStatus.PENDING && subaward.getSequenceNumber() < history.getSequenceOwnerSequenceNumber()) {
+                foundPending = history;
+                break;
+            }
+        }
+        return foundPending;
+    }
+    
+    /**
+     * This method shows prompt for editing pending subaward version.
+     * @param mapping
+     * @param form
+     * @param request
+     * @param response
+     * @return ActionForward
+     * @throws Exception
+     */
+    private ActionForward showPromptForEditingPendingVersion(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        return this.performQuestionWithoutInput(mapping, form, request, response, "EDIT_OR_VERSION_QUESTION_ID",
+                    getResources(request).getMessage(SUBAWARD_VERSION_EDITPENDING_PROMPT_KEY),
+                    KRADConstants.CONFIRMATION_QUESTION,
+                    KRADConstants.MAPPING_CANCEL, "");
+    }
+    
+    /**
+     * This method process the edit pending version prompt.
+     * @param mapping
+     * @param form
+     * @param request
+     * @param response
+     * @return ActionForward
+     * @throws WorkflowException,IOException
+     */
+    private ActionForward processPromptForEditingPendingVersionResponse(ActionMapping mapping, HttpServletRequest request,
+            HttpServletResponse response, SubAwardForm subAwardForm, 
+            VersionHistory foundPending) throws WorkflowException, 
+                                                IOException {
+        ActionForward forward;
+        Object buttonClicked = request.getParameter(KRADConstants.QUESTION_CLICKED_BUTTON);
+        if (ConfirmationQuestion.NO.equals(buttonClicked)) {
+            forward = mapping.findForward(Constants.MAPPING_SUBAWARD_PAGE);            
+        } else {
+            initializeFormWithSubAward(subAwardForm, (SubAward) foundPending.getSequenceOwner());
+            response.sendRedirect(makeDocumentOpenUrl(subAwardForm.getSubAwardDocument()));
+            forward = null;
+        }
+        return forward;
+    }
+    
+    private void initializeFormWithSubAward(SubAwardForm subAwardForm, SubAward subAward) throws WorkflowException {
+        reinitializeSubAwardForm(subAwardForm, findDocumentForSubAward(subAward));
+    }
+    
+    private SubAwardDocument findDocumentForSubAward(SubAward subAward) throws WorkflowException {
+        SubAwardDocument document = (SubAwardDocument) getDocumentService().getByDocumentHeaderId(subAward.getSubAwardDocument().getDocumentNumber());
+        document.setSubAward(subAward);
+        return document;
+    }
+
+    /**.
+     * This method is for createAndSaveNewSubAwardVersion
+     * @param response the Response
+     * @param subAwardForm the SubAwardForm
+     * @param subAwardDocument the SubAwrdDocument
+     * @param subAward the SubAward
+     * @return ActionForward
+     * @throws Exception
+     */
+    private ActionForward createAndSaveNewSubAwardVersion(
+    HttpServletResponse response, SubAwardForm subAwardForm,
+       SubAwardDocument subAwardDocument, SubAward subAward) throws Exception {
+       subAwardForm.getSubAwardDocument().getSubAward().setNewVersion(true);
+       SubAwardDocument newSubAwardDocument = getSubAwardService().createNewSubAwardVersion(subAwardForm.getSubAwardDocument());
+       getDocumentService().saveDocument(newSubAwardDocument);
+       getSubAwardService().updateSubAwardSequenceStatus(newSubAwardDocument.getSubAward(), VersionStatus.PENDING);
+       getVersionHistoryService().updateVersionHistory(newSubAwardDocument.getSubAward(), VersionStatus.PENDING, 
+               GlobalVariables.getUserSession().getPrincipalName());
+        reinitializeSubAwardForm(subAwardForm, newSubAwardDocument);
+        return new ActionForward(makeDocumentOpenUrl(newSubAwardDocument), true);
+    }
+
+    private String makeDocumentOpenUrl(SubAwardDocument newSubAwardDocument) {
+        String workflowUrl = getKualiConfigurationService().getPropertyValueAsString(KRADConstants.WORKFLOW_URL_KEY);
+        return String.format(DOC_HANDLER_URL_PATTERN, workflowUrl, newSubAwardDocument.getDocumentNumber());
+    }
+    /**.
+     * This method prepares the SubAwardForm with
+     * the document found via the SubAward lookup
+     * Because the helper beans may have preserved a different
+     *  SubAwardForm, we need to reset these too
+     * @param subAwardForm the SubAwardForm
+     * @param document the SubAwardDocument
+     * @throws WorkflowException
+     */
+    private void reinitializeSubAwardForm(SubAwardForm subAwardForm,
+    SubAwardDocument document) throws WorkflowException {
+   subAwardForm.populateHeaderFields(document.getDocumentHeader().
+   getWorkflowDocument());
+        subAwardForm.setDocument(document);
+        document.setDocumentSaveAfterSubAwardLookupEditOrVersion(true);
+        subAwardForm.initialize();
+    }
+
+    /**.
+     * This method is for addingFundingSource
+     * @param mapping the ActionMapping
+     * @param form the ActionForm
+     * @param request the Request
+     * @param response the Response
+     * @return ActionForward
+     * @throws Exception
+     */
+    public ActionForward addFundingSource(
+    ActionMapping mapping, ActionForm form, HttpServletRequest request,
+    HttpServletResponse response) throws Exception {
+        SubAwardForm subAwardForm = (SubAwardForm) form;
+        SubAward subAward = subAwardForm.getSubAwardDocument().getSubAward();
+        SubAwardFundingSource fundingSources=
+        subAwardForm.getNewSubAwardFundingSource();
+
+        if (new SubAwardDocumentRule().
+        processAddSubAwardFundingSourceBusinessRules(
+        fundingSources, subAward)) {
+            addFundingSourceToSubAward(
+            subAwardForm.getSubAwardDocument().getSubAward(), fundingSources);
+            subAwardForm.setNewSubAwardFundingSource(
+            new SubAwardFundingSource());
+        }
+        return mapping.findForward(Constants.MAPPING_SUBAWARD_PAGE);
+    }
+
+    /**.
+     * This method is for addingFundingSourceToSubAward
+     * @param fundingSources
+     * @param subAward the SubAward
+     * @param fundingSources the SubAwardFundingSource
+     * @return boolean
+     */
+    boolean addFundingSourceToSubAward(
+    SubAward subAward, SubAwardFundingSource fundingSources) {
+        if (subAward.getSubAwardCode() == null) {
+            String subAwardCode = getSubAwardService().getNextSubAwardCode();
+            subAward.setSubAwardCode(subAwardCode);
+        }
+        fundingSources.setSubAward(subAward);
+        return subAward.getSubAwardFundingSourceList().add(fundingSources);
+    }
+
+    /**.
+     * This method is deleteFundingSource
+      * @param mapping the ActionMapping
+     * @param form the ActionForm
+     * @param request the Request
+     * @param response the Response
+     * @return ActionForward
+     * @throws Exception
+     */
+    public ActionForward deleteFundingSource(ActionMapping mapping,
+    ActionForm form, HttpServletRequest request, HttpServletResponse response)
+    throws Exception {
+        SubAwardForm subAwardForm = (SubAwardForm) form;
+        SubAwardDocument subAwardDocument = subAwardForm.getSubAwardDocument();
+        int selectedLineNumber = getSelectedLine(request);
+        SubAwardFundingSource  subAwardFundingSource =
+        subAwardDocument.getSubAward().getSubAwardFundingSourceList().
+        get(selectedLineNumber);
+
+        subAwardDocument.getSubAward().
+        getSubAwardFundingSourceList().remove(selectedLineNumber);
+//      this.getBusinessObjectService().delete(subAwardFundingSource); // let save() do this
+        return mapping.findForward(Constants.MAPPING_SUBAWARD_PAGE);
+    }
+
+    /**
+     * This method is for adding contacts
+     * This method is for @throws Exception...
+     * @param mapping the ActionMapping
+     * @param form the ActionForm
+     * @param request the Request
+     * @param response the Response
+     * @return ActionForward
+     * @throws Exception
+     */
+    public ActionForward addContacts(ActionMapping mapping,
+    ActionForm form, HttpServletRequest request,
+        HttpServletResponse response) throws Exception {
+
+        SubAwardForm subAwardForm = (SubAwardForm) form;
+        SubAwardContact subAwardContact = subAwardForm.getNewSubAwardContact();
+        SubAward subAward = subAwardForm.getSubAwardDocument().getSubAward();
+
+        if (new SubAwardDocumentRule().
+        processAddSubAwardContactBusinessRules(
+        subAwardContact, subAward)) {
+            addContactsToSubAward(subAwardForm.
+            getSubAwardDocument().getSubAward(), subAwardContact);
+            subAwardForm.setNewSubAwardContact(new SubAwardContact());
+        }
+        return mapping.findForward(Constants.MAPPING_SUBAWARD_PAGE);
+    }
+
+    /**.
+     * This method is for addingContactsToSubAward
+     * @param subAward the SubAward
+     * @param subAwardContact the SubAwardContact
+     * @return boolean
+     */
+    boolean addContactsToSubAward(SubAward subAward,
+    SubAwardContact subAwardContact) {
+        if (subAward.getSubAwardCode() == null) {
+            String subAwardCode = getSubAwardService().getNextSubAwardCode();
+            subAward.setSubAwardCode(subAwardCode);
+        }
+        subAwardContact.setSubAward(subAward);
+        return subAward.getSubAwardContactsList().add(subAwardContact);
+    }
+
+    /**
+     * This method is for deleteContact
+    * @param mapping the ActionMapping
+     * @param form the ActionForm
+     * @param request the Request
+     * @param response the Response
+     * @return ActionForward
+     * @throws Exception
+     */
+    public ActionForward deleteContact(ActionMapping mapping,
+    ActionForm form, HttpServletRequest request, HttpServletResponse response)
+    throws Exception {
+        SubAwardForm subAwardForm = (SubAwardForm) form;
+        SubAwardDocument subAwardDocument = subAwardForm.getSubAwardDocument();
+        int selectedLineNumber = getSelectedLine(request);
+        SubAwardContact subAwardContact =
+        subAwardDocument.getSubAward().
+        getSubAwardContactsList().get(selectedLineNumber);
+        subAwardDocument.getSubAward().
+        getSubAwardContactsList().remove(selectedLineNumber);
+//      this.getBusinessObjectService().delete(subAwardContact); // let save() do this
+        return mapping.findForward(Constants.MAPPING_SUBAWARD_PAGE);
+    }
+
+    /**.
+     * This method is for addCloseouts
+     * @param mapping the ActionMapping
+     * @param form the ActionForm
+     * @param request the Request
+     * @param response the Response
+     * @return ActionForward
+     * @throws Exception
+     */
+    public ActionForward addCloseouts(ActionMapping mapping,
+    ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+
+        SubAwardForm subAwardForm = (SubAwardForm) form;
+        SubAwardCloseout subAwardCloseout =
+        subAwardForm.getNewSubAwardCloseout();
+
+        if (new SubAwardDocumentRule().
+        processAddSubAwardCloseoutBusinessRules(subAwardCloseout)) {
+            if (subAwardCloseout.getDateFollowup() == null) {
+                subAwardCloseout.setDateFollowup(
+                this.getSubAwardService().getCalculatedFollowupDate(
+                subAwardCloseout.getDateRequested()));
+            }
+            addCloseoutToSubAward(subAwardForm.
+            getSubAwardDocument().getSubAward(), subAwardCloseout);
+            subAwardForm.setNewSubAwardCloseout(new SubAwardCloseout());
+        }
+        return mapping.findForward(Constants.MAPPING_SUBAWARD_PAGE);
+    }
+
+    /**.
+     * This method is for addCloseoutToSubAward
+     * @param subAward the SubAward
+     * @param subAwardCloseout the SubAwardCloseout
+     * @return boolean
+     */
+    boolean addCloseoutToSubAward(SubAward subAward,
+    SubAwardCloseout subAwardCloseout) {
+        if (subAward.getSubAwardCode() == null) {
+            String subAwardCode = getSubAwardService().getNextSubAwardCode();
+            subAward.setSubAwardCode(subAwardCode);
+        }
+        subAwardCloseout.setSubAward(subAward);
+        return subAward.getSubAwardCloseoutList().add(subAwardCloseout);
+    }
+   /**.
+ * This method is for deleteCloseout
+    * @param mapping the ActionMapping
+     * @param form the ActionForm
+     * @param request the Request
+     * @param response the Response
+     * @return ActionForward
+     * @throws Exception
+ */
+public ActionForward deleteCloseout(ActionMapping mapping,
+		ActionForm form, HttpServletRequest request,
+		HttpServletResponse response) throws Exception {
+        SubAwardForm subAwardForm = (SubAwardForm) form;
+        SubAwardDocument subAwardDocument = subAwardForm.getSubAwardDocument();
+        int selectedLineNumber = getSelectedLine(request);
+        SubAwardCloseout subAwardCloseout =  subAwardDocument.
+        getSubAward().getSubAwardCloseoutList().get(selectedLineNumber);
+        subAwardDocument.getSubAward().
+        getSubAwardCloseoutList().remove(selectedLineNumber);
+//        this.getBusinessObjectService().delete(subAwardCloseout); // let save() do this
+        return mapping.findForward(Constants.MAPPING_SUBAWARD_PAGE);
+    }
+
+public ActionForward selectAllSubAwardPrintNoticeItems(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+    SubAwardForm subAwardForm = (SubAwardForm)form;
+    subAwardForm.getSubAwardPrintAgreement().selectAllItems();
+    return mapping.findForward(Constants.MAPPING_SUBAWARD_PAGE);
+}
+
+public ActionForward deselectAllSubAwardPrintNoticeItems(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+    SubAwardForm subAwardForm = (SubAwardForm)form;
+    subAwardForm.getSubAwardPrintAgreement().deselectAllItems();
+    return mapping.findForward(Constants.MAPPING_SUBAWARD_PAGE);
+}
+
+}

--- a/src/main/resources/edu/arizona/kc/db/changelog/changesets/db.changelog-UAR-1497.xml
+++ b/src/main/resources/edu/arizona/kc/db/changelog/changesets/db.changelog-UAR-1497.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+	<changeSet id="UAR-1497" author="Adam Kost">
+		<comment>
+			Adding the Award Number column to the SubAward Funding Source.
+		</comment>
+		<sql>
+			ALTER TABLE SUBAWARD_FUNDING_SOURCE ADD 
+                    (AWARD_NUMBER VARCHAR2(12 BYTE),
+                     ACTV_IND VARCHAR2(1) DEFAULT 'Y' NOT NULL);
+            UPDATE SUBAWARD_FUNDING_SOURCE sfs 
+                SET AWARD_NUMBER =
+                  ( SELECT AWARD_NUMBER FROM AWARD a
+                    WHERE a.AWARD_ID = sfs.AWARD_ID )
+            ;
+            ALTER TABLE SUBAWARD_FUNDING_SOURCE MODIFY (AWARD_NUMBER NOT NULL);
+		</sql>
+		<rollback>
+			ALTER TABLE SUBAWARD_FUNDING_SOURCE DROP COLUMN AWARD_NUMBER;
+            ALTER TABLE SUBAWARD_FUNDING_SOURCE DROP ACTIVE;
+		</rollback>
+	</changeSet>
+</databaseChangeLog> 

--- a/src/main/resources/edu/arizona/kc/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/edu/arizona/kc/db/changelog/db.changelog-master.xml
@@ -20,5 +20,6 @@
   <include file="changesets/db.changelog-UAR-1380.xml" />
   <include file="changesets/db.changelog-UAR-1444.xml" />
   <include file="changesets/db.changelog-UAR-973.xml" />
+  <include file="changesets/db.changelog-UAR-1497.xml" />
 </databaseChangeLog>
 

--- a/src/main/resources/org/kuali/kra/datadictionary/SubAwardFundingSource.xml
+++ b/src/main/resources/org/kuali/kra/datadictionary/SubAwardFundingSource.xml
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+ 
+ <bean id="SubAwardFundingSource" parent="SubAwardFundingSource-parentBean" />
+  <bean id="SubAwardFundingSource-parentBean" abstract="true" parent="BusinessObjectEntry">
+    <property name="businessObjectClass" value="org.kuali.kra.subaward.bo.SubAwardFundingSource" />
+		<property name="objectLabel" value="SubAwardFundingSource" />
+		    <property name="inquiryDefinition" >
+		      <ref bean="SubAwardFundingSource-inquiryDefinition" />
+		    </property>
+		    <property name="lookupDefinition" >
+		      <ref bean="SubAwardFundingSource-lookupDefinition" />
+		    </property>
+       		<property name="attributes" >
+		      <list>
+		      	<ref bean="SubAwardFundingSource-subAwardFundingSourceId" />
+		        <ref bean="SubAwardFundingSource-subAwardId" />	
+		        <ref bean="SubAwardFundingSource-awardId" />
+		        <ref bean="SubAwardFundingSource-accountNumber" />
+		        <ref bean="SubAwardFundingSource-statusCode" />
+		        <ref bean="SubAwardFundingSource-sponsorCode" />
+		        <ref bean="SubAwardFundingSource-amountObligatedToDate" /> 
+		   		<ref bean="SubAwardFundingSource-obligationExpirationDate" />
+		      </list>
+		    </property>
+		   
+ 		 </bean>
+
+<!-- Attribute Definitions -->
+    
+   <bean id="SubAwardFundingSource-subAwardFundingSourceId" parent="SubAwardFundingSource-subAwardFundingSourceId-parentBean" />
+  <bean id="SubAwardFundingSource-subAwardFundingSourceId-parentBean" abstract="true" parent="AttributeDefinition">
+       <property name="name" value="subAwardFundingSourceId" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Subaward Funding Source Id" />
+    <property name="shortLabel" value="Subaward Funding Source Id" />
+    <property name="maxLength" value="22" />
+    <property name="validationPattern" >
+      <bean parent="NumericValidationPattern" />
+    </property>
+    <property name="required" value="false" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+            p:size="15" />
+    </property>
+    <property name="summary" value="Subaward Funding Source Id" />
+    <property name="description" value="Subaward Funding Source Id" />    
+  </bean>
+  
+      <bean id="SubAwardFundingSource-subAwardId" parent="SubAwardFundingSource-subAwardId-parentBean" />
+  <bean id="SubAwardFundingSource-subAwardId-parentBean" abstract="true" parent="AttributeDefinition">
+       <property name="name" value="subAwardId" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Subaward Id" />
+    <property name="shortLabel" value="SubAwardId" />
+    <property name="maxLength" value="22" />
+    <property name="validationPattern" >
+      <bean parent="NumericValidationPattern" />
+    </property>
+    <property name="required" value="false" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+            p:size="15" />
+    </property>
+    <property name="summary" value="Subaward Id" />
+    <property name="description" value="Subaward Id" />    
+  </bean>
+
+  
+  <bean id="SubAwardFundingSource-awardId" parent="SubAwardFundingSource-awardId-parentBean" />
+  <bean id="SubAwardFundingSource-awardId-parentBean" abstract="true" parent="Award-awardNumber-parentBean">
+    <property name="name" value="awardId" />
+    <property name="label" value="Award Number" />
+    <property name="shortLabel" value="Award Number" />
+    <property name="required" value="true" />
+     <property name="summary" value="Award Number" />
+    <property name="description" 
+    	value="A unique institutionally assigned number of a previously funded application." />
+    <property name="validationPattern">
+			<bean parent="AnyCharacterValidationPattern"
+            p:allowWhitespace="true" />
+	</property>
+  </bean>
+  
+    <bean id="SubAwardFundingSource-accountNumber" parent="SubAwardFundingSource-accountNumber-parentBean" />
+  <bean id="SubAwardFundingSource-accountNumber-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="accountNumber" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Account ID" />
+    <property name="shortLabel" value="Account ID" />
+    <property name="maxLength" value="7" />
+    <property name="validationPattern" >
+      <bean parent="AlphaNumericValidationPattern" />
+    </property>
+    <property name="required" value="false" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+            p:size="12" />
+    </property>
+    <property name="summary" value="Account ID" />
+    <property name="description" value="Account ID" />
+  </bean>
+  
+  	<bean id="SubAwardFundingSource-statusCode" parent="SubAwardFundingSource-statusCode-parentBean" />
+	<bean id="SubAwardFundingSource-statusCode-parentBean" abstract="true" parent="AttributeDefinition">
+		<property name="name" value="statusCode" />
+		<property name="forceUppercase" value="false" />
+		<property name="label" value="Award status" />
+		<property name="shortLabel" value="Award statusCode" />
+		<property name="maxLength" value="150" />
+		<property name="validationPattern" >
+		  <bean parent="AnyCharacterValidationPattern" p:allowWhitespace="true" />
+		</property>
+		<property name="control" >
+		  <bean p:size="60" parent="TextControlDefinition" />
+		</property>
+		<property name="summary" value="Award statusCode" />
+		<property name="description" value="Award statusCode" />
+	</bean>
+  
+  <bean id="SubAwardFundingSource-sponsorCode" parent="SubAwardFundingSource-sponsorCode-parentBean" />
+  
+  <bean id="SubAwardFundingSource-sponsorCode-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="sponsorCode" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Sponsor ID" />
+    <property name="shortLabel" value="Sponsor" />
+    <property name="maxLength" value="6" />
+    <property name="validationPattern" >
+      <bean parent="AnyCharacterValidationPattern" />
+    </property>
+    <property name="required" value="false" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+            p:size="12" />
+    </property>
+    <property name="summary" value="Agency/Sponsor #" />
+    <property name="description" value="The identification number of the organization or agency that is providing support for the sponsored project." />
+  </bean>
+  
+   <bean id="SubAwardFundingSource-amountObligatedToDate" parent="SubAwardFundingSource-amountObligatedToDate-parentBean" />
+    <bean id="SubAwardFundingSource-amountObligatedToDate-parentBean" abstract="true" parent="AttributeDefinition" >
+        <property name="name" value="amountObligatedToDate" />
+        <property name="forceUppercase" value="false" />
+        <property name="label" value="Amount" />
+        <property name="shortLabel" value="Amount" />
+        <property name="maxLength" value="22" />
+        <property name="validationPattern" >
+	      	<bean parent="FixedPointValidationPattern"
+	            p:precision="12"
+	            p:scale="2"
+	            p:allowNegative="true" />
+    	</property>
+        <property name="control" >
+            <bean parent="TextControlDefinition"
+                p:size="10" />
+        </property>
+        <property name="summary" value="Amount" />
+        <property name="description" value="Amount" />
+    </bean>
+    
+    <bean id="SubAwardFundingSource-obligationExpirationDate" parent="SubAwardFundingSource-obligationExpirationDate-parentBean" />
+    <bean id="SubAwardFundingSource-obligationExpirationDate-parentBean" abstract="true" parent="KraAttributeReferenceDummy-genericDate" >
+        <property name="name" value="obligationExpirationDate" />
+        <property name="label" value="Final Expiration Date" />
+        <property name="shortLabel" value="Final Expiration Date" />
+        <property name="summary" value="Final Expiration Date" />
+        <property name="description" value="Final Expiration Date" />
+    </bean>
+ 
+   <bean id="SubAwardFundingSource-versionNumber" parent="SubAwardFundingSource-versionNumber-parentBean" />
+    <bean id="SubAwardFundingSource-versionNumber-parentBean" abstract="true" parent="AttributeReferenceDummy-versionNumber">
+    </bean>
+
+
+
+      <!-- Business Object Inquiry Definition -->
+ <bean id="SubAwardFundingSource-inquiryDefinition" parent="SubAwardFundingSource-inquiryDefinition-parentBean" />
+
+  <bean id="SubAwardFundingSource-inquiryDefinition-parentBean" abstract="true" parent="InquiryDefinition">
+    <property name="title" value="SubAwardFundingSource" />
+    <property name="inquirySections" >
+      <list>
+        <bean parent="InquirySectionDefinition">
+          <property name="title" value="SubAwardFundingSource" />
+          <property name="numberOfColumns" value="1" />
+          <property name="inquiryFields" >
+            <list>
+              <bean parent="FieldDefinition"
+                    p:attributeName="subAwardFundingSourceId"
+                    p:forceInquiry="true" />             
+            </list>
+          </property>
+        </bean>
+      </list>
+    </property>
+  </bean>
+  
+  <!-- Business Object Lookup Definition -->
+
+  <bean id="SubAwardFundingSource-lookupDefinition" parent="SubAwardFundingSource-lookupDefinition-parentBean" />
+
+  <bean id="SubAwardFundingSource-lookupDefinition-parentBean" abstract="true" parent="LookupDefinition">
+    <property name="title" value="Subaward Funding Source Lookup" />
+    <property name="menubar" value="&lt;a href=&quot;index.jsp&quot;&gt;Main&lt;/a&gt;" />
+
+    <property name="defaultSort" >
+      <bean parent="SortDefinition">
+      </bean>
+    </property>
+    <property name="lookupFields" >
+      <list>
+        <bean parent="FieldDefinition"
+                    p:attributeName="subAwardFundingSourceId"
+                    p:forceInquiry="true" />
+                   
+               
+      </list>
+    </property>
+    <property name="resultFields" >
+      <list>      
+                 <bean parent="FieldDefinition" p:attributeName="subAwardFundingSourceId" p:forceInquiry="true" />   
+                <bean p:attributeName="awardId"   parent="FieldDefinition"/>
+                    <bean p:attributeName="subAwardCode"   parent="FieldDefinition"/>
+      </list>
+    </property>
+  </bean>
+ 
+</beans>
+
+          
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/main/resources/org/kuali/kra/datadictionary/SubAwardFundingSource.xml
+++ b/src/main/resources/org/kuali/kra/datadictionary/SubAwardFundingSource.xml
@@ -21,6 +21,7 @@
 		      	<ref bean="SubAwardFundingSource-subAwardFundingSourceId" />
 		        <ref bean="SubAwardFundingSource-subAwardId" />	
 		        <ref bean="SubAwardFundingSource-awardId" />
+                <ref bean="SubAwardFundingSource-awardNumber" />
 		        <ref bean="SubAwardFundingSource-accountNumber" />
 		        <ref bean="SubAwardFundingSource-statusCode" />
 		        <ref bean="SubAwardFundingSource-sponsorCode" />
@@ -73,19 +74,34 @@
 
   
   <bean id="SubAwardFundingSource-awardId" parent="SubAwardFundingSource-awardId-parentBean" />
-  <bean id="SubAwardFundingSource-awardId-parentBean" abstract="true" parent="Award-awardNumber-parentBean">
+  <bean id="SubAwardFundingSource-awardId-parentBean" abstract="true" parent="Award-awardId-parentBean">
     <property name="name" value="awardId" />
+    <property name="label" value="Award Id" />
+    <property name="shortLabel" value="Award Id" />
+    <property name="required" value="false" />
+    <property name="summary" value="Award Id" />
+    <property name="description" value="Award Id" />
+    <property name="maxLength" value="12" />
+    <property name="validationPattern" >
+      <bean parent="NumericValidationPattern" />
+    </property>
+  </bean>
+  
+  <bean id="SubAwardFundingSource-awardNumber" parent="SubAwardFundingSource-awardNumber-parentBean" />
+  <bean id="SubAwardFundingSource-awardNumber-parentBean" abstract="true" parent="Award-awardNumber-parentBean">
+    <property name="name" value="awardNumber" />
     <property name="label" value="Award Number" />
     <property name="shortLabel" value="Award Number" />
     <property name="required" value="true" />
      <property name="summary" value="Award Number" />
     <property name="description" 
-    	value="A unique institutionally assigned number of a previously funded application." />
+        value="A unique institutionally assigned number of a previously funded application." />
     <property name="validationPattern">
-			<bean parent="AnyCharacterValidationPattern"
+            <bean parent="AnyCharacterValidationPattern"
             p:allowWhitespace="true" />
-	</property>
+    </property>
   </bean>
+ 
   
     <bean id="SubAwardFundingSource-accountNumber" parent="SubAwardFundingSource-accountNumber-parentBean" />
   <bean id="SubAwardFundingSource-accountNumber-parentBean" abstract="true" parent="AttributeDefinition">
@@ -208,25 +224,20 @@
   <bean id="SubAwardFundingSource-lookupDefinition-parentBean" abstract="true" parent="LookupDefinition">
     <property name="title" value="Subaward Funding Source Lookup" />
     <property name="menubar" value="&lt;a href=&quot;index.jsp&quot;&gt;Main&lt;/a&gt;" />
-
     <property name="defaultSort" >
       <bean parent="SortDefinition">
       </bean>
     </property>
     <property name="lookupFields" >
       <list>
-        <bean parent="FieldDefinition"
-                    p:attributeName="subAwardFundingSourceId"
-                    p:forceInquiry="true" />
-                   
-               
+        <bean parent="FieldDefinition" p:attributeName="subAwardFundingSourceId" p:forceInquiry="true" />
       </list>
     </property>
     <property name="resultFields" >
       <list>      
-                 <bean parent="FieldDefinition" p:attributeName="subAwardFundingSourceId" p:forceInquiry="true" />   
-                <bean p:attributeName="awardId"   parent="FieldDefinition"/>
-                    <bean p:attributeName="subAwardCode"   parent="FieldDefinition"/>
+           <bean parent="FieldDefinition" p:attributeName="subAwardFundingSourceId" p:forceInquiry="true" />   
+           <bean p:attributeName="awardId"   parent="FieldDefinition"/>
+           <bean p:attributeName="subAwardCode"   parent="FieldDefinition"/>
       </list>
     </property>
   </bean>

--- a/src/main/resources/org/kuali/kra/subaward/SubAwardSpringBeans.xml
+++ b/src/main/resources/org/kuali/kra/subaward/SubAwardSpringBeans.xml
@@ -1,0 +1,255 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	Copyright 2005-2014 The Kuali Foundation.
+
+	Licensed under the Educational Community License, Version 1.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+R
+	http://www.opensource.org/licenses/ecl1.php
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+       xmlns:p="http://www.springframework.org/schema/p" 
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xmlns:beans="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:lang="http://www.springframework.org/schema/lang"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="http://www.springframework.org/schema/aop
+                           http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                           http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                           http://www.springframework.org/schema/context
+                           http://www.springframework.org/schema/context/spring-context-3.0.xsd
+                           http://www.springframework.org/schema/lang
+                           http://www.springframework.org/schema/lang/spring-lang-3.0.xsd
+                           http://www.springframework.org/schema/tx
+                           http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                           http://www.springframework.org/schema/util
+                           http://www.springframework.org/schema/util/spring-util-3.0.xsd">
+                           
+    <import resource="classpath:org/kuali/rice/core/RiceJTASpringBeans.xml" />
+    <import resource="classpath:org/kuali/kra/KC-RiceDataSourceSpringBeans.xml" />
+    <import resource="classpath:org/kuali/kra/core/CommonSpringBeans.xml" />
+    
+    <bean id="subAwardModule" class="org.kuali.rice.krad.service.impl.ModuleServiceBase">
+        <property name="moduleConfiguration" ref="subAwardModuleConfiguration"/>
+        <property name="kualiModuleService" ref="kualiModuleService"/>
+    </bean>
+  	
+    <bean id="subAwardModuleConfiguration" parent="subAwardModuleConfiguration-parentBean" />
+    <bean id="subAwardModuleConfiguration-parentBean" class="org.kuali.rice.krad.bo.ModuleConfiguration" abstract="true">
+    	<property name="namespaceCode" value="KC-AWARD" />
+    	<property name="packagePrefixes">
+            <list>
+                <value>org.kuali.kra.subaward</value>
+            </list>
+        </property>
+		<property name="databaseRepositoryFilePaths">
+			<list>
+				<value>org/kuali/kra/subaward/repository-subAward.xml</value>				
+			</list>
+		</property>
+	</bean>
+	<bean id="dateTimeService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="dateTimeService" />
+    </bean>
+    
+    <bean id="businessObjectService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="businessObjectService" />
+    </bean>
+    
+    <bean id="businessObjectDictionaryService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="businessObjectDictionaryService" />
+    </bean>
+    
+    <bean id="businessObjectMetaDataService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="businessObjectMetaDataService" />
+    </bean>
+    
+    <bean id="dataDictionaryService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="dataDictionaryService" />
+    </bean>
+    
+    <bean id="documentService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="documentService" />
+    </bean>
+    
+    <bean id="encryptionService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="encryptionService" />
+    </bean>
+    
+    <bean id="kraAuthorizationService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="kraAuthorizationService" />
+    </bean>
+    
+    <bean id="kcPersonService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="kcPersonService" />
+    </bean>
+    
+    <bean id="kraWorkflowService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="kraWorkflowService" />
+    </bean>
+    
+    <bean id="kualiModuleService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="kualiModuleService" />
+    </bean>
+    
+    <bean id="lookupService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="lookupService" />
+    </bean>
+    
+    <bean id="lookupResultsService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="lookupResultsService" />
+    </bean>
+    
+    <bean id="parameterService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="parameterService" />
+    </bean>
+    
+    <bean id="persistenceStructureService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="persistenceStructureService" />
+    </bean>
+    
+    <bean id="persistenceStructureServiceOjb" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="persistenceStructureServiceOjb" />
+    </bean>
+    
+    <bean id="persistenceStructureServiceJpa" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="persistenceStructureServiceJpa" />
+    </bean>
+    
+    <bean id="sequenceAccessorService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="sequenceAccessorService" />
+    </bean>
+    
+    <bean id="subAwardNotificationRoleQualifierService" class="org.kuali.kra.subaward.notification.SubAwardNotificationRoleQualifierServiceImpl" scope="prototype" />
+    
+    <bean id="unitAuthorizationService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="unitAuthorizationService" />
+    </bean>
+    
+    <bean id="versioningService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="versioningService" />
+    </bean>
+    
+    <bean id="versionHistoryService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="versionHistoryService" />
+    </bean>
+	
+    <bean id="parentLookupableHelperService" abstract="true">
+        <property name="persistenceStructureService" ref="persistenceStructureService" />
+        <property name="businessObjectDictionaryService" ref="businessObjectDictionaryService" />
+        <property name="dataDictionaryService" ref="dataDictionaryService" />
+        <property name="encryptionService" ref="encryptionService" />
+        <property name="lookupService" ref="lookupService" />
+        <property name="businessObjectMetaDataService" ref="businessObjectMetaDataService" />
+        <property name="sequenceAccessorService" ref="sequenceAccessorService" />
+        <property name="businessObjectService" ref="businessObjectService" />
+        <property name="lookupResultsService" ref="lookupResultsService" />
+    </bean>
+    
+    <!-- SubAward Services -->
+    <bean id="subAwardPrintingService" class="org.kuali.kra.subawardReporting.printing.service.impl.SubAwardPrintingServiceImpl">
+    	<property name="subAwardSF294Print" ref="subAwardSF294Print" />
+    	<property name="subAwardSF295Print" ref="subAwardSF295Print" />
+    	<property name="printingService" ref="printingService" />
+    	<property name="subAwardFDPAgreement" ref="subAwardFDPAgreement" />
+    	<property name="subAwardFDPModification" ref="subAwardFDPModification" />
+    </bean>
+    
+    <bean id="subAwardSF294Print" class="org.kuali.kra.subawardReporting.printing.print.SubAwardSF294Print">
+        <property name="xmlStream" ref="subawardXmlStream" />
+    </bean>
+    <bean id="subAwardSF295Print" class="org.kuali.kra.subawardReporting.printing.print.SubAwardSF295Print">
+        <property name="xmlStream" ref="subawardXmlStream" />
+    </bean>
+    
+    <bean id="subawardXmlStream" class="org.kuali.kra.subawardReporting.printing.xmlstream.SubawardXmlStream">
+        <property name="businessObjectService" ref="businessObjectService" />
+    </bean>
+    
+    <bean id="printingService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="printingService" />
+    </bean>
+    
+    <bean id="subAwardFDPAgreement" class="org.kuali.kra.subawardReporting.printing.print.SubAwardFDPAgreement">
+        <property name="xmlStream" ref="subAwardFDPPrintXmlStream" />
+    </bean>
+    
+    <bean id="subAwardFDPModification" class="org.kuali.kra.subawardReporting.printing.print.SubAwardFDPModification">
+        <property name="xmlStream" ref="subAwardFDPPrintXmlStream" />
+    </bean>
+    
+    <bean id="subAwardFDPPrintXmlStream" class="org.kuali.kra.subawardReporting.printing.xmlstream.SubAwardFDPPrintXmlStream">
+        <property name="dateTimeService" ref="dateTimeService" />
+        <property name="businessObjectService" ref="businessObjectService" />
+    </bean>
+    
+    <bean id="subAwardService" class="org.kuali.kra.subaward.service.impl.SubAwardServiceImpl">
+        <property name="businessObjectService" ref="businessObjectService" />
+        <property name="documentService" ref="documentService" />
+        <property name="versioningService" ref="versioningService" />
+        <property name="sequenceAccessorService" ref="sequenceAccessorService" />
+        <property name="parameterService" ref="parameterService" />
+        <property name="versionHistoryService" ref="versionHistoryService" />
+    </bean>
+    
+	<bean id="subAwardLookupable" class="org.kuali.rice.kns.lookup.KualiLookupableImpl" scope="prototype">
+  		<property name="lookupableHelperService" ref="subAwardLookupableHelperService" />  
+	</bean>
+	
+	<bean id="subAwardLookupableHelperService" class="org.kuali.kra.subaward.lookup.SubAwardLookupableHelperServiceImpl" parent="parentLookupableHelperService" 
+	      scope="prototype">
+		<property name="versionHistoryService" ref="versionHistoryService" />
+  	</bean>
+  	
+  	<!-- SubAward Task Authorizers -->
+  	
+  	<bean id="parentSubAwardAuthorizer" abstract="true">
+        <property name="unitAuthorizationService" ref="unitAuthorizationService" />
+        <property name="kraWorkflowService" ref="kraWorkflowService" />
+        <property name="kraAuthorizationService" ref="kraAuthorizationService" />
+    </bean>
+  	
+  	<bean id="subAwardTaskAuthorizers" class="org.kuali.kra.authorization.TaskAuthorizerGroup">
+        <property name="groupName" value="subAward" />
+        <property name="taskAuthorizers">
+            <list>
+                <bean class="org.kuali.kra.subaward.document.authorizer.ViewSubAwardAuthorizer" parent="parentSubAwardAuthorizer">
+                    <property name="taskName" value="viewSubaward" />
+                </bean>
+                
+                 <bean class="org.kuali.kra.subaward.document.authorizer.ModifySubAwardAutherizer" parent="parentSubAwardAuthorizer">
+                    <property name="taskName" value="modifySubaward" />
+                </bean>
+                
+                <bean class="org.kuali.kra.subaward.document.authorizer.addInvoiceSubAwardAuthorizer" parent="parentSubAwardAuthorizer">
+                    <property name="taskName" value="addInvoiceSubAward" />
+                </bean>          
+            </list>
+         </property>
+     </bean>
+     
+    <bean id="subAwardRequisitionerDerivedRoleTypeService" class="org.kuali.kra.subaward.service.impl.SubAwardRequisitionerDerivedRoleTypeServiceImpl">
+
+    </bean>
+    
+	<bean id="subAwardRequisitionerDerivedRoleTypeServiceCallback" parent="kcCallbackService" 
+		p:callbackService-ref="subAwardRequisitionerDerivedRoleTypeService" 
+		p:localServiceName="subAwardRequisitionerDerivedRoleTypeService" 
+		p:serviceInterface="org.kuali.rice.kim.framework.role.RoleTypeService"/>
+	
+	<bean id="subAwardFactBuilderService" class="org.kuali.kra.subaward.service.impl.SubAwardFactBuilderServiceImpl">
+		  <property name="documentService" ref="documentService" />
+	</bean>
+	
+</beans>	

--- a/src/main/resources/org/kuali/kra/subaward/SubAwardSpringBeans.xml
+++ b/src/main/resources/org/kuali/kra/subaward/SubAwardSpringBeans.xml
@@ -201,6 +201,7 @@ R
         <property name="sequenceAccessorService" ref="sequenceAccessorService" />
         <property name="parameterService" ref="parameterService" />
         <property name="versionHistoryService" ref="versionHistoryService" />
+        <property name="subAwardFundingSourceDao" ref="subAwardFundingSourceDao" />
     </bean>
     
 	<bean id="subAwardLookupable" class="org.kuali.rice.kns.lookup.KualiLookupableImpl" scope="prototype">
@@ -212,6 +213,8 @@ R
 		<property name="versionHistoryService" ref="versionHistoryService" />
   	</bean>
   	
+    <bean id ="subAwardFundingSourceDao" parent="platformAwareDao" class="org.kuali.kra.subaward.dao.impl.SubAwardFundingSourceDaoOjb" />
+    
   	<!-- SubAward Task Authorizers -->
   	
   	<bean id="parentSubAwardAuthorizer" abstract="true">

--- a/src/main/resources/org/kuali/kra/subaward/repository-subAward.xml
+++ b/src/main/resources/org/kuali/kra/subaward/repository-subAward.xml
@@ -1,0 +1,431 @@
+<!--
+ Copyright 2005-2014 The Kuali Foundation.
+ 
+ Licensed under the Educational Community License, Version 1.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.opensource.org/licenses/ecl1.php
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<descriptor-repository version="1.0">
+
+	<class-descriptor class="org.kuali.kra.subaward.document.SubAwardDocument" table="SUBAWARD_DOCUMENT">
+		<field-descriptor name="documentNumber" column="DOCUMENT_NUMBER" jdbc-type="VARCHAR" primarykey="true" />		
+		<field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+		<field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />		
+		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+		
+        <reference-descriptor name="documentHeader" class-ref="org.kuali.rice.krad.bo.DocumentHeader" auto-retrieve="true" auto-update="object" auto-delete="object">
+            <foreignkey field-ref="documentNumber" />
+        </reference-descriptor>
+        
+		<collection-descriptor name="subAwardList" proxy="true" element-class-ref="org.kuali.kra.subaward.bo.SubAward" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+        	<inverse-foreignkey field-ref="documentNumber" />
+    	</collection-descriptor>
+	</class-descriptor>
+	
+	<class-descriptor class="org.kuali.kra.subaward.bo.SubAward" table="SUBAWARD">
+		<field-descriptor name="subAwardId" column="SUBAWARD_ID" jdbc-type="BIGINT" primarykey="true"  autoincrement="true" sequence-name="SUBAWARD_ID_S" />
+		<field-descriptor name="documentNumber" column="DOCUMENT_NUMBER" jdbc-type="VARCHAR" access="anonymous" />		
+		<field-descriptor name="sequenceNumber" column="SEQUENCE_NUMBER" jdbc-type="INTEGER"/>	
+		<field-descriptor name="subAwardCode" column="SUBAWARD_CODE" jdbc-type="VARCHAR" />
+		<field-descriptor name="organizationId" column="ORGANIZATION_ID" jdbc-type="VARCHAR" />
+		<field-descriptor name="startDate" column="START_DATE" jdbc-type="DATE" />
+		<field-descriptor name="endDate" column="END_DATE" jdbc-type="DATE" />
+		<field-descriptor name="subAwardTypeCode" column="SUBAWARD_TYPE_CODE" jdbc-type="INTEGER" />
+		<field-descriptor name="purchaseOrderNum" column="PURCHASE_ORDER_NUM" jdbc-type="VARCHAR" />
+		<field-descriptor name="title" column="TITLE" jdbc-type="VARCHAR" />
+		<field-descriptor name="statusCode" column="STATUS_CODE" jdbc-type="INTEGER" />
+		<field-descriptor name="accountNumber" column="ACCOUNT_NUMBER" jdbc-type="VARCHAR" />
+		<field-descriptor name="vendorNumber" column="VENDOR_NUMBER" jdbc-type="VARCHAR" />
+		<field-descriptor name="requisitionerId" column="REQUISITIONER_ID" jdbc-type="VARCHAR" />
+		<field-descriptor name="requisitionerUnit" column="REQUISITIONER_UNIT" jdbc-type="VARCHAR" />
+		<field-descriptor name="archiveLocation" column="ARCHIVE_LOCATION" jdbc-type="VARCHAR" />
+		<field-descriptor name="closeoutDate" column="CLOSEOUT_DATE" jdbc-type="DATE" />		
+		<field-descriptor name="comments" column="COMMENTS" jdbc-type="VARCHAR" />
+		<field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+		<field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+		<field-descriptor name="siteInvestigator" column="SITE_INVESTIGATOR" jdbc-type="INTEGER" />
+		<field-descriptor name="costType" column="COST_TYPE" jdbc-type="INTEGER" />
+		<field-descriptor name="executionDate" column="DATE_OF_FULLY_EXECUTED" jdbc-type="DATE" />
+		<field-descriptor name="requisitionId" column="REQUISITION_NUMBER" jdbc-type="VARCHAR" />
+		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+		
+        <reference-descriptor name="subAwardDocument" class-ref="org.kuali.kra.subaward.document.SubAwardDocument" auto-retrieve="true" auto-update="none" auto-delete="none">
+            <foreignkey field-ref="documentNumber" />
+        </reference-descriptor>
+        <reference-descriptor name="organization" class-ref="org.kuali.kra.bo.Organization" auto-retrieve="true" auto-update="none" auto-delete="none"> 
+            <foreignkey field-ref="organizationId"/> 
+        </reference-descriptor>
+        <reference-descriptor name="unit" class-ref="org.kuali.kra.bo.Unit" auto-retrieve="true" auto-update="none" auto-delete="none"> 
+            <foreignkey field-ref="requisitionerUnit"/> 
+        </reference-descriptor>
+        <reference-descriptor name="rolodex" class-ref="org.kuali.kra.bo.Rolodex" auto-retrieve="true" auto-update="none" auto-delete="none"> 
+            <foreignkey field-ref="siteInvestigator"/>
+        </reference-descriptor>
+        <reference-descriptor name="subAwardStatus" class-ref="org.kuali.kra.subaward.bo.SubAwardStatus" auto-retrieve="true" auto-update="none" auto-delete="none"> 
+            <foreignkey field-ref="statusCode"/> 
+        </reference-descriptor>
+        <reference-descriptor name="subAwardType" class-ref="org.kuali.kra.award.home.AwardType" auto-retrieve="true" auto-update="none" auto-delete="none"> 
+            <foreignkey field-ref="subAwardTypeCode"/> 
+        </reference-descriptor>
+         <reference-descriptor name="subAwardCostType" class-ref="org.kuali.kra.subaward.bo.SubAwardCostType" auto-retrieve="true" auto-update="none" auto-delete="none"> 
+            <foreignkey field-ref="costType"/> 
+        </reference-descriptor>
+        
+ 	    <collection-descriptor name="subAwardFundingSourceList" proxy="true" element-class-ref="org.kuali.kra.subaward.bo.SubAwardFundingSource" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+			<inverse-foreignkey field-ref="subAwardId"/>
+		</collection-descriptor>
+		<collection-descriptor name="subAwardAmountInfoList" proxy="true" element-class-ref="org.kuali.kra.subaward.bo.SubAwardAmountInfo" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+			<inverse-foreignkey field-ref="subAwardId"/>
+		</collection-descriptor> 
+		<collection-descriptor name="subAwardContactsList" proxy="true" element-class-ref="org.kuali.kra.subaward.bo.SubAwardContact" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+			<inverse-foreignkey field-ref="subAwardId"/>
+		</collection-descriptor>
+	    <collection-descriptor name="subAwardCloseoutList" proxy="true" element-class-ref="org.kuali.kra.subaward.bo.SubAwardCloseout" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+			<inverse-foreignkey field-ref="subAwardId"/>
+		</collection-descriptor>
+		<collection-descriptor name="subAwardCustomDataList" proxy="true" element-class-ref="org.kuali.kra.subaward.customdata.SubAwardCustomData" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+			<inverse-foreignkey field-ref="subAwardId"/>
+		</collection-descriptor>
+		<collection-descriptor name="subAwardAttachments" proxy="true" element-class-ref="org.kuali.kra.subaward.bo.SubAwardAttachments" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="none">
+			<inverse-foreignkey field-ref="subAwardId"/>
+			<orderby name="attachmentId" sort="ASC" />
+		</collection-descriptor>
+		<collection-descriptor name="subAwardReportList" proxy="true" element-class-ref="org.kuali.kra.subaward.bo.SubAwardReports" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="none">
+			<inverse-foreignkey field-ref="subAwardId"/>
+			<orderby name="subAwardReportId" sort="ASC" />
+		</collection-descriptor>
+		<collection-descriptor name="subAwardTemplateInfo" proxy="true" element-class-ref="org.kuali.kra.subaward.bo.SubAwardTemplateInfo" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="none">
+			<inverse-foreignkey field-ref="subAwardId"/>
+		</collection-descriptor>
+	</class-descriptor>
+	
+    <class-descriptor class="org.kuali.kra.subaward.bo.SubAwardAmountInfo" table="SUBAWARD_AMOUNT_INFO">
+        <field-descriptor name="subAwardAmountInfoId" column="SUBAWARD_AMOUNT_INFO_ID" jdbc-type="INTEGER" primarykey="true" autoincrement="true" sequence-name="SUBAWARD_AMT_INFO_ID_S"/>
+        <field-descriptor name="subAwardId" column="SUBAWARD_ID" jdbc-type="BIGINT" />
+        <field-descriptor name="sequenceNumber" column="SEQUENCE_NUMBER" jdbc-type="INTEGER"/>
+        <field-descriptor name="subAwardCode" column="SUBAWARD_CODE" jdbc-type="VARCHAR" />
+        <field-descriptor name="obligatedAmount" column="OBLIGATED_AMOUNT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+        <field-descriptor name="obligatedChange" column="OBLIGATED_CHANGE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+        <field-descriptor name="anticipatedAmount" column="ANTICIPATED_AMOUNT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+        <field-descriptor name="anticipatedChange" column="ANTICIPATED_CHANGE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+        <field-descriptor name="effectiveDate" column="EFFECTIVE_DATE" jdbc-type="DATE" />
+        <field-descriptor name="comments" column="COMMENTS" jdbc-type="VARCHAR" />
+        <field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+        <field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+        <field-descriptor name="fileName" column="FILE_NAME" jdbc-type="VARCHAR" />
+        <field-descriptor name="document" column="DOCUMENT" jdbc-type="BINARY" />
+        <field-descriptor name="mimeType" column="MIME_TYPE" jdbc-type="VARCHAR" />
+        <field-descriptor name="fileId" column="FILE_ID" jdbc-type="BIGINT"/>
+        <field-descriptor name="modificationEffectiveDate" column="MODIFICATION_EFFECTIVE_DATE" jdbc-type="DATE" />
+        <field-descriptor name="modificationID" column="MODIFICATION_NUMBER" jdbc-type="VARCHAR" />
+        <field-descriptor name="periodofPerformanceStartDate" column="PERFORMANCE_START_DATE" jdbc-type="DATE" />
+        <field-descriptor name="periodofPerformanceEndDate" column="PERFORMANCE_END_DATE" jdbc-type="DATE" />
+        <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+        
+        <reference-descriptor name="file" proxy="true" class-ref="org.kuali.kra.bo.AttachmentFile" auto-retrieve="true" auto-update="object" auto-delete="true"> 
+            <foreignkey field-ref="fileId"/>
+        </reference-descriptor>
+    </class-descriptor>
+    
+    <class-descriptor class="org.kuali.kra.subaward.bo.SubAwardAmountReleased" table="SUBAWARD_AMT_RELEASED">
+        <field-descriptor name="subAwardAmtReleasedId" column="SUBAWARD_AMT_RELEASED_ID" jdbc-type="INTEGER" primarykey="true"  autoincrement="true"  sequence-name="SUBAWARD_AMT_REL_ID_S"/>
+        <field-descriptor name="documentNumber" column="DOCUMENT_NUMBER" jdbc-type="VARCHAR" />
+        <field-descriptor name="subAwardId" column="SUBAWARD_ID" jdbc-type="BIGINT" />
+        <field-descriptor name="sequenceNumber" column="SEQUENCE_NUMBER" jdbc-type="INTEGER"/>
+        <field-descriptor name="subAwardCode" column="SUBAWARD_CODE" jdbc-type="VARCHAR" />
+        <field-descriptor name="amountReleased" column="AMOUNT_RELEASED" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+        <field-descriptor name="effectiveDate" column="EFFECTIVE_DATE" jdbc-type="DATE" />
+        <field-descriptor name="comments" column="COMMENTS" jdbc-type="VARCHAR" />
+        <field-descriptor name="invoiceNumber" column="INVOICE_NUMBER" jdbc-type="VARCHAR" />
+        <field-descriptor name="startDate" column="START_DATE" jdbc-type="DATE" />
+        <field-descriptor name="endDate" column="END_DATE" jdbc-type="DATE" />
+        <field-descriptor name="document" column="DOCUMENT" jdbc-type="BINARY" />
+        <field-descriptor name="fileName" column="FILE_NAME" jdbc-type="VARCHAR" />
+        <field-descriptor name="createdBy" column="CREATED_BY" jdbc-type="VARCHAR" />
+        <field-descriptor name="createdDate" column="CREATED_DATE" jdbc-type="TIMESTAMP" />
+        <field-descriptor name="mimeType" column="MIME_TYPE" jdbc-type="VARCHAR" />
+        <field-descriptor name="invoiceStatus" column="INVOICE_STATUS" jdbc-type="VARCHAR" />
+        <field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+        <field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />        
+        <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="false" />
+        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+    </class-descriptor>
+    
+    <class-descriptor class="org.kuali.kra.subaward.bo.SubAwardApprovalType" table="SUBAWARD_APPROVAL_TYPE">
+        <field-descriptor name="subAwardApprovalTypeCode" column="SUBAWARD_APPROVAL_TYPE_CODE" jdbc-type="INTEGER" primarykey="true" />
+        <field-descriptor name="description" column="DESCRIPTION" jdbc-type="VARCHAR" />
+        <field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+        <field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+        <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+    </class-descriptor>
+    
+    <class-descriptor class="org.kuali.kra.subaward.bo.SubAwardCloseout" table="SUBAWARD_CLOSEOUT">
+        <field-descriptor name="subAwardCloseoutId" column="SUBAWARD_CLOSEOUT_ID" jdbc-type="INTEGER" primarykey="true" autoincrement="true"  sequence-name="SUBAWARD_CLOSEOUT_ID_S"/>
+        <field-descriptor name="subAwardId" column="SUBAWARD_ID" jdbc-type="BIGINT" />
+        <field-descriptor name="sequenceNumber" column="SEQUENCE_NUMBER" jdbc-type="INTEGER"/>
+        <field-descriptor name="subAwardCode" column="SUBAWARD_CODE" jdbc-type="VARCHAR" />
+        <field-descriptor name="closeoutNumber" column="CLOSEOUT_NUMBER" jdbc-type="INTEGER" />
+        <field-descriptor name="closeoutTypeCode" column="CLOSEOUT_TYPE_CODE" jdbc-type="INTEGER" />
+        <field-descriptor name="dateRequested" column="DATE_REQUESTED" jdbc-type="DATE" />
+        <field-descriptor name="dateFollowup" column="DATE_FOLLOWUP" jdbc-type="DATE" />
+        <field-descriptor name="dateReceived" column="DATE_RECEIVED" jdbc-type="DATE" />
+        <field-descriptor name="comments" column="COMMENTS" jdbc-type="VARCHAR" />
+        <field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+        <field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+        <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+    </class-descriptor>
+    
+    <class-descriptor class="org.kuali.kra.subaward.bo.CloseoutType" table="CLOSEOUT_TYPE">
+        <field-descriptor name="closeoutTypeCode" column="CLOSEOUT_TYPE_CODE" jdbc-type="INTEGER" primarykey="true" />
+        <field-descriptor name="description" column="DESCRIPTION" jdbc-type="VARCHAR" />
+        <field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+        <field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+        <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+    </class-descriptor>
+    
+    <class-descriptor class="org.kuali.kra.subaward.bo.SubAwardContact" table="SUBAWARD_CONTACT">
+        <field-descriptor name="subAwardContactId" column="SUBAWARD_CONTACT_ID" jdbc-type="INTEGER" primarykey="true" autoincrement="true"  sequence-name="SUBAWARD_CONTACT_ID_S"/>
+        <field-descriptor name="subAwardId" column="SUBAWARD_ID" jdbc-type="BIGINT" />
+        <field-descriptor name="sequenceNumber" column="SEQUENCE_NUMBER" jdbc-type="INTEGER"/>
+        <field-descriptor name="subAwardCode" column="SUBAWARD_CODE" jdbc-type="VARCHAR" />
+        <field-descriptor name="contactTypeCode" column="CONTACT_TYPE_CODE" jdbc-type="VARCHAR" />
+        <field-descriptor name="rolodexId" column="ROLODEX_ID" jdbc-type="INTEGER" />
+        <field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+        <field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+        <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+        
+        <reference-descriptor name="contactType" class-ref="org.kuali.kra.award.home.ContactType" auto-retrieve="false" auto-update="none" auto-delete="none"> 
+            <foreignkey field-ref="contactTypeCode"/>
+        </reference-descriptor>
+        <reference-descriptor name="rolodex" class-ref="org.kuali.kra.bo.Rolodex" auto-retrieve="true" auto-update="none" auto-delete="none"> 
+            <foreignkey field-ref="rolodexId"/>
+        </reference-descriptor>
+    </class-descriptor>
+    
+    <class-descriptor class="org.kuali.kra.subaward.customdata.SubAwardCustomData" table="SUBAWARD_CUSTOM_DATA">
+        <field-descriptor name="subAwardCustomDataId" column="SUBAWARD_CUSTOM_DATA_ID" jdbc-type="BIGINT" primarykey="true" autoincrement="true" sequence-name="SUBAWARD_CUST_ID_S" />
+        <field-descriptor name="subAwardId" column="SUBAWARD_ID" jdbc-type="BIGINT" access="anonymous"/>
+        <field-descriptor name="sequenceNumber" column="SEQUENCE_NUMBER" jdbc-type="INTEGER"/>
+        <field-descriptor name="subAwardCode" column="SUBAWARD_CODE" jdbc-type="VARCHAR" />
+        <field-descriptor name="customAttributeId" column="CUSTOM_ATTRIBUTE_ID" jdbc-type="BIGINT"/>
+        <field-descriptor name="value" column="VALUE" jdbc-type="VARCHAR"/>
+        <field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP"/>
+        <field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR"/>
+        <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="false" />
+        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+        
+        <reference-descriptor name="customAttribute" class-ref="org.kuali.kra.bo.CustomAttribute" auto-retrieve="true" auto-update="none" auto-delete="none"> 
+          <foreignkey field-ref="customAttributeId"/>
+        </reference-descriptor>
+    </class-descriptor>
+    
+    <class-descriptor class="org.kuali.kra.subaward.bo.SubAwardForms" table="SUBAWARD_FORMS">
+        <field-descriptor name="formId" column="FORM_ID" jdbc-type="VARCHAR" primarykey="true" />
+        <field-descriptor name="description" column="DESCRIPTION" jdbc-type="VARCHAR" />
+        <field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+        <field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+        <field-descriptor name="attachmentContent" column="FORM" jdbc-type="CLOB"  conversion="org.kuali.kra.infrastructure.OjbBlobClobFieldConersion"/>
+        <field-descriptor name="fileName" column="FILE_NAME" jdbc-type="VARCHAR" />
+        <field-descriptor name="contentType" column="CONTENT_TYPE" jdbc-type="VARCHAR" />
+        <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+        <field-descriptor name="templateTypeCode" column="TEMPLATE_TYPE_CODE" jdbc-type="INTEGER" />
+          
+        <reference-descriptor name="subAwardTemplateType" class-ref="org.kuali.kra.subaward.bo.SubawardTemplateType" auto-retrieve="true" auto-update="none" auto-delete="none"> 
+          <foreignkey field-ref="templateTypeCode"/>
+        </reference-descriptor>
+        
+    </class-descriptor>
+	
+	<class-descriptor class="org.kuali.kra.subaward.bo.SubAwardFundingSource" table="SUBAWARD_FUNDING_SOURCE">
+		<field-descriptor name="subAwardFundingSourceId" column="SUBAWARD_FUNDING_SOURCE_ID" jdbc-type="INTEGER" primarykey="true"  autoincrement="true"  sequence-name="SUBAWARD_FUNDING_SOURCE_ID_S" />
+		<field-descriptor name="subAwardId" column="SUBAWARD_ID" jdbc-type="BIGINT" />
+		<field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+		<field-descriptor name="subAwardCode" column="SUBAWARD_CODE" jdbc-type="VARCHAR" />
+		<field-descriptor name="sequenceNumber" column="SEQUENCE_NUMBER" jdbc-type="INTEGER"/>
+		<field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+		<field-descriptor name="awardId" column="AWARD_ID" jdbc-type="BIGINT" />
+		
+		<reference-descriptor name="award" class-ref="org.kuali.kra.award.home.Award" auto-retrieve="true" auto-update="none" auto-delete="none"> 
+			<foreignkey field-ref="awardId"/>
+		</reference-descriptor> 
+		<reference-descriptor name="subAward" class-ref="org.kuali.kra.subaward.bo.SubAward" auto-retrieve="true" auto-update="none" auto-delete="none">
+			<foreignkey field-ref="subAwardId"/>
+		</reference-descriptor>
+	</class-descriptor>
+
+	<class-descriptor class="org.kuali.kra.subaward.bo.SubAwardStatus" table="SUBAWARD_STATUS">
+		<field-descriptor name="subAwardStatusCode" column="SUBAWARD_STATUS_CODE" jdbc-type="INTEGER" primarykey="true" />
+		<field-descriptor name="description" column="DESCRIPTION" jdbc-type="VARCHAR" />
+		<field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+		<field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+	</class-descriptor> 
+	
+	<class-descriptor class="org.kuali.kra.subaward.bo.AwardSubAwardTerms" table="AWARD_SUBAWARD_TERMS">
+		<field-descriptor name="awardSubawardTermsId" column="AWARD_SUBAWARD_TERMS_ID" jdbc-type="INTEGER" primarykey="true" />
+		<field-descriptor name="awardId" column="AWARD_ID" jdbc-type="INTEGER" />
+		<field-descriptor name="mitAwardNumber" column="MIT_AWARD_NUMBER" jdbc-type="VARCHAR" />		
+		<field-descriptor name="subAwardApprovalTypeCode" column="SUBAWARD_APPROVAL_CODE" jdbc-type="INTEGER" />
+		<field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+		<field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+		
+		<reference-descriptor name="award" class-ref="org.kuali.kra.award.home.Award" auto-retrieve="false" auto-update="none" auto-delete="none"> 
+			<foreignkey field-ref="awardId"/>
+		</reference-descriptor>
+		<reference-descriptor name="subAwardApproval" class-ref="org.kuali.kra.subaward.bo.SubAwardApprovalType" auto-retrieve="false" auto-update="none" auto-delete="none"> 
+			<foreignkey field-ref="subAwardApprovalTypeCode"/>
+		</reference-descriptor>
+	</class-descriptor>
+	
+    <class-descriptor class="org.kuali.kra.subaward.bo.TemplateSubAwardTerms" table="TEMPLATE_SUBAWARD_TERMS">
+        <field-descriptor name="templateSubAwardTermsId" column="TEMPLATE_SUBAWARD_TERMS_ID" jdbc-type="INTEGER" primarykey="true" />
+        <field-descriptor name="templateCode" column="TEMPLATE_CODE" jdbc-type="INTEGER" />
+        <field-descriptor name="subAwardApprovalTypeCode" column="SUBAWARD_APPROVAL_CODE" jdbc-type="INTEGER" />
+        <field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+        <field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+        <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+        
+        <reference-descriptor name="subAwardApproval" class-ref="org.kuali.kra.subaward.bo.SubAwardApprovalType" auto-retrieve="false" auto-update="none" auto-delete="none"> 
+            <foreignkey field-ref="subAwardApprovalTypeCode"/>
+        </reference-descriptor>
+        <reference-descriptor name="template" class-ref="org.kuali.kra.award.home.AwardTemplate" auto-retrieve="true" auto-update="none" auto-delete="none"> 
+            <foreignkey field-ref="templateCode"/>
+        </reference-descriptor>
+     </class-descriptor>
+	
+	<class-descriptor class="org.kuali.kra.subaward.bo.SubawardTemplateType" table="SUBAWARD_TEMPLATE_TYPE">
+		<field-descriptor name="templateTypeCode" column="SUBAWARD_TEMPLATE_TYPE_CODE " jdbc-type="INTEGER" primarykey="true" />
+		<field-descriptor name="description" column="DESCRIPTION" jdbc-type="VARCHAR" />
+		<field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+		<field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+	</class-descriptor> 
+	
+	<class-descriptor class="org.kuali.kra.subaward.bo.SubAwardCostType" table="SUBCONTRACT_COST_TYPE">
+		<field-descriptor name="costTypeCode" column="COST_TYPE_CODE" jdbc-type="VARCHAR" primarykey="true" />
+		<field-descriptor name="costTypeDescription" column="DESCRIPTION" jdbc-type="VARCHAR" />
+		<field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+		<field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+	</class-descriptor> 
+	 
+     <class-descriptor class="org.kuali.kra.subaward.bo.SubAwardCopyRightsType" table="SUBCONTRACT_COPYRIGHT_TYPE">
+		<field-descriptor name="copyRightTypeCode" column="COPYRIGHT_TYPE_CODE" jdbc-type="VARCHAR" primarykey="true" />
+		<field-descriptor name="copyRightTypeDescription" column="DESCRIPTION" jdbc-type="VARCHAR" />
+		<field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+		<field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+	</class-descriptor> 
+	
+	<class-descriptor class="org.kuali.kra.subaward.bo.SubAwardReportType" table="SUBAWARD_REPORT_TYPE">
+		<field-descriptor name="subAwardReportTypeCode" column="REPORT_TYPE_CODE" jdbc-type="INTEGER" primarykey="true" />
+		<field-descriptor name="description" column="DESCRIPTION" jdbc-type="VARCHAR" />
+		<field-descriptor name="sortId" column="SORT_ID" jdbc-type="VARCHAR"/>
+		<field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+		<field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="false" />
+		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+	</class-descriptor>
+	
+	<class-descriptor class="org.kuali.kra.subaward.bo.SubAwardAttachmentType" table="SUBAWARD_ATTACHMENT_TYPE">
+		<field-descriptor name="subAwardAttachmentTypeCode" column="ATTACHMENT_TYPE_CODE" jdbc-type="INTEGER" primarykey="true" />
+		<field-descriptor name="description" column="DESCRIPTION" jdbc-type="VARCHAR" />
+		<field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+		<field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="false" />
+		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+	</class-descriptor>
+	
+	<class-descriptor class="org.kuali.kra.subaward.bo.SubAwardAttachments" table="SUBAWARD_ATTACHMENTS">
+		<field-descriptor name="attachmentId" column="ATTACHMENT_ID" jdbc-type="INTEGER" primarykey="true" sequence-name="SEQ_SUBAWARD_ATTACHMENT_ID" autoincrement="true"/>
+		<field-descriptor name="subAwardId" column="SUBAWARD_ID" jdbc-type="BIGINT"  />
+		<field-descriptor name="subAwardCode" column="SUBAWARD_CODE" jdbc-type="VARCHAR"/>
+		<field-descriptor name="sequenceNumber" column="SEQUENCE_NUMBER" jdbc-type="INTEGER"/>
+		<field-descriptor name="subAwardAttachmentTypeCode" column="ATTACHMENT_TYPE_CODE" jdbc-type="VARCHAR"/>
+		<field-descriptor name="documentId" column="DOCUMENT_ID" jdbc-type="INTEGER" />
+		<field-descriptor name="fileId" column="FILE_ID" jdbc-type="BIGINT"/>
+		<field-descriptor name="fileName" column="FILE_NAME" jdbc-type="VARCHAR"/>
+		<field-descriptor name="document" column="DOCUMENT" jdbc-type="BINARY" />
+		<field-descriptor name="description" column="DESCRIPTION" jdbc-type="VARCHAR" />
+		<field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+		<field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="false" />
+		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+		
+		<reference-descriptor name="typeAttachment" class-ref="org.kuali.kra.subaward.bo.SubAwardAttachmentType" auto-retrieve="true" auto-update="none" auto-delete="none"> 
+			<foreignkey field-ref="subAwardAttachmentTypeCode"/>
+		</reference-descriptor>
+		
+		<reference-descriptor name="file" proxy="true" class-ref="org.kuali.kra.bo.AttachmentFile" auto-retrieve="true" auto-update="object" auto-delete="true"> 
+			<foreignkey field-ref="fileId"/>
+		</reference-descriptor>
+	</class-descriptor>
+	<class-descriptor class="org.kuali.kra.subaward.bo.SubAwardReports" table="SUBAWARD_REPORTS">
+		<field-descriptor name="subAwardReportId" column="SUBAWARD_REPORT_ID" jdbc-type="VARCHAR" primarykey="true" sequence-name="SEQ_SUBAWARD_REPORT_ID" autoincrement="true"/>
+		<field-descriptor name="subAwardId" column="SUBAWARD_ID" jdbc-type="BIGINT" />
+		<field-descriptor name="subAwardCode" column="SUBAWARD_CODE" jdbc-type="VARCHAR"/>
+		<field-descriptor name="sequenceNumber" column="SEQUENCE_NUMBER" jdbc-type="INTEGER"/>
+		<field-descriptor name="subAwardReportTypeCode" column="REPORT_TYPE_CODE" jdbc-type="VARCHAR"/>
+		<field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+		<field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="false" />
+		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+		<reference-descriptor name="typeCode" class-ref="org.kuali.kra.subaward.bo.SubAwardReportType" auto-retrieve="true" auto-update="none" auto-delete="none"> 
+			<foreignkey field-ref="subAwardReportTypeCode"/>
+		</reference-descriptor>
+	</class-descriptor>
+	
+	<class-descriptor class="org.kuali.kra.subaward.bo.SubAwardTemplateInfo" table="SUBAWARD_TEMPLATE_INFO">
+        <field-descriptor name="subAwardId" column="SUBAWARD_ID" jdbc-type="BIGINT" primarykey="true" />
+        <field-descriptor name="subAwardCode" column="SUBAWARD_CODE" jdbc-type="VARCHAR" />
+        <field-descriptor name="sequenceNumber" column="SEQUENCE_NUMBER" jdbc-type="INTEGER" />
+        <field-descriptor name="sowOrSubProposalBudget" column="SOW_OR_SUB_PROPOSAL_BUDGET" jdbc-type="VARCHAR"/>
+        <field-descriptor name="subProposalDate" column="SUB_PROPOSAL_DATE" jdbc-type="DATE" />
+        <field-descriptor name="invoiceOrPaymentContact" column="INVOICE_OR_PAYMENT_CONTACT" jdbc-type="INTEGER"/>
+        <field-descriptor name="finalStmtOfCostscontact" column="FINAL_STMT_OF_COSTS_CONTACT" jdbc-type="INTEGER" />
+        <field-descriptor name="changeRequestsContact" column="CHANGE_REQUESTS_CONTACT" jdbc-type="INTEGER" />
+        <field-descriptor name="terminationContact" column="TERMINATION_CONTACT" jdbc-type="INTEGER" />
+        <field-descriptor name="noCostExtensionContact" column="NO_COST_EXTENSION_CONTACT" jdbc-type="INTEGER" />
+        <field-descriptor name="perfSiteDiffFromOrgAddr" column="PERF_SITE_DIFF_FROM_ORG_ADDR" jdbc-type="VARCHAR"/>
+        <field-descriptor name="perfSiteSameAsSubPiAddr" column="PERF_SITE_SAME_AS_SUB_PI_ADDR" jdbc-type="VARCHAR"/>
+        <field-descriptor name="subRegisteredInCcr" column="SUB_REGISTERED_IN_CCR" jdbc-type="VARCHAR"/>
+        <field-descriptor name="subExemptFromReportingComp" column="SUB_EXEMPT_FROM_REPORTING_COMP" jdbc-type="VARCHAR"/>
+        <field-descriptor name="parentDunsNumber" column="PARENT_DUNS_NUMBER" jdbc-type="VARCHAR"/>
+        <field-descriptor name="parentCongressionalDistrict" column="PARENT_CONGRESSIONAL_DISTRICT" jdbc-type="VARCHAR"/>
+        <field-descriptor name="exemptFromRprtgExecComp" column="EXEMPT_FROM_RPRTG_EXEC_COMP" jdbc-type="VARCHAR"/>
+        <field-descriptor name="copyRightType" column="COPYRIGHT_TYPE" jdbc-type="INTEGER" />
+        <field-descriptor name="automaticCarryForward" column="AUTOMATIC_CARRY_FORWARD" jdbc-type="VARCHAR"/>
+        <field-descriptor name="carryForwardRequestsSentTo" column="CARRY_FORWARD_REQUESTS_SENT_TO" jdbc-type="INTEGER" />
+        <field-descriptor name="treatmentPrgmIncomeAdditive" column="TREATMENT_PRGM_INCOME_ADDITIVE" jdbc-type="VARCHAR"/>
+        <field-descriptor name="applicableProgramRegulations" column="APPLICABLE_PROGRAM_REGULATIONS" jdbc-type="VARCHAR"/>
+        <field-descriptor name="applicableProgramRegsDate" column="APPLICABLE_PROGRAM_REGS_DATE" jdbc-type="DATE" />
+        <field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+		<field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+    </class-descriptor>
+    
+</descriptor-repository>

--- a/src/main/resources/org/kuali/kra/subaward/repository-subAward.xml
+++ b/src/main/resources/org/kuali/kra/subaward/repository-subAward.xml
@@ -262,11 +262,13 @@
 		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
 		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
 		<field-descriptor name="awardId" column="AWARD_ID" jdbc-type="BIGINT" />
+        <field-descriptor name="awardNumber" column="AWARD_NUMBER" jdbc-type="VARCHAR" />
+        <field-descriptor name="active" column="ACTV_IND" jdbc-type="CHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
 		
-		<reference-descriptor name="award" class-ref="org.kuali.kra.award.home.Award" auto-retrieve="true" auto-update="none" auto-delete="none"> 
+		<reference-descriptor name="award" class-ref="org.kuali.kra.award.home.Award" auto-retrieve="false" auto-update="none" auto-delete="none"> 
 			<foreignkey field-ref="awardId"/>
 		</reference-descriptor> 
-		<reference-descriptor name="subAward" class-ref="org.kuali.kra.subaward.bo.SubAward" auto-retrieve="true" auto-update="none" auto-delete="none">
+		<reference-descriptor name="subAward" class-ref="org.kuali.kra.subaward.bo.SubAward" auto-retrieve="false" auto-update="none" auto-delete="none">
 			<foreignkey field-ref="subAwardId"/>
 		</reference-descriptor>
 	</class-descriptor>

--- a/src/main/webapp/WEB-INF/tags/subaward/subAwardFundingSource.tag
+++ b/src/main/webapp/WEB-INF/tags/subaward/subAwardFundingSource.tag
@@ -1,0 +1,157 @@
+<%--
+ Copyright 2005-2014 The Kuali Foundation
+ 
+ Licensed under the Educational Community License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.opensource.org/licenses/ecl1.php
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+--%>
+<%@ include file="/WEB-INF/jsp/kraTldHeader.jsp"%>
+
+<c:set var="subAwardFundingSourceAttributes" value="${DataDictionary.SubAwardFundingSource.attributes}" />
+<c:set var="action" value="subAward" />
+<c:set var="subAwardFundingSource" value="${KualiForm.document.subAwardList[0].subAwardFundingSourceList}"/>
+<c:set var="newSubAwardFundingSource" value="${KualiForm.newSubAwardFundingSource}" />
+
+<kul:tab tabTitle="Funding Source" defaultOpen="${KualiForm.document.subAwardList[0].defaultOpen}" alwaysOpen="true" transparentBackground="false" tabErrorKey="newSubAwardFundingSource.award.awardNumber*" auditCluster="requiredFieldsAuditErrors" tabAuditKey="" useRiceAuditMode="true">
+	<div class="tab-container" align="center">
+    	<h3>
+    		<span class="subhead-left"> Funding Source </span>	
+    		<div align="right"><kul:help parameterNamespace="KC-SUBAWARD" parameterDetailType="Document" parameterName="subAwardFundingSourceHelpUrl" altText="help"/></div>
+        </h3>
+        <table cellpadding=0 cellspacing=0 summary="">
+		<tbody class="addline">         
+        <tr>
+      	<th><div align="left">&nbsp;</div></th>
+        <th colspan=3><div align="center"><kul:htmlAttributeLabel attributeEntry="${subAwardFundingSourceAttributes.awardId}" /></div></th>
+        <th><div align="center"><kul:htmlAttributeLabel attributeEntry="${subAwardFundingSourceAttributes.accountNumber}" /></div></th>
+        <th><div align="center"><kul:htmlAttributeLabel attributeEntry="${subAwardFundingSourceAttributes.statusCode}" /></div></th>
+        <th><div align="center"><kul:htmlAttributeLabel attributeEntry="${subAwardFundingSourceAttributes.sponsorCode}" /></div></th>
+        <th><div align="center"><kul:htmlAttributeLabel attributeEntry="${subAwardFundingSourceAttributes.amountObligatedToDate}" /></div></th>
+        <th><div align="center"><kul:htmlAttributeLabel attributeEntry="${subAwardFundingSourceAttributes.obligationExpirationDate}" /></div></th>
+         <kul:htmlAttributeHeaderCell literalLabel="Actions" scope="col"/>
+          	   </tr>     
+          	    <c:if test="${readOnly!='true'}">
+			   <tr>
+               <th class="infoline" >
+						Add:
+				</th>
+     			 <td align="center"  colspan=3><kul:htmlControlAttribute property="newSubAwardFundingSource.award.awardNumber" attributeEntry="${subAwardFundingSourceAttributes.awardId}" />
+     			 <c:if test="${readOnly!='true'}">
+                 <kul:lookup boClassName="org.kuali.kra.award.home.Award" fieldConversions="awardNumber:newSubAwardFundingSource.award.awardNumber,awardDocument.documentNumber:newSubAwardFundingSource.award.awardDocument.documentNumber,awardId:newSubAwardFundingSource.awardId,accountNumber:newSubAwardFundingSource.award.accountNumber,statusCode:newSubAwardFundingSource.award.statusCode,sponsorCode:newSubAwardFundingSource.award.sponsorCode,sponsorName:newSubAwardFundingSource.award.sponsorName,awardAmountInfo.amountObligatedToDate:newSubAwardFundingSource.award.awardAmountInfos[0].amountObligatedToDate,awardAmountInfo.obligationExpirationDate:newSubAwardFundingSource.award.awardAmountInfos[0].obligationExpirationDate,awardStatus.description:newSubAwardFundingSource.award.awardStatus.description" anchor="${tabKey}" />
+                 </c:if>
+               	</td>
+   				<td><div align="center">
+     					<kul:htmlControlAttribute property="newSubAwardFundingSource.award.accountNumber" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.accountNumber}" datePicker="false" />           
+   					</div> 
+   				</td>
+   				<td><div align="center">
+     					<kul:htmlControlAttribute property="newSubAwardFundingSource.award.awardStatus.description" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.statusCode}" datePicker="false" />         
+   					</div> 
+   				</td>
+					<td><div align="center">
+							<kul:htmlControlAttribute
+									property="newSubAwardFundingSource.award.sponsorCode" readOnly="true"
+									attributeEntry="${subAwardFundingSourceAttributes.sponsorCode}"
+									datePicker="false" /><c:if
+								test="${!empty newSubAwardFundingSource.award.sponsorName}">
+								: <kul:htmlControlAttribute
+									property="newSubAwardFundingSource.award.sponsorName" readOnly="true"
+									attributeEntry="${subAwardFundingSourceAttributes.sponsorCode}"
+									datePicker="false" />
+							</c:if> 
+						</div></td>
+					<td><div align="center">
+     					<kul:htmlControlAttribute property="newSubAwardFundingSource.award.awardAmountInfos[0].amountObligatedToDate" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.amountObligatedToDate}" datePicker="false" />         
+   					</div> 
+   				</td>	
+   				<td><div align="center">
+     					<kul:htmlControlAttribute property="newSubAwardFundingSource.award.awardAmountInfos[0].obligationExpirationDate" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.obligationExpirationDate}" datePicker="false" />         
+   					</div> 
+   				</td>		
+   				<td class="infoline" rowspan="1"><div align="center">
+   				 <c:if test="${readOnly!='true'}">
+						<html:image property="methodToCall.addFundingSource.anchor${tabKey}" 
+						            src='${ConfigProperties.kra.externalizable.images.url}tinybutton-add1.gif' 
+						            styleClass="tinybutton addButton"/>
+				 </c:if>
+	                </div>
+	            </td>   
+   			</tr> 
+   			</c:if>
+   			</tbody>
+     	<c:forEach var="subAwardFundingSource" items="${KualiForm.document.subAwardList[0].subAwardFundingSourceList}" varStatus="status">
+		             <tr>
+		             
+						<th width="5%" class="infoline" rowspan="1">
+							<c:out value="${status.index+1}" />
+						</th>
+						<c:set  var="documentNumber" value="${subAwardFundingSource.award.awardDocument.documentNumber}"/> 
+						    <td width="6%" valign="middle"> 
+						    
+						    <a
+						href="${ConfigProperties.application.url}/awardHome.do?methodToCall=docHandler&command=displayDocSearchView&docId=${documentNumber}&medusaOpenedDoc=true"
+						target="_blank" class="medusaOpenLink">Open award</a>
+						</td>
+						  <td width="6%" valign="middle"> 
+						 <a
+						href="${ConfigProperties.application.url}/awardHome.do?methodToCall=medusa&command=displayDocSearchView&docId=${documentNumber}&medusaOpenedDoc=true"
+						target="_blank" class="medusaOpenLink"> medusa </a>
+						 
+						    </td>
+		                 <td width="9%" valign="middle">
+		               
+		                  
+		                 
+						<div align="left">
+	                		<kul:htmlControlAttribute property="document.subAwardList[0].subAwardFundingSourceList[${status.index}].award.awardNumber" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.awardId}" />
+						</div>
+						</td> 
+		                <td width="9%" valign="middle">
+						<div align="center">
+	                		<kul:htmlControlAttribute property="document.subAwardList[0].subAwardFundingSourceList[${status.index}].award.accountNumber" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.accountNumber}"/>                		
+						</div>
+						</td>
+		                <td width="9%" valign="middle">
+						<div align="center">
+	                		<kul:htmlControlAttribute property="document.subAwardList[0].subAwardFundingSourceList[${status.index}].award.awardStatus.description" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.statusCode}"/>
+						</div>
+						</td>
+						<td width="9%" valign="middle">
+						<div align="center">
+							<kul:htmlControlAttribute property="document.subAwardList[0].subAwardFundingSourceList[${status.index}].award.sponsorCode" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.sponsorCode}"/> : <kul:htmlControlAttribute property="document.subAwardList[0].subAwardFundingSourceList[${status.index}].award.sponsorName" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.sponsorCode}"/>         
+						</div>
+						</td>
+						<td width="9%" valign="middle">
+						<div align="center">
+							<kul:htmlControlAttribute property="document.subAwardList[0].subAwardFundingSourceList[${status.index}].award.awardAmountInfos[0].amountObligatedToDate" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.amountObligatedToDate}"/>
+						</div>
+						</td>
+						<td width="9%" valign="middle">
+						<div align="center">
+							<kul:htmlControlAttribute property="document.subAwardList[0].subAwardFundingSourceList[${status.index}].award.awardAmountInfos[0].obligationExpirationDate" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.obligationExpirationDate}" datePicker="false"/>
+						</div>
+						</td>
+						
+						    <td width="10%" valign="middle" rowspan="1">
+						<div align="center">
+						  <c:if test="${!readOnly}">
+	                		<html:image property="methodToCall.deleteFundingSource.line${status.index}.anchor${currentTabIndex}"
+								src='${ConfigProperties.kra.externalizable.images.url}tinybutton-delete1.gif' styleClass="tinybutton"/>
+						  </c:if>
+						  <c:if test="${readOnly}">&nbsp;</c:if>
+						</div>
+						</td>           
+		            </tr>
+      
+	        	</c:forEach>
+        </table>
+    </div> 
+</kul:tab>

--- a/src/main/webapp/WEB-INF/tags/subaward/subAwardFundingSource.tag
+++ b/src/main/webapp/WEB-INF/tags/subaward/subAwardFundingSource.tag
@@ -17,10 +17,10 @@
 
 <c:set var="subAwardFundingSourceAttributes" value="${DataDictionary.SubAwardFundingSource.attributes}" />
 <c:set var="action" value="subAward" />
-<c:set var="subAwardFundingSource" value="${KualiForm.document.subAwardList[0].subAwardFundingSourceList}"/>
+<!-- c:set var="subAwardFundingSource" value="${KualiForm.document.subAwardList[0].subAwardFundingSourceList}"/-->
 <c:set var="newSubAwardFundingSource" value="${KualiForm.newSubAwardFundingSource}" />
 
-<kul:tab tabTitle="Funding Source" defaultOpen="${KualiForm.document.subAwardList[0].defaultOpen}" alwaysOpen="true" transparentBackground="false" tabErrorKey="newSubAwardFundingSource.award.awardNumber*" auditCluster="requiredFieldsAuditErrors" tabAuditKey="" useRiceAuditMode="true">
+<kul:tab tabTitle="Funding Source" defaultOpen="${KualiForm.document.subAwardList[0].defaultOpen}" alwaysOpen="true" transparentBackground="false" tabErrorKey="newSubAwardFundingSource.awardNumber*" auditCluster="requiredFieldsAuditErrors" tabAuditKey="" useRiceAuditMode="true">
 	<div class="tab-container" align="center">
     	<h3>
     		<span class="subhead-left"> Funding Source </span>	
@@ -30,7 +30,7 @@
 		<tbody class="addline">         
         <tr>
       	<th><div align="left">&nbsp;</div></th>
-        <th colspan=3><div align="center"><kul:htmlAttributeLabel attributeEntry="${subAwardFundingSourceAttributes.awardId}" /></div></th>
+        <th colspan=3><div align="center"><kul:htmlAttributeLabel attributeEntry="${subAwardFundingSourceAttributes.awardNumber}" /></div></th>
         <th><div align="center"><kul:htmlAttributeLabel attributeEntry="${subAwardFundingSourceAttributes.accountNumber}" /></div></th>
         <th><div align="center"><kul:htmlAttributeLabel attributeEntry="${subAwardFundingSourceAttributes.statusCode}" /></div></th>
         <th><div align="center"><kul:htmlAttributeLabel attributeEntry="${subAwardFundingSourceAttributes.sponsorCode}" /></div></th>
@@ -43,10 +43,12 @@
                <th class="infoline" >
 						Add:
 				</th>
-     			 <td align="center"  colspan=3><kul:htmlControlAttribute property="newSubAwardFundingSource.award.awardNumber" attributeEntry="${subAwardFundingSourceAttributes.awardId}" />
-     			 <c:if test="${readOnly!='true'}">
-                 <kul:lookup boClassName="org.kuali.kra.award.home.Award" fieldConversions="awardNumber:newSubAwardFundingSource.award.awardNumber,awardDocument.documentNumber:newSubAwardFundingSource.award.awardDocument.documentNumber,awardId:newSubAwardFundingSource.awardId,accountNumber:newSubAwardFundingSource.award.accountNumber,statusCode:newSubAwardFundingSource.award.statusCode,sponsorCode:newSubAwardFundingSource.award.sponsorCode,sponsorName:newSubAwardFundingSource.award.sponsorName,awardAmountInfo.amountObligatedToDate:newSubAwardFundingSource.award.awardAmountInfos[0].amountObligatedToDate,awardAmountInfo.obligationExpirationDate:newSubAwardFundingSource.award.awardAmountInfos[0].obligationExpirationDate,awardStatus.description:newSubAwardFundingSource.award.awardStatus.description" anchor="${tabKey}" />
-                 </c:if>
+     			 <td align="center" colspan=3>
+                    <kul:htmlControlAttribute property="newSubAwardFundingSource.awardNumber" attributeEntry="${subAwardFundingSourceAttributes.awardNumber}" />
+         			<c:if test="${readOnly!='true'}">
+                        <kul:lookup boClassName="org.kuali.kra.award.home.Award" fieldConversions="awardNumber:newSubAwardFundingSource.awardNumber,awardDocument.documentNumber:newSubAwardFundingSource.award.awardDocument.documentNumber,awardId:newSubAwardFundingSource.awardId,accountNumber:newSubAwardFundingSource.award.accountNumber,statusCode:newSubAwardFundingSource.award.statusCode,sponsorCode:newSubAwardFundingSource.award.sponsorCode,awardAmountInfo.amountObligatedToDate:newSubAwardFundingSource.award.awardAmountInfos[0].amountObligatedToDate,awardAmountInfo.obligationExpirationDate:newSubAwardFundingSource.award.awardAmountInfos[0].obligationExpirationDate,awardStatus.description:newSubAwardFundingSource.award.awardStatus.description" anchor="${tabKey}" 
+                             lookupParameters="newSubAwardFundingSource.awardNumber:awardNumber"/>
+                    </c:if>
                	</td>
    				<td><div align="center">
      					<kul:htmlControlAttribute property="newSubAwardFundingSource.award.accountNumber" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.accountNumber}" datePicker="false" />           
@@ -87,71 +89,64 @@
    			</tr> 
    			</c:if>
    			</tbody>
-     	<c:forEach var="subAwardFundingSource" items="${KualiForm.document.subAwardList[0].subAwardFundingSourceList}" varStatus="status">
+     	<c:forEach var="subAwardFundingSource" items="${KualiForm.filteredSubAwardFundingSources}" varStatus="status">
 		             <tr>
-		             
 						<th width="5%" class="infoline" rowspan="1">
 							<c:out value="${status.index+1}" />
 						</th>
-						<c:set  var="documentNumber" value="${subAwardFundingSource.award.awardDocument.documentNumber}"/> 
-						    <td width="6%" valign="middle"> 
-						    
-						    <a
-						href="${ConfigProperties.application.url}/awardHome.do?methodToCall=docHandler&command=displayDocSearchView&docId=${documentNumber}&medusaOpenedDoc=true"
-						target="_blank" class="medusaOpenLink">Open award</a>
-						</td>
+						<c:set  var="documentNumber" value="${subAwardFundingSource.award.awardDocument.documentNumber}"/>
+                        <c:set  var="awardNumber" value="${subAwardFundingSource.award.awardNumber}"/>  
+						  <td width="6%" valign="middle">    
+						    <a href="${ConfigProperties.application.url}/awardHome.do?methodToCall=docHandler&command=displayDocSearchView&docId=${documentNumber}&medusaOpenedDoc=true"
+						      target="_blank" class="medusaOpenLink">Open award</a>
+						  </td>
 						  <td width="6%" valign="middle"> 
-						 <a
-						href="${ConfigProperties.application.url}/awardHome.do?methodToCall=medusa&command=displayDocSearchView&docId=${documentNumber}&medusaOpenedDoc=true"
-						target="_blank" class="medusaOpenLink"> medusa </a>
-						 
-						    </td>
-		                 <td width="9%" valign="middle">
-		               
-		                  
-		                 
-						<div align="left">
-	                		<kul:htmlControlAttribute property="document.subAwardList[0].subAwardFundingSourceList[${status.index}].award.awardNumber" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.awardId}" />
-						</div>
-						</td> 
-		                <td width="9%" valign="middle">
-						<div align="center">
-	                		<kul:htmlControlAttribute property="document.subAwardList[0].subAwardFundingSourceList[${status.index}].award.accountNumber" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.accountNumber}"/>                		
-						</div>
-						</td>
-		                <td width="9%" valign="middle">
-						<div align="center">
-	                		<kul:htmlControlAttribute property="document.subAwardList[0].subAwardFundingSourceList[${status.index}].award.awardStatus.description" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.statusCode}"/>
-						</div>
-						</td>
-						<td width="9%" valign="middle">
-						<div align="center">
-							<kul:htmlControlAttribute property="document.subAwardList[0].subAwardFundingSourceList[${status.index}].award.sponsorCode" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.sponsorCode}"/> : <kul:htmlControlAttribute property="document.subAwardList[0].subAwardFundingSourceList[${status.index}].award.sponsorName" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.sponsorCode}"/>         
-						</div>
-						</td>
-						<td width="9%" valign="middle">
-						<div align="center">
-							<kul:htmlControlAttribute property="document.subAwardList[0].subAwardFundingSourceList[${status.index}].award.awardAmountInfos[0].amountObligatedToDate" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.amountObligatedToDate}"/>
-						</div>
-						</td>
-						<td width="9%" valign="middle">
-						<div align="center">
-							<kul:htmlControlAttribute property="document.subAwardList[0].subAwardFundingSourceList[${status.index}].award.awardAmountInfos[0].obligationExpirationDate" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.obligationExpirationDate}" datePicker="false"/>
-						</div>
-						</td>
+    						 <a	href="${ConfigProperties.application.url}/awardHome.do?methodToCall=medusa&command=displayDocSearchView&docId=${documentNumber}&medusaOpenedDoc=true"
+    						  target="_blank" class="medusaOpenLink"> medusa </a>
+						  </td>
+		                  <td width="9%" valign="middle">
+    						<div align="left">
+                                <!-- input type="hidden" name="filteredSubAwardFundingSources[${status.index}].award.awardId" value="${subAwardFundingSource.award.awardId}" /-->
+                                <kul:htmlControlAttribute property="filteredSubAwardFundingSources[${status.index}].award.awardNumber" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.awardNumber}" />
+                            </div>
+						  </td> 
+		                  <td width="9%" valign="middle">
+    						<div align="center">
+    	                		<kul:htmlControlAttribute property="filteredSubAwardFundingSources[${status.index}].award.accountNumber" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.accountNumber}"/>                		
+    						</div>
+						  </td>
+		                  <td width="9%" valign="middle">
+    						<div align="center">
+    	                		<kul:htmlControlAttribute property="filteredSubAwardFundingSources[${status.index}].award.awardStatus.description" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.statusCode}"/>
+    						</div>
+						  </td>
+						  <td width="9%" valign="middle">
+    						<div align="center">
+    							<kul:htmlControlAttribute property="filteredSubAwardFundingSources[${status.index}].award.sponsorCode" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.sponsorCode}"/> : <kul:htmlControlAttribute property="filteredSubAwardFundingSources[${status.index}].award.sponsorName" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.sponsorCode}"/>         
+    						</div>
+						  </td>
+						  <td width="9%" valign="middle">
+    						<div align="center">
+    							<kul:htmlControlAttribute property="filteredSubAwardFundingSources[${status.index}].award.awardAmountInfos[0].amountObligatedToDate" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.amountObligatedToDate}"/>
+    						</div>
+						  </td>
+						  <td width="9%" valign="middle">
+    						<div align="center">
+    							<kul:htmlControlAttribute property="filteredSubAwardFundingSources[${status.index}].award.awardAmountInfos[0].obligationExpirationDate" readOnly="true" attributeEntry="${subAwardFundingSourceAttributes.obligationExpirationDate}" datePicker="false"/>
+    						</div>
+						  </td>
 						
-						    <td width="10%" valign="middle" rowspan="1">
-						<div align="center">
-						  <c:if test="${!readOnly}">
-	                		<html:image property="methodToCall.deleteFundingSource.line${status.index}.anchor${currentTabIndex}"
-								src='${ConfigProperties.kra.externalizable.images.url}tinybutton-delete1.gif' styleClass="tinybutton"/>
-						  </c:if>
-						  <c:if test="${readOnly}">&nbsp;</c:if>
-						</div>
-						</td>           
+						   <td width="10%" valign="middle" rowspan="1">
+    						<div align="center">
+    						  <c:if test="${!readOnly}">
+    	                		<html:image property="methodToCall.deleteFundingSource.line${status.index}.anchor${currentTabIndex}"
+    								src='${ConfigProperties.kra.externalizable.images.url}tinybutton-delete1.gif' styleClass="tinybutton"/>
+    						  </c:if>
+    						  <c:if test="${readOnly}">&nbsp;</c:if>
+    						</div>
+						  </td>           
 		            </tr>
-      
-	        	</c:forEach>
-        </table>
+        </c:forEach>
+       </table>
     </div> 
 </kul:tab>


### PR DESCRIPTION
This fix considers that an Award and a Subaward are 'linked' if there is at least one ACTIVE SubAwardFundingSource object in the DB that references the corresponding AwardNumber and Subaward Code (note that there could be multiple SFS for the same Award/Subaward pair for the different versions of them). 
The business requirements state that ONLY one Award/Subaward link will be displayed, even if there are multiple SFS for the different versions and ONLY the ACTIVE/PENDING version should be displayed.
When a link is 'deleted', all the rows corresponding to the SFS are not removed any more, but marked as INACTIVE. As such, the removed 'link' will not be visible any more for ANY of the versions of the Awad/Subaward.
Added SubAwardFundingSourceDAO with custom PS, to improve the performance of loading the active SFS for an Award/Subaward