### PR TITLE
UAR-1619 Allow numbers with 12 digits total for subaward amounts

### DIFF
--- a/src/main/resources/org/kuali/kra/datadictionary/SubAwardAmountInfo.xml
+++ b/src/main/resources/org/kuali/kra/datadictionary/SubAwardAmountInfo.xml
@@ -1,0 +1,410 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2005-2014 The Kuali Foundation
+ 
+ Licensed under the Educational Community License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.opensource.org/licenses/ecl1.php
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+ 
+ <bean id="SubAwardAmountInfo" parent="SubAwardAmountInfo-parentBean" />
+  <bean id="SubAwardAmountInfo-parentBean" abstract="true" parent="BusinessObjectEntry">
+    <property name="businessObjectClass" value="org.kuali.kra.subaward.bo.SubAwardAmountInfo" />
+		<property name="objectLabel" value="SubAwardAmountInfo" />
+		    <property name="inquiryDefinition" >
+		      <ref bean="SubAwardAmountInfo-inquiryDefinition" />
+		    </property>
+		    <property name="lookupDefinition" >
+		      <ref bean="SubAwardAmountInfo-lookupDefinition" />
+		    </property>
+       		<property name="attributes" >
+		      <list>
+		      	<ref bean="SubAwardAmountInfo-subAwardAmountInfoId" />
+		        <ref bean="SubAwardAmountInfo-subAwardId" />
+		        <ref bean="SubAwardAmountInfo-obligatedAmount" />
+				<ref bean="SubAwardAmountInfo-obligatedChange" />
+		        <ref bean="SubAwardAmountInfo-anticipatedAmount" />
+		        <ref bean="SubAwardAmountInfo-anticipatedChange" />
+		        <ref bean="SubAwardAmountInfo-effectiveDate" />
+		        <ref bean="SubAwardAmountInfo-comments" />
+		        <ref bean="SubAwardAmountInfo-fileName" />
+				<ref bean="SubAwardAmountInfo-document" />
+		        <ref bean="SubAwardAmountInfo-mimeType" />
+		        <ref bean="SubAwardAmountInfo-modificationEffectiveDate" />
+		        <ref bean="SubAwardAmountInfo-modificationID" />
+		        <ref bean="SubAwardAmountInfo-periodofPerformanceStartDate" />
+		        <ref bean="SubAwardAmountInfo-periodofPerformanceEndDate" />
+		      </list>
+		    </property>
+		   
+ 		 </bean>
+    
+
+<!-- Attribute Definitions -->
+    
+   <bean id="SubAwardAmountInfo-subAwardAmountInfoId" parent="SubAwardAmountInfo-subAwardAmountInfoId-parentBean" />
+  <bean id="SubAwardAmountInfo-subAwardAmountInfoId-parentBean" abstract="true" parent="AttributeDefinition">
+       <property name="name" value="subAwardAmountInfoId" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Subaward Amount Info Id" />
+    <property name="shortLabel" value="Subaward Amount Info Id" />
+    <property name="maxLength" value="22" />
+    <property name="validationPattern" >
+      <bean parent="NumericValidationPattern" />
+    </property>
+    <property name="required" value="false" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+            p:size="10" />
+    </property>
+    <property name="summary" value="Subaward Amount Info Id" />
+    <property name="description" value="Subaward Amount Info Id" />    
+  </bean>
+      
+   <bean id="SubAwardAmountInfo-subAwardId" parent="SubAwardAmountInfo-subAwardId-parentBean" />
+  <bean id="SubAwardAmountInfo-subAwardId-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="subAwardId" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Subaward Id" />
+    <property name="shortLabel" value="Subaward Id" />
+    <property name="maxLength" value="22" />
+    <property name="validationPattern" >
+      <bean parent="NumericValidationPattern" />
+    </property>
+    <property name="required" value="false" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+            p:size="10" />
+    </property>
+    <property name="summary" value="Subaward Id" />
+    <property name="description" value="Subaward Id" />    
+  </bean> 
+  
+  
+   <bean id="SubAwardAmountInfo-obligatedAmount" parent="SubAwardAmountInfo-obligatedAmount-parentBean" />
+  
+  <bean id="SubAwardAmountInfo-obligatedAmount-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="obligatedAmount" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Obligated Amount" />
+    <property name="shortLabel" value="Obligated Amount" />
+    <property name="maxLength" value="22" />
+    <property name="validationPattern" >
+      <bean parent="FixedPointValidationPattern"
+            p:precision="12"
+            p:scale="2"
+            p:allowNegative="true" />
+    </property>
+    <property name="required" value="false" />
+    <property name="control" >
+      <bean parent="CurrencyControlDefinition"
+            p:formattedMaxLength="22"
+            p:size="16" />
+    </property>
+    <property name="summary" value="Obligated Amount" />
+    <property name="description" value="Obligated Amount" />    
+  </bean>    
+     
+  <bean id="SubAwardAmountInfo-obligatedChange" parent="SubAwardAmountInfo-obligatedChange-parentBean" />
+  
+  <bean id="SubAwardAmountInfo-obligatedChange-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="obligatedChange" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Obligated Change" />
+    <property name="shortLabel" value="Obligated Change" />
+    <property name="maxLength" value="12" />
+    <property name="validationPattern" >
+     <bean parent="FixedPointValidationPattern"
+            p:precision="10"
+            p:scale="2"
+            p:allowNegative="true" />
+            
+    </property>
+    <property name="required" value="true" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+            p:size="10" />
+    </property>
+    <property name="summary" value="Obligated Change" />
+    <property name="description" value="Obligated Change" />    
+  </bean>    
+           
+   <bean id="SubAwardAmountInfo-anticipatedAmount" parent="SubAwardAmountInfo-anticipatedAmount-parentBean" />
+  
+  <bean id="SubAwardAmountInfo-anticipatedAmount-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="anticipatedAmount" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Anticipated Amount" />
+    <property name="shortLabel" value="Anticipated Amount" />
+    <property name="maxLength" value="22" />
+    <property name="validationPattern" >
+     <bean parent="FixedPointValidationPattern"
+            p:precision="10"
+            p:scale="2" />
+    </property>
+    <property name="required" value="false" />
+   <property name="control" >
+      <bean parent="CurrencyControlDefinition"
+            p:formattedMaxLength="22"
+            p:size="16" />
+    </property>
+    <property name="summary" value="Anticipated Amount" />
+    <property name="description" value="Anticipated Amount" />    
+  </bean>        
+           
+        <bean id="SubAwardAmountInfo-anticipatedChange" parent="SubAwardAmountInfo-anticipatedChange-parentBean" />
+  
+  <bean id="SubAwardAmountInfo-anticipatedChange-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="anticipatedChange" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Anticipated Change" />
+    <property name="shortLabel" value="Anticipated Change" />
+    <property name="maxLength" value="12" />
+    <property name="validationPattern" >
+     <bean parent="FixedPointValidationPattern"
+            p:precision="10"
+            p:scale="2" 
+            p:allowNegative="true" />
+            
+    </property>
+    <property name="required" value="true" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+            p:size="10" />
+    </property>
+    <property name="summary" value="Anticipated Change" />
+    <property name="description" value="Anticipated Change" />    
+  </bean> 
+  
+  <bean id="SubAwardAmountInfo-effectiveDate" parent="SubAwardAmountInfo-effectiveDate-parentBean" />
+  
+  <bean id="SubAwardAmountInfo-effectiveDate-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="effectiveDate" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Effective Date" />
+    <property name="shortLabel" value="Effective Date" />
+    <property name="maxLength" value="22" />
+    <property name="validationPattern" >
+      <bean parent="NumericValidationPattern" />
+    </property>
+    <property name="required" value="true" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+            p:size="10" />
+    </property>
+    <property name="summary" value="Effective Date" />
+    <property name="description" value="Effective Date" />    
+  </bean> 
+  
+    <bean id="SubAwardAmountInfo-comments" parent="SubAwardAmountInfo-comments-parentBean" />
+  
+  <bean id="SubAwardAmountInfo-comments-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="comments" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Comments" />
+    <property name="shortLabel" value="Comments" />
+    <property name="maxLength" value="4000" />
+    <property name="required" value="false" />
+    <property name="control" >
+  <bean parent="TextareaControlDefinition" p:rows="3" p:cols="60" />
+    </property>
+    <property name="summary" value="Comments" />
+    <property name="description" value="Comments" />    
+  </bean> 
+  
+  <bean id="SubAwardAmountInfo-fileName" parent="SubAwardAmountInfo-fileName-parentBean" />
+    <bean id="SubAwardAmountInfo-fileName-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="fileName" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="File Name" />
+    <property name="shortLabel" value="File Name" />
+    <property name="maxLength" value="150" />
+    <property name="validationPattern" >
+      <bean parent="AnyCharacterValidationPattern"
+            	p:allowWhitespace="true" />
+    </property>
+    <property name="required" value="false" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+            p:size="15" />
+    </property>
+    <property name="summary" value="File Name" />
+    <property name="description" value="File Name" />    
+  </bean>          
+           
+     <bean id="SubAwardAmountInfo-document" parent="SubAwardAmountInfo-document-parentBean" />
+    <bean id="SubAwardAmountInfo-document-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="document" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Document" />
+    <property name="shortLabel" value="Document" />
+    <property name="maxLength" value="22" />
+    <property name="validationPattern" >
+      <bean parent="NumericValidationPattern" />
+    </property>
+    <property name="required" value="false" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+            p:size="10" />
+    </property>
+    <property name="summary" value="Document" />
+    <property name="description" value="Document" />    
+  </bean>    
+  
+          
+     <bean id="SubAwardAmountInfo-mimeType" parent="SubAwardAmountInfo-mimeType-parentBean" />
+    <bean id="SubAwardAmountInfo-mimeType-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="mimeType" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Mime Type" />
+    <property name="shortLabel" value="Mime Type" />
+    <property name="maxLength" value="4000" />
+    <property name="validationPattern" >
+      <bean parent="AnyCharacterValidationPattern"
+                p:allowWhitespace="true" />
+    </property>
+    <property name="required" value="false" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+            p:size="10" />
+    </property>
+    <property name="summary" value="Mime Type" />
+    <property name="description" value="Mime Type" />    
+  </bean>     
+  
+  <bean id="SubAwardAmountInfo-modificationEffectiveDate" parent="SubAwardAmountInfo-modificationEffectiveDate-parentBean" />
+  
+  <bean id="SubAwardAmountInfo-modificationEffectiveDate-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="modificationEffectiveDate" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Modification Effective Date" />
+    <property name="shortLabel" value="Modification Effective Date " />
+    <property name="maxLength" value="22" />
+    <property name="validationPattern" >
+      <bean parent="NumericValidationPattern" />
+    </property>
+    <property name="required" value="false" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+            p:size="10" />
+    </property>
+    <property name="summary" value="Modification Effective Date " />
+    <property name="description" value="Modification Effective Date " />    
+  </bean>
+  
+  <bean id="SubAwardAmountInfo-modificationID" parent="SubAwardAmountInfo-modificationID-parentBean" />
+  <bean id="SubAwardAmountInfo-modificationID-parentBean" abstract="true" parent="SubAward-modificationId">
+      <property name="name" value="modificationID" />
+  </bean> 
+  
+  <bean id="SubAwardAmountInfo-periodofPerformanceStartDate" parent="SubAwardAmountInfo-periodofPerformanceStartDate-parentBean" />
+  
+  <bean id="SubAwardAmountInfo-periodofPerformanceStartDate-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="periodofPerformanceStartDate" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Period of Performance Start Date" />
+    <property name="shortLabel" value="Period of Performance Start Date" />
+    <property name="maxLength" value="22" />
+    <property name="validationPattern" >
+      <bean parent="NumericValidationPattern" />
+    </property>
+    <property name="required" value="false" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+            p:size="10" />
+    </property>
+    <property name="summary" value="Period of Performance Start Date" />
+    <property name="description" value="Period of Performance Start Date" />    
+  </bean>
+  
+  <bean id="SubAwardAmountInfo-periodofPerformanceEndDate" parent="SubAwardAmountInfo-periodofPerformanceEndDate-parentBean" />
+  
+  <bean id="SubAwardAmountInfo-periodofPerformanceEndDate-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="periodofPerformanceEndDate" />
+    <property name="forceUppercase" value="false" />
+    <property name="label" value="Period of Performance End Date" />
+    <property name="shortLabel" value="Period of Performance End Date" />
+    <property name="maxLength" value="22" />
+    <property name="validationPattern" >
+      <bean parent="NumericValidationPattern" />
+    </property>
+    <property name="required" value="false" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+            p:size="10" />
+    </property>
+    <property name="summary" value="Period of Performance End Date" />
+    <property name="description" value="Period of Performance End Date" />    
+  </bean>
+  
+ <bean id="SubAwardAmountInfo-versionNumber" parent="SubAwardAmountInfo-versionNumber-parentBean" />
+    <bean id="SubAwardAmountInfo-versionNumber-parentBean" abstract="true" parent="AttributeReferenceDummy-versionNumber">
+    </bean>
+           
+ <!-- Business Object Inquiry Definition -->
+ <bean id="SubAwardAmountInfo-inquiryDefinition" parent="SubAwardAmountInfo-inquiryDefinition-parentBean" />
+
+  <bean id="SubAwardAmountInfo-inquiryDefinition-parentBean" abstract="true" parent="InquiryDefinition">
+    <property name="title" value="Subaward Amount Info" />
+    <property name="inquirySections" >
+      <list>
+        <bean parent="InquirySectionDefinition">
+          <property name="title" value="SubAwardAmountInfo" />
+          <property name="numberOfColumns" value="1" />
+          <property name="inquiryFields" >
+            <list>
+              <bean parent="FieldDefinition"
+                    p:attributeName="subAwardAmountInfoId"
+                    p:forceInquiry="true" />             
+            </list>
+          </property>
+        </bean>
+      </list>
+    </property>
+  </bean>
+  
+  <!-- Business Object Lookup Definition -->
+
+  <bean id="SubAwardAmountInfo-lookupDefinition" parent="SubAwardAmountInfo-lookupDefinition-parentBean" />
+
+  <bean id="SubAwardAmountInfo-lookupDefinition-parentBean" abstract="true" parent="LookupDefinition">
+    <property name="title" value="Subaward Amount Info Lookup" />
+    <property name="menubar" value="&lt;a href=&quot;index.jsp&quot;&gt;Main&lt;/a&gt;" />
+
+    <property name="defaultSort" >
+      <bean parent="SortDefinition">
+      </bean>
+    </property>
+    <property name="lookupFields" >
+      <list>
+        <bean parent="FieldDefinition"
+                    p:attributeName="subAwardAmountInfoId"
+                    p:forceInquiry="true" />
+                    <bean p:attributeName="subAwardCode"   parent="FieldDefinition"/>
+                    <bean p:attributeName="subAwardId"   parent="FieldDefinition"/>
+               
+      </list>
+    </property>
+    <property name="resultFields" >
+      <list>      
+                <bean parent="FieldDefinition" p:attributeName="subAwardAmountInfoId" p:forceInquiry="true" />   
+                <bean p:attributeName="subAwardCode"   parent="FieldDefinition"/>
+                <bean p:attributeName="subAwardId"   parent="FieldDefinition"/>
+      </list>
+    </property>
+  </bean>
+ 
+</beans>

--- a/src/main/resources/org/kuali/kra/datadictionary/SubAwardAmountInfo.xml
+++ b/src/main/resources/org/kuali/kra/datadictionary/SubAwardAmountInfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright 2005-2014 The Kuali Foundation
+ Copyright 2005-2015 The Kuali Foundation
  
  Licensed under the Educational Community License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -125,18 +125,17 @@
     <property name="forceUppercase" value="false" />
     <property name="label" value="Obligated Change" />
     <property name="shortLabel" value="Obligated Change" />
-    <property name="maxLength" value="12" />
+    <property name="maxLength" value="22" />
     <property name="validationPattern" >
      <bean parent="FixedPointValidationPattern"
-            p:precision="10"
+            p:precision="12"
             p:scale="2"
             p:allowNegative="true" />
-            
     </property>
-    <property name="required" value="true" />
     <property name="control" >
-      <bean parent="TextControlDefinition"
-            p:size="10" />
+      <bean parent="CurrencyControlDefinition"
+            p:formattedMaxLength="22"
+            p:size="16" />
     </property>
     <property name="summary" value="Obligated Change" />
     <property name="description" value="Obligated Change" />    
@@ -151,15 +150,15 @@
     <property name="shortLabel" value="Anticipated Amount" />
     <property name="maxLength" value="22" />
     <property name="validationPattern" >
-     <bean parent="FixedPointValidationPattern"
-            p:precision="10"
+        <bean parent="FixedPointValidationPattern"
+            p:precision="12"
             p:scale="2" />
     </property>
     <property name="required" value="false" />
-   <property name="control" >
-      <bean parent="CurrencyControlDefinition"
-            p:formattedMaxLength="22"
-            p:size="16" />
+    <property name="control" >
+        <bean parent="CurrencyControlDefinition"
+                p:formattedMaxLength="22"
+                p:size="16" />
     </property>
     <property name="summary" value="Anticipated Amount" />
     <property name="description" value="Anticipated Amount" />    
@@ -172,18 +171,19 @@
     <property name="forceUppercase" value="false" />
     <property name="label" value="Anticipated Change" />
     <property name="shortLabel" value="Anticipated Change" />
-    <property name="maxLength" value="12" />
+    <property name="maxLength" value="22" />
     <property name="validationPattern" >
      <bean parent="FixedPointValidationPattern"
-            p:precision="10"
+            p:precision="12"
             p:scale="2" 
             p:allowNegative="true" />
             
     </property>
     <property name="required" value="true" />
     <property name="control" >
-      <bean parent="TextControlDefinition"
-            p:size="10" />
+        <bean parent="CurrencyControlDefinition"
+                p:formattedMaxLength="22"
+                p:size="16" />
     </property>
     <property name="summary" value="Anticipated Change" />
     <property name="description" value="Anticipated Change" />    

--- a/src/main/resources/org/kuali/kra/datadictionary/SubAwardAmountReleased.xml
+++ b/src/main/resources/org/kuali/kra/datadictionary/SubAwardAmountReleased.xml
@@ -86,8 +86,9 @@
     </property>
     <property name="required" value="true" />
     <property name="control" >
-    <bean parent="TextControlDefinition"
-            p:size="10" />
+      <bean parent="CurrencyControlDefinition"
+            p:formattedMaxLength="22"
+            p:size="16" />
     </property>
     <property name="summary" value="Amount Released" />
     <property name="description" value="Amount Released" />    


### PR DESCRIPTION
Changed validation rules for amounts in subaward to be consistent with 12 digits. Columns in the database already are set to this size.