### PR TITLE
UAR 1609 - Add SPS Restricted Notes Functionality to Proposal Development

### DIFF
--- a/src/main/java/edu/arizona/kra/proposaldevelopment/bo/SPSRestrictedNote.java
+++ b/src/main/java/edu/arizona/kra/proposaldevelopment/bo/SPSRestrictedNote.java
@@ -1,0 +1,136 @@
+package edu.arizona.kra.proposaldevelopment.bo;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+
+import javax.persistence.Transient;
+
+import org.kuali.kra.bo.KraPersistableBusinessObjectBase;
+import org.kuali.kra.proposaldevelopment.bo.DevelopmentProposal;
+
+public class SPSRestrictedNote extends KraPersistableBusinessObjectBase{
+    private static final long serialVersionUID = 3127043554039982403L;
+
+    private Integer id;   
+    
+    private String proposalNumber;
+  
+    private Timestamp createdDate;
+    
+    private String authorId;
+    
+    @Transient
+    private String authorName;
+   
+    private String noteText;
+    
+    private String noteTopic;
+    
+    private Date proposalReceivedDate;
+    
+    private String proposalReceivedTime;
+    
+    private Boolean active = Boolean.TRUE;
+    
+    @Transient
+    private DevelopmentProposal propDev;
+  
+
+   
+    public Date getProposalReceivedDate() {
+        return proposalReceivedDate;
+    }
+
+    public void setProposalReceivedDate(Date proposalReceivedDate) {
+        this.proposalReceivedDate = proposalReceivedDate;
+    }
+
+    public String getProposalReceivedTime() {
+        return proposalReceivedTime;
+    }
+
+    public void setProposalReceivedTime(String proposalReceivedTime) {
+        this.proposalReceivedTime = proposalReceivedTime;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getProposalNumber() {
+        return proposalNumber;
+    }
+
+    public void setProposalNumber(String proposalNumber) {
+        this.proposalNumber = proposalNumber;
+    }
+
+    public Timestamp getCreateDate() {
+        return createdDate;
+    }
+
+    public void setCreateDate(Timestamp createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public String getAuthorId() {
+        return authorId;
+    }
+
+    public void setAuthorId(String authorId) {
+        this.authorId = authorId;
+    }
+
+    public String getNoteText() {
+        return noteText;
+    }
+
+    public void setNoteText(String noteText) {
+        this.noteText = noteText;
+    }
+
+    public DevelopmentProposal getPropDev() {
+        return propDev;
+    }
+
+    public void setPropDev(DevelopmentProposal propDev) {
+        this.propDev = propDev;
+    }
+
+    public Boolean isActive() {
+        return active;
+    }
+
+    public void setActive(Boolean active) {
+        this.active = active;
+    }
+
+    public String getAuthorName() {
+        return authorName;
+    }
+
+    public void setAuthorName(String authorName) {
+        this.authorName = authorName;
+    }
+
+    public Timestamp getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(Timestamp createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public String getNoteTopic() {
+        return noteTopic;
+    }
+
+    public void setNoteTopic(String noteTopic) {
+        this.noteTopic = noteTopic;
+    }
+
+}

--- a/src/main/java/edu/arizona/kra/proposaldevelopment/dao/SPSRestrictedNoteDao.java
+++ b/src/main/java/edu/arizona/kra/proposaldevelopment/dao/SPSRestrictedNoteDao.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2005-2015 The Kuali Foundation
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.opensource.org/licenses/ecl1.php
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.arizona.kra.proposaldevelopment.dao;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.ojb.broker.accesslayer.LookupException;
+
+import edu.arizona.kra.proposaldevelopment.bo.SPSRestrictedNote;
+
+/**
+ * SPS Restricted Notes DAO interface.
+ * @author nataliac
+ */
+public interface SPSRestrictedNoteDao {
+
+    /**
+     * Searches the SPS Restricted Notes associated with a Proposal Number
+     * 
+     * @return  A list of SPSRestrictedNote
+     * @throws LookupException 
+     * @throws SQLException 
+     */
+    public List<SPSRestrictedNote> getSPSRestrictedNotes(String proposalNumber) throws SQLException, LookupException;
+
+
+    /**
+     * Adds the given SPS Restricted note in the DB
+     * 
+     * @param SPSRestrictedNote spsRestrictedNote
+     * @return SPSRestrictedNote the newly added SPS Restricted Note
+     * @throws LookupException 
+     * @throws SQLException 
+     */
+    public SPSRestrictedNote addSPSRestrictedNote(SPSRestrictedNote spsRestrictedNote) throws SQLException, LookupException;
+
+    
+    /**
+     * Deletes a SPS Restricted note from the DB
+     * 
+     * @param SPSRestrictedNote spsRestrictedNote to be deleted
+     * @return true if note was successfully deleted
+     * @throws LookupException 
+     * @throws SQLException 
+     */
+    public boolean deleteSPSRestrictedNote(SPSRestrictedNote spsRestrictedNote) throws SQLException, LookupException;
+
+
+
+
+}

--- a/src/main/java/edu/arizona/kra/proposaldevelopment/dao/ojb/PropDevRoutingStateDaoOjb.java
+++ b/src/main/java/edu/arizona/kra/proposaldevelopment/dao/ojb/PropDevRoutingStateDaoOjb.java
@@ -94,7 +94,9 @@ public class PropDevRoutingStateDaoOjb extends LookupDaoOjb implements PropDevRo
                     rtState.setLeadUnitName( rs.getString(COL_LEAD_UNIT_NAME));
                     rtState.setLeadCollege("");
                     String ordExpedited = rs.getString(COL_ORD_EXP);
-                    rtState.setORDExpedited(!StringUtils.isEmpty(ordExpedited)&&YES.equalsIgnoreCase(ordExpedited));
+                    rtState.setORDExpedited(YES.equalsIgnoreCase(ordExpedited));
+                    String fpr = rs.getString(COL_FPR);
+                    rtState.setFinalProposalReceived(YES.equalsIgnoreCase(fpr));
                     rtState.setSPSPersonId(rs.getString(COL_SPS_REVIEWER_ID));
                     rtState.setSPSReviewerName(rs.getString(COL_SPS_REVIEWER_NAME));
                     results.add(rtState);

--- a/src/main/java/edu/arizona/kra/proposaldevelopment/dao/ojb/SPSRestrictedNoteDaoOjb.java
+++ b/src/main/java/edu/arizona/kra/proposaldevelopment/dao/ojb/SPSRestrictedNoteDaoOjb.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2005-2015 The Kuali Foundation
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.osedu.org/licenses/ECL-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.arizona.kra.proposaldevelopment.dao.ojb;
+
+
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.ojb.broker.accesslayer.LookupException;
+import org.apache.ojb.broker.query.Criteria;
+import org.apache.ojb.broker.query.QueryByCriteria;
+import org.kuali.rice.core.framework.persistence.ojb.dao.PlatformAwareDaoBaseOjb;
+import org.kuali.rice.krad.service.BusinessObjectService;
+import org.kuali.rice.krad.service.KRADServiceLocator;
+import org.kuali.rice.krad.service.util.OjbCollectionAware;
+
+import edu.arizona.kra.proposaldevelopment.bo.SPSRestrictedNote;
+import edu.arizona.kra.proposaldevelopment.dao.SPSRestrictedNoteDao;
+
+import static edu.arizona.kra.proposaldevelopment.PropDevRoutingStateConstants.*;
+
+
+/**
+ * SPS Restricted Notes DAO Ojb implementation.
+ * @author nataliac
+ */
+public class SPSRestrictedNoteDaoOjb extends PlatformAwareDaoBaseOjb implements OjbCollectionAware, SPSRestrictedNoteDao {
+    private static final Log LOG = LogFactory.getLog(PlatformAwareDaoBaseOjb.class);
+    
+    private BusinessObjectService businessObjectService;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<SPSRestrictedNote> getSPSRestrictedNotes(String proposalNumber) throws SQLException, LookupException {
+        LOG.debug("getSPSRestrictedNotes: prop="+proposalNumber);
+        
+        List<SPSRestrictedNote> result = new ArrayList<SPSRestrictedNote>();
+        if ( StringUtils.isNotEmpty( proposalNumber ) ){
+            Criteria criteria = new Criteria();
+            criteria.addEqualTo(PROP_NUMBER, proposalNumber);
+            criteria.addEqualTo(ACTIVE, Boolean.TRUE);
+            QueryByCriteria query = new QueryByCriteria(SPSRestrictedNote.class,criteria);
+            query.addOrderBy(CREATED_DATE, true);
+            result = (List<SPSRestrictedNote>)getPersistenceBrokerTemplate().getCollectionByQuery(query);
+        }
+        return result;
+    }
+
+    @Override
+    public SPSRestrictedNote addSPSRestrictedNote(SPSRestrictedNote spsRestrictedNote) throws SQLException, LookupException {
+        return getBusinessObjectService().save(spsRestrictedNote);
+    }
+
+    @Override
+    public boolean deleteSPSRestrictedNote(SPSRestrictedNote spsRestrictedNote) throws SQLException, LookupException {
+        spsRestrictedNote.setActive(false);
+        getBusinessObjectService().save(spsRestrictedNote);
+        return true;
+    }
+    
+    
+    protected BusinessObjectService getBusinessObjectService(){
+        if ( businessObjectService == null ){
+            businessObjectService = KRADServiceLocator.getBusinessObjectService();
+        }
+        return businessObjectService;
+    }
+
+}

--- a/src/main/java/edu/arizona/kra/proposaldevelopment/service/PropDevRoutingStateService.java
+++ b/src/main/java/edu/arizona/kra/proposaldevelopment/service/PropDevRoutingStateService.java
@@ -23,6 +23,7 @@ import org.kuali.kra.bo.KcPerson;
 import org.kuali.rice.krad.exception.AuthorizationException;
 
 import edu.arizona.kra.proposaldevelopment.bo.ProposalDevelopmentRoutingState;
+import edu.arizona.kra.proposaldevelopment.bo.SPSRestrictedNote;
 import edu.arizona.kra.proposaldevelopment.bo.SPSReviewer;
 
 /**
@@ -78,10 +79,43 @@ public interface PropDevRoutingStateService {
 
     /**
      * Returns the list of SPSReviewer beans containing principalId and FullNames for the users that have the SPSReviewer role
-     * @return
+     * @return List<SPSReviewer> 
      * @throws LookupException 
      */
     public List<SPSReviewer> findSPSReviewers() throws LookupException;
+
+
+    /**
+     * Returns the list of SPSReviewer restricted notes for the given proposalNumber 
+     * @return List<SPSRestrictedNote>
+     * @throws AuthorizationException, IllegalArgumentException; 
+     */
+    List<SPSRestrictedNote> getSPSRestrictedNotes(String proposalNumber) throws AuthorizationException, IllegalArgumentException;
+
+
+    /**
+     * Adds a new SPSRestrictedNote to the DB
+     * The service will check if the currentUser is not authorized for this action, will throw a AuthorizationException.
+     * @return SPSRestrictedNote - the newly added note
+     * @throws AuthorizationException, IllegalArgumentException 
+     */
+    SPSRestrictedNote addSPSRestrictedNote(SPSRestrictedNote spsRestrictedNote) throws AuthorizationException, IllegalArgumentException;
+
+
+    /**
+     * Delete the given SPSRestrictedNote from the DB
+     * The service will check if the currentUser is not authorized for this action, will throw a AuthorizationException.
+     * @return boolean - true if the deletion was successful, false otherwise
+     * @throws AuthorizationException, IllegalArgumentException 
+     */
+    boolean deleteSPSRestrictedNote(SPSRestrictedNote spsRestrictedNote) throws AuthorizationException, IllegalArgumentException;
+
+
+    /**
+     * Returns TRUE if the current authenticated user has the right to edit SPS Restricted Notes, FALSE otherwise
+     * @return boolean
+     */
+    boolean canEditSPSRestrictedNotes();
 
 
 }

--- a/src/main/java/edu/arizona/kra/proposaldevelopment/service/impl/PropDevRoutingStateServiceImpl.java
+++ b/src/main/java/edu/arizona/kra/proposaldevelopment/service/impl/PropDevRoutingStateServiceImpl.java
@@ -25,14 +25,20 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.ojb.broker.accesslayer.LookupException;
 import org.kuali.kra.bo.KcPerson;
+import org.kuali.kra.infrastructure.KraServiceLocator;
 import org.kuali.kra.service.KcPersonService;
 import org.kuali.rice.krad.exception.AuthorizationException;
+import org.kuali.rice.krad.service.DocumentHeaderService;
+import org.kuali.rice.krad.service.KRADServiceLocator;
+import org.kuali.rice.krad.service.NoteService;
 import org.kuali.rice.krad.util.GlobalVariables;
 
 import edu.arizona.kra.proposaldevelopment.PropDevRoutingStateConstants;
 import edu.arizona.kra.proposaldevelopment.bo.ProposalDevelopmentRoutingState;
+import edu.arizona.kra.proposaldevelopment.bo.SPSRestrictedNote;
 import edu.arizona.kra.proposaldevelopment.bo.SPSReviewer;
 import edu.arizona.kra.proposaldevelopment.dao.PropDevRoutingStateDao;
+import edu.arizona.kra.proposaldevelopment.dao.SPSRestrictedNoteDao;
 import edu.arizona.kra.proposaldevelopment.service.CustomAuthorizationService;
 import edu.arizona.kra.proposaldevelopment.service.PropDevRoutingStateService;
 
@@ -46,7 +52,10 @@ public class PropDevRoutingStateServiceImpl implements PropDevRoutingStateServic
 
     private CustomAuthorizationService authorizationService;
     private KcPersonService kcPersonService;
-    protected PropDevRoutingStateDao dataAccessObject;
+    protected PropDevRoutingStateDao propDevRoutingStateDao;
+    protected SPSRestrictedNoteDao SPSRestrictedNoteDao;
+    protected DocumentHeaderService documentHeaderService;
+    protected NoteService noteService;
 
 
     private static final Log LOG = LogFactory.getLog(PropDevRoutingStateServiceImpl.class);
@@ -62,7 +71,7 @@ public class PropDevRoutingStateServiceImpl implements PropDevRoutingStateServic
         LOG.debug("getSearchResults():"+searchCriteria.toString());
         List <ProposalDevelopmentRoutingState> results = new ArrayList<ProposalDevelopmentRoutingState>();
         try {
-            results = dataAccessObject.getPropDevRoutingState(searchCriteria);
+            results = propDevRoutingStateDao.getPropDevRoutingState(searchCriteria);
         } catch (Exception e){
             e.printStackTrace();
             LOG.error(e);
@@ -72,10 +81,88 @@ public class PropDevRoutingStateServiceImpl implements PropDevRoutingStateServic
     }
 
 
-
-    public void setDataAccessObject(PropDevRoutingStateDao dataAccessObject) {
-        this.dataAccessObject = dataAccessObject;
+    @Override
+    public List<SPSRestrictedNote> getSPSRestrictedNotes(String proposalNumber) throws  AuthorizationException, IllegalArgumentException {
+        LOG.debug("getSPSRestrictedNotes(): prop="+proposalNumber+" currentUser:"+GlobalVariables.getUserSession().getPrincipalName());
+        
+        if ( StringUtils.isEmpty(proposalNumber) ){
+            throw new IllegalArgumentException("Null/empty proposalNumber !");
+        }
+        
+        List<SPSRestrictedNote> restrictedNotes = new ArrayList<SPSRestrictedNote>();
+        try {
+            restrictedNotes = SPSRestrictedNoteDao.getSPSRestrictedNotes(proposalNumber);
+            //populate SPS Restricted Notes Author Ids.
+            Collection<String> membersIds= new ArrayList<String>(restrictedNotes.size());
+            for (SPSRestrictedNote note: restrictedNotes){
+                membersIds.add(note.getAuthorId());
+            }
+            List<SPSReviewer> authors = propDevRoutingStateDao.findSPSReviewers(membersIds);
+            for (SPSRestrictedNote note: restrictedNotes){
+                for ( SPSReviewer author: authors){
+                    if ( note.getAuthorId().equalsIgnoreCase( author.getPrincipalId())){
+                        note.setAuthorName( author.getFullName());
+                        break;
+                    }
+                }
+            }
+            
+        } catch (Exception e){
+            e.printStackTrace();
+            LOG.error(e);
+            throw new RuntimeException(e);
+        }
+        LOG.debug("getSPSRestrictedNotes(): Finished.");
+        return restrictedNotes;
     }
+    
+    @Override
+    public boolean canEditSPSRestrictedNotes(){
+        LOG.debug("canEditSPSRestrictedNotes()");
+        String currentUserId = GlobalVariables.getUserSession().getPrincipalId();
+        if ( !StringUtils.isEmpty(currentUserId) ){
+            return getAuthorizationService().hasSPSPermission(currentUserId, PropDevRoutingStateConstants.EDIT_SPS_RESTRICTED_NOTES_PERMISSION);
+        }
+        return false;
+    }
+    
+    
+    @Override
+    public SPSRestrictedNote addSPSRestrictedNote(SPSRestrictedNote spsRestrictedNote) throws AuthorizationException, IllegalArgumentException{
+        LOG.debug("addSPSRestrictedNote(): "+spsRestrictedNote);
+        checkUserAuthorization( PropDevRoutingStateConstants.EDIT_SPS_RESTRICTED_NOTES_PERMISSION);
+        try {
+            return SPSRestrictedNoteDao.addSPSRestrictedNote(spsRestrictedNote);
+        } catch (Exception e){
+            e.printStackTrace();
+            LOG.error(e);
+            throw new RuntimeException(e);
+        }
+    }
+    
+
+    @Override
+    public boolean deleteSPSRestrictedNote(SPSRestrictedNote spsRestrictedNote) throws AuthorizationException, IllegalArgumentException {
+        LOG.debug("deleteSPSRestrictedNote(): "+spsRestrictedNote);
+        checkUserAuthorization( PropDevRoutingStateConstants.EDIT_SPS_RESTRICTED_NOTES_PERMISSION);
+        try {
+            return SPSRestrictedNoteDao.deleteSPSRestrictedNote(spsRestrictedNote);
+        } catch (Exception e){
+            e.printStackTrace();
+            LOG.error(e);
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    public void setPropDevRoutingStateDao(PropDevRoutingStateDao propDevRoutingStateDao) {
+        this.propDevRoutingStateDao = propDevRoutingStateDao;
+    }
+    
+    public void setSPSRestrictedNoteDao(SPSRestrictedNoteDao SPSRestrictedNoteDao) {
+        this.SPSRestrictedNoteDao = SPSRestrictedNoteDao;
+    }
+
 
     public void setAuthorizationService(CustomAuthorizationService authorizationService) {
         this.authorizationService = authorizationService;
@@ -92,13 +179,27 @@ public class PropDevRoutingStateServiceImpl implements PropDevRoutingStateServic
     public void setKcPersonService(KcPersonService kcPersonService) {
         this.kcPersonService = kcPersonService;
     }
+    
+    protected DocumentHeaderService getDocumentHeaderService() {
+        if (documentHeaderService == null ){
+            documentHeaderService = KraServiceLocator.getService(DocumentHeaderService.class);
+        }
+        return documentHeaderService;
+    }
+    
+    protected NoteService getNoteService() {
+        if (this.noteService == null) {
+            this.noteService = KRADServiceLocator.getNoteService();
+        }
+        return this.noteService;
+    }
 
 
     @Override
     public Boolean getORDExpedited(String proposalNumber) throws LookupException {
         LOG.debug("getORDExpedited():"+proposalNumber);
         try {
-            return dataAccessObject.getORDExpedited(proposalNumber);
+            return propDevRoutingStateDao.getORDExpedited(proposalNumber);
         } catch (Exception e){
             e.printStackTrace();
             LOG.error(e);
@@ -113,7 +214,7 @@ public class PropDevRoutingStateServiceImpl implements PropDevRoutingStateServic
         checkUserAuthorization( PropDevRoutingStateConstants.EDIT_ORD_EXPEDITED_PERMISSION);
 
         try {
-            dataAccessObject.setORDExpedited(proposalNumber, ordExp);
+            propDevRoutingStateDao.setORDExpedited(proposalNumber, ordExp);
         } catch (Exception e){
             e.printStackTrace();
             LOG.error(e);
@@ -127,7 +228,7 @@ public class PropDevRoutingStateServiceImpl implements PropDevRoutingStateServic
     public KcPerson getSPSReviewer(String proposalNumber) throws LookupException {
         LOG.debug("getSPSReviewer():"+proposalNumber);
         try {
-            String spsReviewerId = dataAccessObject.getSPSReviewer(proposalNumber);
+            String spsReviewerId = propDevRoutingStateDao.getSPSReviewer(proposalNumber);
             if ( StringUtils.isNotEmpty(spsReviewerId)){
                 return getKcPersonService().getKcPersonByPersonId(spsReviewerId);
             }
@@ -152,7 +253,7 @@ public class PropDevRoutingStateServiceImpl implements PropDevRoutingStateServic
             throw new IllegalArgumentException("setSPSReviewer: Invalid user:"+kcPersonId);
         }
         try {
-            dataAccessObject.setSPSReviewer(proposalNumber, kcPerson.getPersonId(), kcPerson.getFullName());
+            propDevRoutingStateDao.setSPSReviewer(proposalNumber, kcPerson.getPersonId(), kcPerson.getFullName());
         } catch (Exception e){
             e.printStackTrace();
             LOG.error(e);
@@ -169,7 +270,7 @@ public class PropDevRoutingStateServiceImpl implements PropDevRoutingStateServic
         List<SPSReviewer> result = new ArrayList<SPSReviewer>();
         try {
             Collection<String> membersIds= getAuthorizationService().getSPSReviewerRoleMembers();
-            result = dataAccessObject.findSPSReviewers(membersIds);
+            result = propDevRoutingStateDao.findSPSReviewers(membersIds);
         } catch (Exception e){
             e.printStackTrace();
             LOG.error(e);
@@ -178,8 +279,6 @@ public class PropDevRoutingStateServiceImpl implements PropDevRoutingStateServic
         LOG.debug("findSPSReviewers():FINISHED");
         return result;
     }
-
-
 
 
 

--- a/src/main/java/org/kuali/kra/infrastructure/KeyConstants.java
+++ b/src/main/java/org/kuali/kra/infrastructure/KeyConstants.java
@@ -1114,6 +1114,12 @@ public final class KeyConstants {
 	public static final String ERROR_UNIT_ADMIN_MULTIPLE_FOR_TYPE_NOT_ALLOWED = "error.unit.admin.multiple.for.type.not.allowed";
 
     public static final String CLEAR_MODULAR_ERROR_BEFORE_FINALIZE = "clear.modular.error.before.finalize";
+    
+    // SPS Restricted Notes
+    public static final String NEW_SPS_RESTRICTED_NOTE_TOPIC = "newSPSRestrictedNote.noteTopic";
+    public static final String NEW_SPS_RESTRICTED_NOTE_TEXT = "newSPSRestrictedNote.noteText";
+    public static final String NEW_SPS_RESTRICTED_NOTE_DATE = "newSPSRestrictedNote.proposalReceivedDate";
+    public static final String NEW_SPS_RESTRICTED_NOTE_TIME = "newSPSRestrictedNote.proposalReceivedTime";
 
     /**
      * private utility class ctor.

--- a/src/main/java/org/kuali/kra/proposaldevelopment/bo/DevelopmentProposal.java
+++ b/src/main/java/org/kuali/kra/proposaldevelopment/bo/DevelopmentProposal.java
@@ -59,7 +59,7 @@ public class DevelopmentProposal extends KraPersistableBusinessObjectBase implem
 
     private static final String ATTACHMENTS_COMPLETE = "Complete";
 
-    private static final String ATTACHMENTS_INCOMPLETE = "Inomplete";
+    private static final String ATTACHMENTS_INCOMPLETE = "Incomplete";
 
     private static final String ATTACHMENTS_NONE = "None";
     

--- a/src/main/java/org/kuali/kra/proposaldevelopment/web/struts/action/ProposalDevelopmentAbstractsAttachmentsAction.java
+++ b/src/main/java/org/kuali/kra/proposaldevelopment/web/struts/action/ProposalDevelopmentAbstractsAttachmentsAction.java
@@ -1,0 +1,908 @@
+/*
+ * Copyright 2005-2014 The Kuali Foundation
+ * 
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.osedu.org/licenses/ECL-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kuali.kra.proposaldevelopment.web.struts.action;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.kuali.kra.bo.KraPersistableBusinessObjectBase;
+import org.kuali.kra.infrastructure.Constants;
+import org.kuali.kra.infrastructure.KeyConstants;
+import org.kuali.kra.infrastructure.KraServiceLocator;
+import org.kuali.kra.proposaldevelopment.bo.*;
+import org.kuali.kra.proposaldevelopment.document.ProposalDevelopmentDocument;
+import org.kuali.kra.proposaldevelopment.notification.ProposalDevelopmentNotificationContext;
+import org.kuali.kra.proposaldevelopment.notification.ProposalDevelopmentNotificationRenderer;
+import org.kuali.kra.proposaldevelopment.rule.event.*;
+import org.kuali.kra.proposaldevelopment.rules.ProposalDevelopmentInstituteAttachmentRule;
+import org.kuali.kra.proposaldevelopment.service.NarrativeService;
+import org.kuali.kra.proposaldevelopment.service.ProposalAbstractsService;
+import org.kuali.kra.proposaldevelopment.service.ProposalPersonBiographyService;
+import org.kuali.kra.proposaldevelopment.web.struts.form.ProposalDevelopmentForm;
+import org.kuali.kra.web.struts.action.KraTransactionalDocumentActionBase;
+import org.kuali.kra.web.struts.action.StrutsConfirmation;
+import org.kuali.rice.core.api.CoreApiServiceLocator;
+import org.kuali.rice.core.api.datetime.DateTimeService;
+import org.kuali.rice.coreservice.framework.parameter.ParameterConstants;
+import org.kuali.rice.kns.web.struts.form.KualiDocumentFormBase;
+import org.kuali.rice.krad.bo.Note;
+import org.kuali.rice.krad.service.BusinessObjectService;
+import org.kuali.rice.krad.service.KualiRuleService;
+import org.kuali.rice.krad.util.GlobalVariables;
+import org.kuali.rice.krad.util.MessageMap;
+import org.kuali.rice.krad.util.ObjectUtils;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.kuali.kra.infrastructure.Constants.*;
+import static org.kuali.kra.infrastructure.KeyConstants.QUESTION_DELETE_ABSTRACT_CONFIRMATION;
+import static org.kuali.kra.infrastructure.KeyConstants.QUESTION_DELETE_ATTACHMENT_CONFIRMATION;
+import static org.kuali.kra.infrastructure.KraServiceLocator.getService;
+import static org.kuali.rice.krad.util.KRADConstants.QUESTION_INST_ATTRIBUTE_NAME;
+
+/**
+ * <code>Struts Action</code> class process requests from Proposal Abstract Attachments page.
+ * It handles Proposal attachments, Institutional attachments, Personnel attachments and Abstracts.
+ * Attachment(Narrative) Module Maintenance, Narrative user Rights, Upload Attachment, View Attachment, 
+ * Abstract Maintenance are the main features processed by this class 
+ * 
+ * @author KRADEV team
+ * @version 1.0
+ */
+public class ProposalDevelopmentAbstractsAttachmentsAction extends ProposalDevelopmentAction {
+    private static final String PROPOSAL_NARRATIVE_TYPE_GROUP2 = "proposalNarrativeTypeGroup";
+    private static final String EMPTY_STRING = "";
+    private static final String MODULE_NUMBER = "moduleNumber";
+    private static final String PROPOSAL_NUMBER = "proposalNumber";
+    private static final String PROPOSAL_PERSON_NUMBER = "proposalPersonNumber";
+    private static final String BIOGRAPHY_NUMBER = "biographyNumber";
+    private static final Log LOG = LogFactory.getLog(ProposalDevelopmentAbstractsAttachmentsAction.class);
+    private static final String LINE_NUMBER = "line";
+    private static final String CONFIRM_DELETE_ABSTRACT_KEY = "confirmDeleteAbstract";
+    private static final String CONFIRM_DELETE_INSTITUTIONAL_ATTACHMENT_KEY = "confirmDeleteInstitutionalAttachment";
+    private static final String CONFIRM_DELETE_PERSONNEL_ATTACHMENT_KEY = "confirmDeletePersonnelAttachment";
+    private static final String CONFIRM_DELETE_PROPOSAL_ATTACHMENT_KEY = "confirmDeleteProposalAttachment";
+    
+    /**
+     * Overridden method from ProposalDevelopmentAction. It populates Narrative module user rights
+     * before the save.
+     * Proposal Attachments and Institutional Attachments are being saved into <i>NARRATIVE</i> table
+     * 
+     * @see org.kuali.kra.proposaldevelopment.web.struts.action.ProposalDevelopmentAction#save(org.apache.struts.action.ActionMapping, org.apache.struts.action.ActionForm, javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+     */
+    @Override
+    public ActionForward save(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response)
+            throws Exception {
+        ProposalDevelopmentForm proposalDevelopmentForm = (ProposalDevelopmentForm) form;
+        ProposalDevelopmentDocument proposalDevelopmentDocument = proposalDevelopmentForm.getProposalDevelopmentDocument();
+        
+        Narrative newNarrative = proposalDevelopmentForm.getNewNarrative();
+        
+        boolean rulePassed = true;
+        // check any business rules
+        rulePassed &= getKualiRuleService().applyRules(new SaveNarrativesEvent(EMPTY_STRING,proposalDevelopmentDocument,newNarrative, proposalDevelopmentForm.getNarratives()));
+        rulePassed &= getKualiRuleService().applyRules(new SavePersonnelAttachmentEvent(EMPTY_STRING, proposalDevelopmentDocument, proposalDevelopmentForm.getNewPropPersonBio()));
+        rulePassed &= getKualiRuleService().applyRules(new SaveInstituteAttachmentsEvent(EMPTY_STRING,proposalDevelopmentDocument));
+
+        if (!rulePassed){
+            mapping.findForward(Constants.MAPPING_BASIC);
+        }
+        // refresh, so the status can be displayed properly on tab title
+        List<Narrative> narativeListToBeSaved = proposalDevelopmentDocument.getDevelopmentProposal().getNarratives();
+        for (Narrative narrativeToBeSaved : narativeListToBeSaved) {
+            narrativeToBeSaved.refreshNonUpdateableReferences();
+        }
+        
+        return super.save(mapping, form, request, response);
+    }
+    /**
+     * Populates module level rights for each narrative for logged in user.
+     * @see org.kuali.kra.proposaldevelopment.web.struts.action.ProposalDevelopmentAction#execute(org.apache.struts.action.ActionMapping, org.apache.struts.action.ActionForm, javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+     */
+    @Override
+    public ActionForward execute(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        
+        ((ProposalDevelopmentForm)form).getProposalDevelopmentParameters().put(PROPOSAL_NARRATIVE_TYPE_GROUP2,getParameterService().getParameter(Constants.MODULE_NAMESPACE_PROPOSAL_DEVELOPMENT, ParameterConstants.DOCUMENT_COMPONENT, PROPOSAL_NARRATIVE_TYPE_GROUP2));
+        ActionForward actionForward = super.execute(mapping, form, request, response); 
+        ProposalDevelopmentDocument doc = (ProposalDevelopmentDocument)((ProposalDevelopmentForm)form).getDocument();
+        KraServiceLocator.getService(ProposalPersonBiographyService.class).setPersonnelBioTimeStampUser(doc.getDevelopmentProposal().getPropPersonBios()); 
+        List<Narrative> narratives = new ArrayList<Narrative> ();
+        narratives.addAll(doc.getDevelopmentProposal().getNarratives());
+        narratives.addAll(doc.getDevelopmentProposal().getInstituteAttachments());
+        KraServiceLocator.getService(NarrativeService.class).setNarrativeTimeStampUser(narratives);
+        KraServiceLocator.getService(ProposalAbstractsService.class).loadAbstractsUploadUserFullName(doc.getDevelopmentProposal().getProposalAbstracts());
+        return actionForward;
+    }    
+
+    /**
+     * 
+     * This method adds new proposal attachment(narrative) to the narrative list.
+     * User can not add more than one narrative with the same narrative type which 
+     * has allowMultipleFlag as false. This rule is being validated by using AddNarrativeRule
+     * @param mapping
+     * @param form
+     * @param request
+     * @param response
+     * @return ActionForward of ProposalAbstractsAttachments page
+     * @throws Exception
+     */
+    public ActionForward addProposalAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+
+        ProposalDevelopmentForm proposalDevelopmentForm = (ProposalDevelopmentForm) form;
+        ProposalDevelopmentDocument proposalDevelopmentDocument = proposalDevelopmentForm.getProposalDevelopmentDocument();
+        Narrative narrative = proposalDevelopmentForm.getNewNarrative();
+        if(getKualiRuleService().applyRules(new AddNarrativeEvent(EMPTY_STRING, proposalDevelopmentDocument, narrative))){
+            proposalDevelopmentDocument.getDevelopmentProposal().addNarrative(narrative);
+            proposalDevelopmentForm.setNewNarrative(new Narrative());
+            populateTabState(proposalDevelopmentForm, "Proposal Attachments " + proposalDevelopmentDocument.getDevelopmentProposal().getNarratives().size());
+        }
+        return mapping.findForward(Constants.MAPPING_BASIC);
+    }
+    
+    /**
+     * 
+     * This method used to stream the attachment byte array onto the browser.
+     * @param mapping
+     * @param form
+     * @param request
+     * @param response
+     * @return
+     * @throws Exception
+     */
+    public ActionForward downloadInstituteAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        ProposalDevelopmentForm proposalDevelopmentForm = (ProposalDevelopmentForm) form;
+        String line = request.getParameter(LINE_NUMBER);
+        int lineNumber = line == null ? 0 : Integer.parseInt(line);
+        ProposalDevelopmentDocument pd = proposalDevelopmentForm.getProposalDevelopmentDocument();
+        Narrative narrative = pd.getDevelopmentProposal().getInstituteAttachments().get(lineNumber);
+        NarrativeAttachment narrativeAttachment = findNarrativeAttachment(narrative);
+        if(narrativeAttachment==null && !narrative.getNarrativeAttachmentList().isEmpty()){//get it from the memory
+            narrativeAttachment = narrative.getNarrativeAttachmentList().get(0);
+        }
+        streamToResponse(narrativeAttachment,response); 
+        return null;
+    }
+    
+    /**
+     * 
+     * This method used to stream the attachment byte array onto the browser.
+     * @param mapping
+     * @param form
+     * @param request
+     * @param response
+     * @return
+     * @throws Exception
+     */
+    public ActionForward downloadProposalAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        ProposalDevelopmentForm proposalDevelopmentForm = (ProposalDevelopmentForm) form;
+        String line = request.getParameter(LINE_NUMBER);
+        int lineNumber = line == null ? 0 : Integer.parseInt(line);
+        ProposalDevelopmentDocument pd = proposalDevelopmentForm.getProposalDevelopmentDocument();
+        Narrative narrative = pd.getDevelopmentProposal().getNarratives().get(lineNumber);
+        NarrativeAttachment narrativeAttachment = findNarrativeAttachment(narrative);
+        if(narrativeAttachment==null && !narrative.getNarrativeAttachmentList().isEmpty()){//get it from the memory
+            narrativeAttachment = narrative.getNarrativeAttachmentList().get(0);
+        }
+        streamToResponse(narrativeAttachment,response);
+        return null;
+    }
+    /**
+     * 
+     * This method used to find the narrative attachment for a narrative
+     * @param narrative
+     * @return NarrativeAttachment
+     */
+    private NarrativeAttachment findNarrativeAttachment(Narrative narrative){
+        Map<String,String> narrativeAttachemntMap = new HashMap<String,String>();
+        narrativeAttachemntMap.put(PROPOSAL_NUMBER, narrative.getProposalNumber());
+        narrativeAttachemntMap.put(MODULE_NUMBER, narrative.getModuleNumber()+"");
+        return (NarrativeAttachment)getBusinessObjectService().findByPrimaryKey(NarrativeAttachment.class, narrativeAttachemntMap);
+    }
+    
+    /**
+     * This method is used to perform a bulk status change operation on all attachments
+     * @param mapping
+     * @param form
+     * @param request
+     * @param response
+     * @return ActionForward
+     * @throws Exception
+     */
+    public ActionForward markAllNarrativeStatuses(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        
+        ProposalDevelopmentForm developmentForm = (ProposalDevelopmentForm) form;
+        developmentForm.getProposalDevelopmentDocument().getBudgetParent().markNarratives(developmentForm.getNarrativeStatusChange());
+        developmentForm.clearNarrativeStatusChangeKey();
+        return mapping.findForward(MAPPING_BASIC);
+    }
+    
+    public ActionForward modifyProposalAttachmentStatus(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        ProposalDevelopmentForm proposalDevelopmentForm = (ProposalDevelopmentForm) form;
+        ProposalDevelopmentDocument pd = proposalDevelopmentForm.getProposalDevelopmentDocument();
+        ActionForward forward = mapping.findForward(MAPPING_BASIC);
+
+        Narrative modifiedNarrative = pd.getDevelopmentProposal().getNarrative(getSelectedLine(request));
+        
+        pd.getDevelopmentProposal().modifyNarrativeStatus(getSelectedLine(request));
+
+        return forward;
+    }
+
+    /**
+     * 
+     * This method is used to delete the proposal attachment
+     * @param mapping
+     * @param form
+     * @param request
+     * @param response
+     * @return ActionForward
+     * @throws Exception
+     */
+    public ActionForward deleteProposalAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        return confirm(buildDeleteAttachmentConfirmationQuestion(mapping, form, request, response, CONFIRM_DELETE_PROPOSAL_ATTACHMENT_KEY), CONFIRM_DELETE_PROPOSAL_ATTACHMENT_KEY, EMPTY_STRING);
+    }
+
+    /**
+     * 
+     * This method is used to delete the proposal attachment
+     * @param mapping The mapping associated with this action.
+     * @param form The Proposal Development form.
+     * @param request the HTTP request
+     * @param response the HTTP response
+     * @return the destination (always the original proposal web page that caused this action to be invoked)
+     * @throws Exception
+     */
+    public ActionForward confirmDeleteProposalAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        ProposalDevelopmentForm pdForm = (ProposalDevelopmentForm) form;
+        ProposalDevelopmentDocument pdDoc = pdForm.getProposalDevelopmentDocument();
+        populateTabState((ProposalDevelopmentForm) form, "Proposal Attachments " + pdDoc.getDevelopmentProposal().getNarratives().size());
+        return deleteAttachment(mapping, form, request, response, CONFIRM_DELETE_PROPOSAL_ATTACHMENT_KEY, "deleteProposalAttachment");
+    }
+    
+    /**
+     * @param mapping The mapping associated with this action.
+     * @param form The Proposal Development form.
+     * @param request the HTTP request
+     * @param response the HTTP response
+     * @param key Name of the key for this confirmation
+     * @param deleteMethodName String name of the delete method to use.
+     * @return the destination (always the original proposal web page that caused this action to be invoked)
+     * @throws Exception
+     */
+    public ActionForward deleteAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response, String key, String deleteMethodName) throws Exception {
+        Object question = request.getParameter(QUESTION_INST_ATTRIBUTE_NAME);
+        
+        if (key.equals(question)) {
+            ProposalDevelopmentDocument document = ((ProposalDevelopmentForm) form).getProposalDevelopmentDocument();
+            
+            LOG.info("Running delete '" + deleteMethodName + "' on " + document + " for " + getLineToDelete(request));
+            document.getDevelopmentProposal().getClass().getMethod(deleteMethodName, int.class).invoke(document.getDevelopmentProposal(), getLineToDelete(request));
+        }
+        
+        return mapping.findForward(MAPPING_BASIC);
+       
+    }
+
+    /**
+     * 
+     * This method used to get the proposal user rights
+     * @param mapping
+     * @param form
+     * @param request
+     * @param response
+     * @return 
+     * @throws Exception
+     */
+     public ActionForward getInstituteAttachmentRights(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+             HttpServletResponse response) throws Exception {
+         ProposalDevelopmentForm proposalDevelopmentForm = (ProposalDevelopmentForm) form;
+         proposalDevelopmentForm.setShowMaintenanceLinks(false);
+         String line = request.getParameter(LINE_NUMBER);
+         int lineNumber = line == null ? getLineToDelete(request) : Integer.parseInt(line);
+         ProposalDevelopmentDocument pd = proposalDevelopmentForm.getProposalDevelopmentDocument();
+         pd.getDevelopmentProposal().populatePersonNameForInstituteAttachmentUserRights(lineNumber);
+         
+         Narrative narrative = pd.getDevelopmentProposal().getInstituteAttachment(lineNumber);
+         List<NarrativeUserRights> userRights = narrative.getNarrativeUserRights();
+         List<NarrativeUserRights> editUserRights = (List<NarrativeUserRights>) ObjectUtils.deepCopy((Serializable) userRights);
+         proposalDevelopmentForm.setNewNarrativeUserRights(editUserRights);
+         
+         request.setAttribute(LINE_NUMBER, ""+lineNumber);
+         return mapping.findForward(MAPPING_INSTITUTE_ATTACHMENT_RIGHTS_PAGE);
+     }
+     
+   /**
+    * 
+    * This method used to get the proposal user rights
+    * @param mapping
+    * @param form
+    * @param request
+    * @param response
+    * @return 
+    * @throws Exception
+    */
+    public ActionForward getProposalAttachmentRights(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        ProposalDevelopmentForm proposalDevelopmentForm = (ProposalDevelopmentForm) form;
+        proposalDevelopmentForm.setShowMaintenanceLinks(false);
+        String line = request.getParameter(LINE_NUMBER);
+        int lineNumber = line == null ? getLineToDelete(request) : Integer.parseInt(line);
+        ProposalDevelopmentDocument pd = proposalDevelopmentForm.getProposalDevelopmentDocument();
+        pd.getDevelopmentProposal().populatePersonNameForNarrativeUserRights(lineNumber);
+        
+        Narrative narrative = pd.getDevelopmentProposal().getNarratives().get(lineNumber);
+        List<NarrativeUserRights> userRights = narrative.getNarrativeUserRights();
+        List<NarrativeUserRights> editUserRights = (List<NarrativeUserRights>) ObjectUtils.deepCopy((Serializable) userRights);
+        proposalDevelopmentForm.setNewNarrativeUserRights(editUserRights);
+        
+        request.setAttribute(LINE_NUMBER, ""+lineNumber);
+        return mapping.findForward(MAPPING_NARRATIVE_ATTACHMENT_RIGHTS_PAGE);
+    }
+
+    /**
+     * 
+     * This method to send the request back to a page which closes by itself. Since Attachment right page 
+     * is opened in a new window, after saving, it should close by itself.
+     * @param mapping
+     * @param form
+     * @param request
+     * @param response
+     * @return ActionForward of close page
+     * @throws Exception
+     */
+    public ActionForward addProposalAttachmentRights(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        
+        ActionForward forward;
+        
+        ProposalDevelopmentForm proposalDevelopmentForm = (ProposalDevelopmentForm) form;
+        ProposalDevelopmentDocument proposalDevelopmentDocument = proposalDevelopmentForm.getProposalDevelopmentDocument();
+        List<NarrativeUserRights> newNarrativeUserRights = proposalDevelopmentForm.getNewNarrativeUserRights();
+        int lineNumber = getLineNumber(request);
+        
+        // check any business rules
+        boolean rulePassed = getKualiRuleService().applyRules(new NewNarrativeUserRightsEvent(proposalDevelopmentDocument, newNarrativeUserRights, lineNumber));
+        
+        if (!rulePassed) {
+            request.setAttribute(LINE_NUMBER, Integer.toString(lineNumber));
+            forward = mapping.findForward(MAPPING_NARRATIVE_ATTACHMENT_RIGHTS_PAGE);
+        }
+        else {
+            proposalDevelopmentDocument.getDevelopmentProposal().getNarrative(lineNumber).setNarrativeUserRights(newNarrativeUserRights);
+            forward = mapping.findForward(MAPPING_CLOSE_PAGE);
+        }
+        
+        return forward;
+    }
+
+    /**
+     * 
+     * This method to send the request back to a page which closes by itself. Since Attachment right page 
+     * is opened in a new window, after saving, it should close by itself.
+     * @param mapping
+     * @param form
+     * @param request
+     * @param response
+     * @return ActionForward of close page
+     * @throws Exception
+     */
+    public ActionForward addInstituteAttachmentRights(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        
+        ActionForward forward;
+
+        ProposalDevelopmentForm proposalDevelopmentForm = (ProposalDevelopmentForm) form;
+        ProposalDevelopmentDocument proposalDevelopmentDocument = proposalDevelopmentForm.getProposalDevelopmentDocument();
+        List<NarrativeUserRights> newNarrativeUserRights = proposalDevelopmentForm.getNewNarrativeUserRights();
+        int lineNumber = getLineNumber(request);
+        
+        // check any business rules
+        boolean rulePassed = getKualiRuleService().applyRules(new NewNarrativeUserRightsEvent(proposalDevelopmentDocument, newNarrativeUserRights, lineNumber));
+        
+        if (!rulePassed) {
+            request.setAttribute(LINE_NUMBER, Integer.toString(lineNumber));
+            forward = mapping.findForward(MAPPING_INSTITUTE_ATTACHMENT_RIGHTS_PAGE);
+        }
+        else {
+            proposalDevelopmentDocument.getDevelopmentProposal().getInstituteAttachment(lineNumber).setNarrativeUserRights(newNarrativeUserRights);
+            forward = mapping.findForward(MAPPING_CLOSE_PAGE);
+        }
+        
+        return forward;
+    }
+
+    /**
+     * 
+     * This method used to replace the attachment
+     * @param mapping
+     * @param form
+     * @param request
+     * @param response
+     * @return
+     * @throws Exception
+     */
+    public ActionForward replaceProposalAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        ProposalDevelopmentForm proposalDevelopmentForm = (ProposalDevelopmentForm) form;
+        ProposalDevelopmentDocument pd = proposalDevelopmentForm.getProposalDevelopmentDocument();
+        ActionForward forward = mapping.findForward(MAPPING_BASIC);
+        Narrative modifiedNarrative = pd.getDevelopmentProposal().getNarrative(getSelectedLine(request));
+        
+        boolean rulePassed = getKualiRuleService().applyRules(new ReplaceNarrativeEvent("document.developmentProposalList[0].narrative[" + getSelectedLine(request) + "]", pd, modifiedNarrative));
+        if(rulePassed) {
+            pd.getDevelopmentProposal().replaceAttachment(getSelectedLine(request));
+
+            ProposalDevelopmentNotificationContext context = 
+                new ProposalDevelopmentNotificationContext(pd.getDevelopmentProposal(), "102", "Proposal Data Override");
+            ((ProposalDevelopmentNotificationRenderer) context.getRenderer()).setModifiedNarrative(modifiedNarrative);
+            if (proposalDevelopmentForm.getNotificationHelper().getPromptUserForNotificationEditor(context)) {
+                proposalDevelopmentForm.getNotificationHelper().initializeDefaultValues(context);
+                forward = mapping.findForward("notificationEditor");
+            } else {
+                getNotificationService().sendNotification(context);                
+            }
+        }
+
+        return forward;
+    }
+    
+    public ActionForward replacePersonnelAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        ProposalDevelopmentForm proposalDevelopmentForm = (ProposalDevelopmentForm) form;
+        ProposalDevelopmentDocument pd = proposalDevelopmentForm.getProposalDevelopmentDocument();
+        ActionForward forward = mapping.findForward(MAPPING_BASIC);
+        ProposalPersonBiography ppb = pd.getDevelopmentProposal().getPropPersonBio(getSelectedLine(request));
+
+        boolean rulePassed = getKualiRuleService().applyRules(
+                new ReplacePersonnelAttachmentEvent("document.developmentProposalList[0].propPersonBios[" + getSelectedLine(request) + "]",
+                        pd,
+                        ppb));
+        if(rulePassed) {
+            ppb.populateAttachment();
+           //I don't think anything needs to be done
+            
+            this.getBusinessObjectService().save(ppb);
+        }
+        return forward;
+    }
+    
+    /**
+     * 
+     * This method used to replace the attachment
+     * @param mapping
+     * @param form
+     * @param request
+     * @param response
+     * @return
+     * @throws Exception
+     */
+    public ActionForward replaceInstituteAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        ProposalDevelopmentForm proposalDevelopmentForm = (ProposalDevelopmentForm) form;
+        ProposalDevelopmentDocument pd = proposalDevelopmentForm.getProposalDevelopmentDocument();
+        boolean rulePassed = getKualiRuleService().applyRules(
+                new ReplaceInstituteAttachmentEvent("document.developmentProposalList[0].instituteAttachment[" + getSelectedLine(request) + "]",
+                            pd,
+                            pd.getDevelopmentProposal().getInstituteAttachment(getSelectedLine(request))));
+        if(rulePassed) {
+            pd.getDevelopmentProposal().replaceInstituteAttachment(getSelectedLine(request));
+        }
+        return mapping.findForward(MAPPING_BASIC);
+    }
+    
+    /**
+     * Update the User and Timestamp for the business object.
+     * @param bo the business object
+     */
+    private void setUpdateFields(KraPersistableBusinessObjectBase bo) {
+        String updateUser = GlobalVariables.getUserSession().getPrincipalName();
+        bo.setUpdateUser(updateUser);
+        bo.setUpdateTimestamp((getService(DateTimeService.class)).getCurrentTimestamp());
+        if (bo instanceof ProposalAbstract) {
+            ProposalAbstract abstractBo = (ProposalAbstract) bo;
+            abstractBo.setTimestampDisplay((getService(DateTimeService.class)).getCurrentTimestamp());
+            abstractBo.setUploadUserDisplay(updateUser);
+        }
+    }
+    
+    /**
+     * Adds an Abstract to the Proposal Development Document.
+     * 
+     * Assuming we have a valid new abstract, it is taken from the form 
+     * and moved into the document's list of abstracts.  The form's abstract
+     * is then cleared for the next abstract to be added.
+     * 
+     * @param mapping The mapping associated with this action.
+     * @param form The Proposal Development form.
+     * @param request the HTTP request
+     * @param response the HTTP response
+     * @return the destination (always the original proposal web page that caused this action to be invoked)
+     * @throws Exception
+     */
+    public ActionForward addAbstract(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        
+        ProposalDevelopmentForm proposalDevelopmentForm = (ProposalDevelopmentForm) form;
+        ProposalAbstract proposalAbstract = proposalDevelopmentForm.getNewProposalAbstract();
+        
+        // check any business rules
+        boolean rulePassed = getKualiRuleService().applyRules(new AddAbstractEvent(proposalDevelopmentForm.getProposalDevelopmentDocument(), proposalAbstract));
+                    
+        // if the rule evaluation passed, let's add it
+        if (rulePassed) {
+            setUpdateFields(proposalAbstract);
+            proposalAbstract.setTimestampDisplay((getService(DateTimeService.class)).getCurrentTimestamp());
+            proposalAbstract.setUploadUserDisplay(GlobalVariables.getUserSession().getPrincipalName());
+            proposalDevelopmentForm.getProposalDevelopmentDocument().getDevelopmentProposal().getProposalAbstracts().add(proposalAbstract);
+            proposalDevelopmentForm.setNewProposalAbstract(new ProposalAbstract());
+        }
+        return mapping.findForward(Constants.MAPPING_BASIC);
+    }
+    
+    /**
+     * Deletes an Abstract from the Proposal Development Document.
+     * 
+     * If the user confirms the deletion, the abstract is removed from
+     * the document's list of abstracts.
+     * 
+     * @param mapping The mapping associated with this action.
+     * @param form The Proposal Development form.
+     * @param request the HTTP request
+     * @param response the HTTP response
+     * @return the destination (always the original proposal web page that caused this action to be invoked)
+     * @throws Exception
+     */
+    // START SNIPPET: deleteAbstract
+    public ActionForward deleteAbstract(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        return confirm(buildDeleteAbstractConfirmationQuestion(mapping, form, request, response), CONFIRM_DELETE_ABSTRACT_KEY, EMPTY_STRING);
+    }
+    // END SNIPPET: deleteAbstract
+
+    /**
+     * Method dispatched from <code>{@link KraTransactionalDocumentActionBase#confirm(StrutsQuestion, String, String)}</code> for when a "yes" condition is met.
+     * 
+     * @param mapping The mapping associated with this action.
+     * @param form The Proposal Development form.
+     * @param request the HTTP request
+     * @param response the HTTP response
+     * @return the destination (always the original proposal web page that caused this action to be invoked)
+     * @throws Exception
+     * @see KraTransactionalDocumentActionBase#confirm(StrutsQuestion, String, String)
+     */
+    // START SNIPPET: confirmDeleteAbstract
+    public ActionForward confirmDeleteAbstract(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        Object question = request.getParameter(QUESTION_INST_ATTRIBUTE_NAME);
+        
+        int lineNum = getLineToDelete(request);
+
+        if (CONFIRM_DELETE_ABSTRACT_KEY.equals(question)) { 
+            ((ProposalDevelopmentForm) form).getProposalDevelopmentDocument().getDevelopmentProposal().getProposalAbstracts().remove(lineNum);
+        }
+        
+        return mapping.findForward(MAPPING_BASIC);
+    }        
+    // END SNIPPET: confirmDeleteAbstract
+
+    /**
+     * Builds the Delete Abstract Confirmation Question as a <code>{@link StrutsConfirmation}</code> instance.<br/>  
+     * <br/>
+     * The confirmation question is extracted from the resource bundle
+     * and the parameter {0} is replaced with the name of the abstract type
+     * that will be deleted.
+     * 
+     * @param mapping The mapping associated with this action.
+     * @param form The Proposal Development form.
+     * @param request the HTTP request
+     * @param response the HTTP response
+     * @return the confirmation question
+     * @throws Exception
+     * @see buildParameterizedConfirmationQuestion
+     */
+    // START SNIPPET: buildDeleteAbstractConfirmationQuestion
+    private StrutsConfirmation buildDeleteAbstractConfirmationQuestion(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        // Abstracts are stored in a document. We need to document to retrieve the abstract.
+        ProposalDevelopmentDocument doc = ((ProposalDevelopmentForm) form).getProposalDevelopmentDocument();
+
+        // Get the description. This will be used as a parameter to build the message for requesting confirmation feedback from the user.
+        String description = doc.getDevelopmentProposal().getProposalAbstracts().get(getLineToDelete(request)).getAbstractType().getDescription();
+        return buildParameterizedConfirmationQuestion(mapping, form, request, response, CONFIRM_DELETE_ABSTRACT_KEY, QUESTION_DELETE_ABSTRACT_CONFIRMATION, description);
+    }
+    // END SNIPPET: buildDeleteAbstractConfirmationQuestion
+
+    /**
+     * Builds the Delete Abstract Confirmation Question as a <code>{@link StrutsConfirmation}</code> instance.<br/>  
+     * <br/>
+     * The confirmation question is extracted from the resource bundle
+     * and the parameter {0} is replaced with the name of the abstract type
+     * that will be deleted.
+     * 
+     * @param mapping The mapping associated with this action.
+     * @param form The Proposal Development form.
+     * @param request the HTTP request
+     * @param response the HTTP response
+     * @param questionId String questionId. This needs to be unique for each type of attachment because there are different attachments to delete.
+     * @return the confirmation question
+     * @throws Exception
+     * @see buildParameterizedConfirmationQuestion
+     */
+    private StrutsConfirmation buildDeleteAttachmentConfirmationQuestion(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response, String questionId) throws Exception {
+        ProposalDevelopmentDocument doc = ((ProposalDevelopmentForm) form).getProposalDevelopmentDocument();
+        String description = null;
+        String fileName = null;
+        if (CONFIRM_DELETE_INSTITUTIONAL_ATTACHMENT_KEY.equals(questionId)) {
+            description = INSTITUTIONAL_ATTACHMENT_TYPE_NAME;
+            fileName = doc.getDevelopmentProposal().getInstituteAttachment(getLineToDelete(request)).getFileName();
+        }
+        else if (CONFIRM_DELETE_PERSONNEL_ATTACHMENT_KEY.equals(questionId)) {
+            description = PERSONNEL_ATTACHMENT_TYPE_NAME;
+            fileName = doc.getDevelopmentProposal().getPropPersonBio(getLineToDelete(request)).getFileName();
+        }
+        else if (CONFIRM_DELETE_PROPOSAL_ATTACHMENT_KEY.equals(questionId)) {
+            description = PROPOSAL_ATTACHMENT_TYPE_NAME;
+            fileName = doc.getDevelopmentProposal().getNarrative(getLineToDelete(request)).getFileName();
+        }
+        return buildParameterizedConfirmationQuestion(mapping, form, request, response, questionId, QUESTION_DELETE_ATTACHMENT_CONFIRMATION, description, fileName);
+    }
+
+    @Override
+    protected BusinessObjectService getBusinessObjectService() {
+        return getService(BusinessObjectService.class);
+    }
+    
+    @Override
+    protected KualiRuleService getKualiRuleService() {
+        return getService(KualiRuleService.class);
+    }
+
+    /**
+     * Adds a personnel attachment.
+     * 
+     * Move the new attachment from the form 
+     * into the document's list of personnelbiographyattachment.  The form's newpersonbio
+     * is then cleared for the next personnel attachment to be added.
+     * 
+     * @param mapping The mapping associated with this action.
+     * @param form The Proposal Development form.
+     * @param request the HTTP request
+     * @param response the HTTP response
+     * @return the destination (always the original proposal web page that caused this action to be invoked)
+     * @throws Exception
+     */
+    public ActionForward addPersonnelAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        ProposalDevelopmentForm proposalDevelopmentForm = (ProposalDevelopmentForm) form;
+        ProposalDevelopmentDocument proposalDevelopmentDocument = proposalDevelopmentForm.getProposalDevelopmentDocument();
+        if(getKualiRuleService().applyRules(new AddPersonnelAttachmentEvent(EMPTY_STRING, proposalDevelopmentDocument, proposalDevelopmentForm.getNewPropPersonBio()))){
+            proposalDevelopmentDocument.getDevelopmentProposal().addProposalPersonBiography(proposalDevelopmentForm.getNewPropPersonBio());
+            proposalDevelopmentForm.setNewPropPersonBio(new ProposalPersonBiography());
+            populateTabState(proposalDevelopmentForm, "Personnel Attachments " + proposalDevelopmentDocument.getDevelopmentProposal().getPropPersonBios().size());
+        } 
+
+        return mapping.findForward(Constants.MAPPING_BASIC);
+    }
+
+    /**
+     * Deletes a personnel attachment from the Proposal Development Document.
+     * 
+     * Removed the personnel attachment from the document's list of personnel attachments.
+     * 
+     * @param mapping The mapping associated with this action.
+     * @param form The Proposal Development form.
+     * @param request the HTTP request
+     * @param response the HTTP response
+     * @return the destination (always the original proposal web page that caused this action to be invoked)
+     * @throws Exception
+     */
+    public ActionForward deletePersonnelAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        String questionId = CONFIRM_DELETE_PERSONNEL_ATTACHMENT_KEY;
+        return confirm(buildDeleteAttachmentConfirmationQuestion(mapping, form, request, response, questionId), questionId, EMPTY_STRING);
+    }
+
+    /**
+     * Deletes a personnel attachment from the Proposal Development Document.
+     * 
+     * Removed the personnel attachment from the document's list of personnel attachments.
+     * 
+     * @param mapping The mapping associated with this action.
+     * @param form The Proposal Development form.
+     * @param request the HTTP request
+     * @param response the HTTP response
+     * @return the destination (always the original proposal web page that caused this action to be invoked)
+     * @throws Exception
+     */
+    public ActionForward confirmDeletePersonnelAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        ProposalDevelopmentForm pdForm = (ProposalDevelopmentForm) form;
+        ProposalDevelopmentDocument pdDoc = pdForm.getProposalDevelopmentDocument();
+        populateTabState((ProposalDevelopmentForm) form, "Personnel Attachments " + pdDoc.getDevelopmentProposal().getPropPersonBios().size());
+
+        return deleteAttachment(mapping, form, request, response, CONFIRM_DELETE_PERSONNEL_ATTACHMENT_KEY, "deleteProposalPersonBiography");
+    }
+
+    /**
+     * View a personnel attachment file.
+     *      
+     * @param mapping The mapping associated with this action.
+     * @param form The Proposal Development form.
+     * @param request the HTTP request
+     * @param response the HTTP response
+     * @return the destination (always the original proposal web page that caused this action to be invoked)
+     * @throws Exception
+     */
+    public ActionForward viewPersonnelAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+        ProposalDevelopmentForm proposalDevelopmentForm = (ProposalDevelopmentForm) form;
+        ProposalDevelopmentDocument pd = proposalDevelopmentForm.getProposalDevelopmentDocument();
+        String line = request.getParameter(LINE_NUMBER);
+        int lineNumber = line == null ? 0 : Integer.parseInt(line);
+        ProposalPersonBiography propPersonBio = pd.getDevelopmentProposal().getPropPersonBios().get(lineNumber);
+        Map<String,String> propPersonBioAttVal = new HashMap<String,String>();
+        propPersonBioAttVal.put(PROPOSAL_NUMBER, propPersonBio.getProposalNumber());
+        propPersonBioAttVal.put(BIOGRAPHY_NUMBER, propPersonBio.getBiographyNumber()+"");
+        propPersonBioAttVal.put(PROPOSAL_PERSON_NUMBER, propPersonBio.getProposalPersonNumber()+"");
+        ProposalPersonBiographyAttachment propPersonBioAttachment = (ProposalPersonBiographyAttachment)getBusinessObjectService().findByPrimaryKey(ProposalPersonBiographyAttachment.class, propPersonBioAttVal);
+        if(propPersonBioAttachment==null && !propPersonBio.getPersonnelAttachmentList().isEmpty()){//get it from the memory
+            propPersonBioAttachment = propPersonBio.getPersonnelAttachmentList().get(0);
+        }
+        streamToResponse(propPersonBioAttachment,response);
+        return  null;
+    }
+
+
+    /**
+     * 
+     * It add and institutional attachment to proposal document.
+     * @param mapping
+     * @param form
+     * @param request
+     * @param response
+     * @return
+     * @throws Exception
+     */
+    public ActionForward addInstitutionalAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        ProposalDevelopmentForm proposalDevelopmentForm = (ProposalDevelopmentForm) form;
+        ProposalDevelopmentDocument proposalDevelopmentDocument = proposalDevelopmentForm.getProposalDevelopmentDocument();
+        Narrative narrative = proposalDevelopmentForm.getNewInstituteAttachment();
+        narrative.setModuleStatusCode(Constants.NARRATIVE_MODULE_STATUS_COMPLETE);
+        if(getKualiRuleService().applyRules(new AddInstituteAttachmentEvent(EMPTY_STRING, proposalDevelopmentDocument, narrative))){
+            proposalDevelopmentDocument.getDevelopmentProposal().addInstituteAttachment(narrative);
+            proposalDevelopmentForm.setNewInstituteAttachment(new Narrative());
+            populateTabState(proposalDevelopmentForm, "Internal Attachments " + proposalDevelopmentDocument.getDevelopmentProposal().getInstituteAttachments().size());
+        }
+        return mapping.findForward(Constants.MAPPING_BASIC);
+
+    }
+
+    /**
+     * 
+     * Delete an institutional attachment
+     * @param mapping
+     * @param form
+     * @param request
+     * @param response
+     * @return
+     * @throws Exception
+     */
+    public ActionForward deleteInstitutionalAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        String questionId = CONFIRM_DELETE_INSTITUTIONAL_ATTACHMENT_KEY;
+        return confirm(buildDeleteAttachmentConfirmationQuestion(mapping, form, request, response, questionId), questionId, EMPTY_STRING);
+    }
+
+    /**
+     * 
+     * Delete an institutional attachment
+     * @param mapping
+     * @param form
+     * @param request
+     * @param response
+     * @return
+     * @throws Exception
+     */
+    public ActionForward confirmDeleteInstitutionalAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        ProposalDevelopmentForm pdForm = (ProposalDevelopmentForm) form;
+        ProposalDevelopmentDocument pdDoc = pdForm.getProposalDevelopmentDocument();
+        populateTabState((ProposalDevelopmentForm) form, "Internal Attachments " + pdDoc.getDevelopmentProposal().getInstituteAttachments().size());
+        return deleteAttachment(mapping, form, request, response, CONFIRM_DELETE_INSTITUTIONAL_ATTACHMENT_KEY, "deleteInstitutionalAttachment");
+    }
+
+    /**
+     * 
+     * View an institutional attachment file.
+     * @param mapping
+     * @param form
+     * @param request
+     * @param response
+     * @return
+     * @throws Exception
+     */
+    public ActionForward viewInstitutionalAttachment(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) throws Exception {
+          //return downloadProposalAttachment(mapping, form, request, response);
+          ProposalDevelopmentForm proposalDevelopmentForm = (ProposalDevelopmentForm) form;
+          ProposalDevelopmentDocument pd = proposalDevelopmentForm.getProposalDevelopmentDocument();
+          String line = request.getParameter(LINE_NUMBER);
+          int lineNumber = line == null ? 0 : Integer.parseInt(line);
+          Narrative narrative = pd.getDevelopmentProposal().getInstituteAttachments().get(lineNumber);
+          NarrativeAttachment narrativeAttachment = findNarrativeAttachment(narrative);
+          if(narrativeAttachment==null && !narrative.getNarrativeAttachmentList().isEmpty()){//get it from the memory
+              narrativeAttachment = narrative.getNarrativeAttachmentList().get(0);
+          }
+          streamToResponse(narrativeAttachment,response);
+          return null;
+
+    }
+    
+    /**
+     * @see org.kuali.kra.proposaldevelopment.web.struts.action.ProposalDevelopmentAction#processAuthorizationViolation(java.lang.String, org.apache.struts.action.ActionMapping, org.apache.struts.action.ActionForm, javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+     */
+    public ActionForward processAuthorizationViolation(String taskName, ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        ActionForward forward = null;
+        if (!StringUtils.equals(taskName, "addProposalAttachmentRights")) {
+            forward = super.processAuthorizationViolation(taskName, mapping, form, request, response);
+        }
+        else {
+            MessageMap errorMap = GlobalVariables.getMessageMap();
+            errorMap.putError(Constants.NEW_NARRATIVE_USER_RIGHTS_PROPERTY_KEY, KeyConstants.AUTHORIZATION_VIOLATION);
+            ProposalDevelopmentForm proposalDevelopmentForm = (ProposalDevelopmentForm) form;
+            int lineNumber = getLineNumber(request);
+            request.setAttribute(LINE_NUMBER, Integer.toString(lineNumber));
+            forward = mapping.findForward(MAPPING_NARRATIVE_ATTACHMENT_RIGHTS_PAGE);
+        }
+        return forward;
+    }
+    
+    private int getLineNumber(HttpServletRequest request) {
+        int lineNumber = 0;
+        String lineStr = request.getParameter(LINE_NUMBER);
+        if (lineStr == null) {
+            lineNumber = getLineToDelete(request);
+        } else {
+            try {
+                lineNumber = Integer.parseInt(lineStr);
+            } catch (Exception ex) {
+                // do nothing; 0 will be returned
+            }
+        }
+        return lineNumber;
+    }
+    
+    /**
+     * Hopefully a temporary fix to resolve the timestamp being the last post not the current post.
+     * @see org.kuali.rice.kns.web.struts.action.KualiDocumentActionBase#insertBONote(org.apache.struts.action.ActionMapping, org.apache.struts.action.ActionForm, javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+     */
+    @Override
+    public ActionForward insertBONote(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        KualiDocumentFormBase kualiDocumentFormBase = (KualiDocumentFormBase) form;
+        Note newNote = kualiDocumentFormBase.getNewNote();
+        newNote.setNotePostedTimestamp(CoreApiServiceLocator.getDateTimeService().getCurrentTimestamp());
+        return super.insertBONote(mapping, form, request, response);
+    }
+}

--- a/src/main/java/org/kuali/kra/proposaldevelopment/web/struts/form/ProposalDevelopmentForm.java
+++ b/src/main/java/org/kuali/kra/proposaldevelopment/web/struts/form/ProposalDevelopmentForm.java
@@ -21,6 +21,7 @@ import static org.kuali.kra.logging.BufferedLogger.warn;
 import static org.kuali.rice.krad.util.KRADConstants.EMPTY_STRING;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -120,10 +121,15 @@ import org.kuali.rice.kns.service.KNSServiceLocator;
 import org.kuali.rice.kns.util.ActionFormUtilMap;
 import org.kuali.rice.kns.web.ui.ExtraButton;
 import org.kuali.rice.kns.web.ui.HeaderField;
+import org.kuali.rice.krad.bo.Note;
+import org.kuali.rice.krad.exception.AuthorizationException;
 import org.kuali.rice.krad.service.BusinessObjectService;
 import org.kuali.rice.krad.util.GlobalVariables;
 import org.kuali.rice.krad.util.KRADConstants;
 import org.springframework.util.AutoPopulatingList;
+
+import edu.arizona.kra.proposaldevelopment.bo.SPSRestrictedNote;
+import edu.arizona.kra.proposaldevelopment.service.PropDevRoutingStateService;
 
 
 /**
@@ -241,6 +247,12 @@ public class ProposalDevelopmentForm extends BudgetVersionFormBase implements Re
     private NarrativeStatus narrativeStatusesChange;
     
     private String leadUnitName;
+    
+    private PropDevRoutingStateService propDevRoutingStateService;
+    private boolean canEditSPSRestrictedNotes;
+    private SPSRestrictedNote newSPSRestrictedNote;
+    private List<SPSRestrictedNote> SPSRestrictedNotes;
+    
 
     public ProposalDevelopmentForm() {
         super();
@@ -315,6 +327,9 @@ public class ProposalDevelopmentForm extends BudgetVersionFormBase implements Re
         setNewPropPersonBio(new ProposalPersonBiography());
         setApproverViewTabTitle();
         customDataHelper = new ProposalDevelopmentCustomDataHelper(this);
+        newSPSRestrictedNote = new SPSRestrictedNote();
+        //Save user authorization to edit SPS Restricted notes for use inside the jsp
+        canEditSPSRestrictedNotes = getPropDevRoutingStateService().canEditSPSRestrictedNotes();
     }
 
     /**
@@ -375,8 +390,25 @@ public class ProposalDevelopmentForm extends BudgetVersionFormBase implements Re
             }   
             personCount++;
         }
+        
+        String proposalNumber = proposalDevelopmentDocument.getDevelopmentProposal().getProposalNumber();
+        if ( StringUtils.isNotEmpty( proposalNumber )){
+            setSPSRestrictedNotes(getPropDevRoutingStateService().getSPSRestrictedNotes(proposalNumber));
+        }
+        
     }
     
+//    private void initializeSPSRestrictedNote(String proposalNumber) {
+//        newSPSRestrictedNote = new SPSRestrictedNote();
+//        newSPSRestrictedNote.setNoteTopic("");
+//        newSPSRestrictedNote.setNoteText("");
+//        newSPSRestrictedNote.setProposalNumber(proposalNumber);
+//        newSPSRestrictedNote.setProposalReceivedDate(new java.sql.Date(Calendar.getInstance().getTimeInMillis()));
+//        newSPSRestrictedNote.setProposalReceivedTime("12:00");
+//        newSPSRestrictedNote.setMeridiem("AM");
+//        
+//    }
+
     /**
      * 
      * This method helps debug the http request object.  It prints the values in the request.
@@ -2121,6 +2153,38 @@ public class ProposalDevelopmentForm extends BudgetVersionFormBase implements Re
     
     public String getLeadUnitName() {
     	return this.leadUnitName;
+    }
+    
+    protected PropDevRoutingStateService getPropDevRoutingStateService() {
+        if ( propDevRoutingStateService == null){
+            propDevRoutingStateService = KraServiceLocator.getService(PropDevRoutingStateService.class);
+        }
+        return propDevRoutingStateService;
+    }
+
+    public SPSRestrictedNote getNewSPSRestrictedNote() {
+        return newSPSRestrictedNote;
+    }
+
+    public void setNewSPSRestrictedNote(SPSRestrictedNote newSPSRestrictedNote) {
+        this.newSPSRestrictedNote = newSPSRestrictedNote;
+    }
+
+    public List<SPSRestrictedNote> getSPSRestrictedNotes() {
+        return SPSRestrictedNotes;
+    }
+
+    public void setSPSRestrictedNotes(List<SPSRestrictedNote> sPSRestrictedNotes) {
+        SPSRestrictedNotes = sPSRestrictedNotes;
+    }
+    
+    
+    public boolean getCanEditSPSRestrictedNotes(){
+        return canEditSPSRestrictedNotes;  
+    }
+    
+    public boolean canEditSPSRestrictedNotes(){
+        return canEditSPSRestrictedNotes;      
     }
 
 }

--- a/src/main/resources/ApplicationResources.properties
+++ b/src/main/resources/ApplicationResources.properties
@@ -1099,4 +1099,4 @@ error.unit.admin.global.no.details=No records applied to this Maintenence Docume
 error.unit.admin.multiple.for.type.not.allowed=Multiple Unit Administrators not allowed for Unit Administrator Type: {0}.{1}
 
 clear.modular.error.before.finalize=Please complete modular budget before making budget final.
-
+error.SPSRestrictedNote.time={0} Time format exception, expects {1}

--- a/src/main/resources/edu/arizona/kc/db/changelog/changesets/db.changelog-UAR-1609.xml
+++ b/src/main/resources/edu/arizona/kc/db/changelog/changesets/db.changelog-UAR-1609.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="UAR-1609_1" author="Natalia Ibanez">
+        <comment>
+            Adding the table and sequence for SPS Restricted Notes
+        </comment>
+        <sql>
+            create table KRAOWNER.eps_prop_sps_notes(
+            ID NUMBER(12,0) NOT NULL PRIMARY KEY,
+            PROPOSAL_NUMBER VARCHAR2(12 BYTE) NOT NULL,
+            CREATED_DATE DATE NOT NULL,
+            AUTH_PRINCIPAL_ID VARCHAR2(12 BYTE) NOT NULL,
+            NOTE_TEXT VARCHAR2(800),
+            NOTE_TOPIC VARCHAR2(40),
+            PROPOSAL_RECEIVED_DATE DATE,
+            PROPOSAL_RECEIVED_TIME VARCHAR2(15 BYTE),
+            OBJ_ID VARCHAR2(36 BYTE) NOT NULL,
+            VER_NBR NUMBER(8,0) DEFAULT 0 NOT NULL,
+            UPDATE_TIMESTAMP DATE NOT NULL,
+            UPDATE_USER VARCHAR2(60 BYTE) NOT NULL,
+            ACTV_IND VARCHAR2(1) DEFAULT 'Y' NOT NULL,
+            CONSTRAINT fk_eps_prop_sps_notes_kra
+            FOREIGN KEY (PROPOSAL_NUMBER)
+            REFERENCES EPS_PROPOSAL(PROPOSAL_NUMBER)
+            );
+            CREATE SEQUENCE KRAOWNER.eps_prop_sps_notes_seq
+            MINVALUE 1
+            START WITH 1
+            INCREMENT BY 1
+            NOCACHE;
+        </sql>
+        <rollback>
+            DROP table eps_prop_sps_notes CASCADE CONSTRAINTS;
+            DROP SEQUENCE eps_prop_sps_notes_seq;
+        </rollback>
+    </changeSet>
+    <changeSet id="UAR-1609_2" author="Natalia Ibanez">
+        <comment>
+            Adding sps restricted notes edit permission and assigning it to the right role
+        </comment>
+        <sql>
+            --create Edit SPS Restricted Notes Permission
+            insert into KRIM_PERM_T (PERM_ID,OBJ_ID,VER_NBR,PERM_TMPL_ID,NMSPC_CD,NM,DESC_TXT,ACTV_IND)
+            values (KRIM_PERM_ID_S.NEXTVAL, SYS_GUID(), 1, '1', 'KC-ADM', 'Edit SPS Restricted Notes', 'Edit SPS
+            Restricted Notes', 'Y');
+
+            -- add Edit SPS Restricted Notes Permission to SPS Proposal Reviewer Role
+            insert into KRIM_ROLE_PERM_T (ROLE_PERM_ID,OBJ_ID,VER_NBR,ACTV_IND,ROLE_ID,PERM_ID)
+            values (KRIM_ROLE_PERM_ID_S.NEXTVAL, SYS_GUID(), 1, 'Y',
+            (select ROLE_ID from KRIM_ROLE_T
+            where ROLE_NM='SPS Proposal Reviewer'),
+            (select PERM_ID from KRIM_PERM_T where NM='Edit SPS Restricted Notes'));
+        </sql>
+        <rollback>
+            delete from krim_role_perm_t where role_id IN (select ROLE_ID from KRIM_ROLE_T where ROLE_NM='SPS Proposal Reviewer');
+
+            delete from krim_perm_t where NM='Edit SPS Restricted Notes';
+        </rollback>
+    </changeSet>
+</databaseChangeLog> 

--- a/src/main/resources/edu/arizona/kc/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/edu/arizona/kc/db/changelog/db.changelog-master.xml
@@ -22,5 +22,6 @@
   <include file="changesets/db.changelog-UAR-973.xml" />
   <include file="changesets/db.changelog-UAR-1497.xml" />
   <include file="changesets/db.changelog-UAR-1453.xml" />
+  <include file="changesets/db.changelog-UAR-1609.xml" />
 </databaseChangeLog>
 

--- a/src/main/resources/edu/arizona/kra/datadictionary/SPSRestrictedNote.xml
+++ b/src/main/resources/edu/arizona/kra/datadictionary/SPSRestrictedNote.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+
+    <bean id="SPSRestrictedNote" parent="SPSRestrictedNote-parentBean"/>
+    <bean id="SPSRestrictedNote-parentBean" abstract="true" parent="BusinessObjectEntry">
+        <property name="businessObjectClass" value="edu.arizona.kra.proposaldevelopment.bo.SPSRestrictedNote"/>
+        <property name="objectLabel" value="SPS Restricted Note"/>
+        <property name="attributes">
+            <list>
+                <ref bean="SPSRestrictedNote-authorUniversalIdentifier"/>
+                <ref bean="SPSRestrictedNote-authorName"/>
+                <ref bean="SPSRestrictedNote-notePostedTimestamp"/>
+                <ref bean="SPSRestrictedNote-noteText"/>
+                <ref bean="SPSRestrictedNote-noteTopic"/>
+                <ref bean="SPSRestrictedNote-proposalNumber"/>
+                <ref bean="SPSRestrictedNote-proposalReceivedDate"/>
+                <ref bean="SPSRestrictedNote-proposalReceivedTime"/>
+            </list>
+        </property>
+        
+    </bean>
+
+<!-- Attribute Definitions -->
+
+
+    <bean id="SPSRestrictedNote-authorUniversalIdentifier" parent="SPSRestrictedNote-authorUniversalIdentifier-parentBean"/>
+    <bean id="SPSRestrictedNote-authorUniversalIdentifier-parentBean" abstract="true" parent="AttributeReferenceDummy-genericSystemId">
+        <property name="shortLabel" value="Author"/>
+        <property name="required" value="true"/>
+        <property name="name" value="authorId"/>
+        <property name="label" value="Author Id"/>
+        <property name="description" value="A free-form text field for the full name of the Author of the Note, expressed as &quot;Lastname, Firstname Initial&quot;"/>
+    </bean>
+
+    <bean id="SPSRestrictedNote-authorName" parent="SPSRestrictedNote-authorName-parentBean"/>
+    <bean id="SPSRestrictedNote-authorName-parentBean" abstract="true" parent="AttributeDefinition">
+        <property name="shortLabel" value="Author Name"/>
+        <property name="required" value="false"/>
+        <property name="forceUppercase" value="false"/>
+        <property name="name" value="authorName"/>
+        <property name="label" value="Author Name"/>
+        <property name="maxLength" value="40"/>
+        <property name="validationPattern">
+            <bean parent="AlphaNumericValidationPattern" p:lowerCase="true"/>
+        </property>
+        <property name="control">
+            <bean parent="TextControlDefinition" p:size="10"/>
+        </property>
+    </bean>
+
+    <bean id="SPSRestrictedNote-notePostedTimestamp" parent="SPSRestrictedNote-notePostedTimestamp-parentBean"/>
+    <bean id="SPSRestrictedNote-notePostedTimestamp-parentBean" abstract="true" parent="AttributeDefinition">
+        <property name="forceUppercase" value="true"/>
+        <property name="shortLabel" value="Posted Timestamp"/>
+        <property name="maxLength" value="36"/>
+        <property name="control">
+            <bean parent="TextControlDefinition" p:size="36"/>
+        </property>
+        <property name="controlField">
+            <bean parent="Uif-TextControl" p:size="12"/>
+        </property>
+        <property name="summary" value="&amp;nbsp;"/>
+        <property name="name" value="createdDate"/>
+        <property name="label" value="Posted Timestamp"/>
+        <property name="description" value="A free-form text field that identifies the time and date at which the Notes is posted."/>
+    </bean>
+
+    <bean id="SPSRestrictedNote-noteTopic" parent="SPSRestrictedNote-noteTopic-parentBean"/>
+    <bean id="SPSRestrictedNote-noteTopic-parentBean" abstract="true" parent="AttributeDefinition">
+        <property name="forceUppercase" value="false"/>
+        <property name="shortLabel" value="Note Topic"/>
+        <property name="maxLength" value="40"/>
+        <property name="required" value="false"/>
+        <property name="control">
+            <bean parent="TextControlDefinition" p:size="20"/>
+        </property>
+        <property name="controlField">
+            <bean parent="Uif-TextControl" p:size="20"/>
+        </property>
+        <property name="summary" value="&amp;nbsp;"/>
+        <property name="name" value="noteTopic"/>
+        <property name="label" value="Note Topic"/>
+        <property name="description" value="A free-form text field for entering the topic of the Note."/>
+    </bean>
+
+    <bean id="SPSRestrictedNote-noteText" parent="SPSRestrictedNote-noteText-parentBean"/>
+    <bean id="SPSRestrictedNote-noteText-parentBean" abstract="true" parent="AttributeDefinition">
+        <property name="forceUppercase" value="false"/>
+        <property name="shortLabel" value="Note Text"/>
+        <property name="maxLength" value="800"/>
+        <property name="validationPattern">
+            <bean parent="UTF8AnyCharacterValidationPattern" p:allowWhitespace="true"/>
+        </property>
+        <property name="required" value="true"/>
+        <property name="control">
+            <bean parent="TextareaControlDefinition" p:cols="50" p:rows="3"/>
+        </property>
+        <property name="controlField">
+            <bean parent="Uif-TextAreaControl" p:cols="50" p:rows="3"/>
+        </property>
+        <property name="summary" value="&amp;nbsp;"/>
+        <property name="name" value="noteText"/>
+        <property name="label" value="Note Text"/>
+        <property name="description" value="A free-form text field for the text of the Note."/>
+    </bean>
+
+    <bean id="SPSRestrictedNote-proposalNumber" parent="SPSRestrictedNote-proposalNumber-parentBean"/>
+    <bean id="SPSRestrictedNote-proposalNumber-parentBean" abstract="true" parent="AttributeDefinition">
+        <property name="forceUppercase" value="true"/>
+        <property name="shortLabel" value="Proposal Number"/>
+        <property name="maxLength" value="36"/>
+        <property name="validationPattern">
+            <bean parent="AnyCharacterValidationPattern"/>
+        </property>
+        <property name="control">
+            <bean parent="TextControlDefinition" p:size="38"/>
+        </property>
+        <property name="summary" value="Proposal Number"/>
+        <property name="name" value="proposalNumber"/>
+        <property name="label" value="Proposal Number"/>
+        <property name="description" value="Development Proposal Number"/>
+    </bean>
+
+
+    <bean id="SPSRestrictedNote-proposalReceivedDate" parent="SPSRestrictedNote-proposalReceivedDate-parentBean"/>
+    <bean id="SPSRestrictedNote-proposalReceivedDate-parentBean" abstract="true" parent="AttributeReferenceDummy-genericDate">
+        <property name="name" value="proposalReceivedDate"/>
+        <property name="label" value="Proposal Received Date"/>
+        <property name="shortLabel" value="Proposal Received Date"/>
+        <property name="required" value="true"/>
+        <property name="summary" value="Final Proposal Received Date"/>
+        <property name="description" value="Allows user to record the date SPS received the final package/permissions for the proposal submission via email"/>
+    </bean>
+
+    <bean id="SPSRestrictedNote-proposalReceivedTime" parent="SPSRestrictedNote-proposalReceivedTime-parentBean"/>
+    <bean id="SPSRestrictedNote-proposalReceivedTime-parentBean" abstract="true" parent="AttributeDefinition">
+        <property name="name" value="proposalReceivedTime"/>
+        <property name="label" value="Proposal Received Time"/>
+        <property name="shortLabel" value="Proposal Received Time"/>
+        <property name="required" value="true"/>
+        <property name="maxLength" value="15" />
+        <property name="control">
+            <bean parent="TextControlDefinition" p:size="15" />
+        </property>
+        <property name="summary" value="Final Proposal Received Time"/>
+        <property name="description" value="Allows user to record the time SPS received the final package/permissions for proposal submission via email"/>
+    </bean>
+    
+</beans>

--- a/src/main/resources/edu/arizona/kra/proposaldevelopment/CustomPropDevSpringBeans.xml
+++ b/src/main/resources/edu/arizona/kra/proposaldevelopment/CustomPropDevSpringBeans.xml
@@ -37,8 +37,11 @@
                            http://www.springframework.org/schema/util/spring-util-3.0.xsd">
                            
     <bean id="propDevRoutingStateService" class="edu.arizona.kra.proposaldevelopment.service.impl.PropDevRoutingStateServiceImpl">
-        <property name="dataAccessObject">
+        <property name="propDevRoutingStateDao">
             <ref bean="propDevRoutingStateDao" />
+        </property>
+        <property name="SPSRestrictedNoteDao">
+            <ref bean="SPSRestrictedNoteDao" />
         </property>
         <property name="authorizationService">
             <ref bean="customAuthorizationService" />
@@ -71,6 +74,6 @@
         <property name="identityManagementService" ref="identityService" />
         <property name="permissionService" ref="permissionService" />
     </bean>
-    <bean id="propDevRoutingStateDao" parent="platformAwareDao" class="edu.arizona.kra.proposaldevelopment.dao.ojb.PropDevRoutingStateDaoOjb">
-    </bean>
+    <bean id="propDevRoutingStateDao" parent="platformAwareDao" class="edu.arizona.kra.proposaldevelopment.dao.ojb.PropDevRoutingStateDaoOjb"/>
+    <bean id="SPSRestrictedNoteDao" parent="platformAwareDao" class="edu.arizona.kra.proposaldevelopment.dao.ojb.SPSRestrictedNoteDaoOjb" />
 </beans>

--- a/src/main/resources/org/kuali/kra/proposaldevelopment/ProposalDevelopmentSpringBeans.xml
+++ b/src/main/resources/org/kuali/kra/proposaldevelopment/ProposalDevelopmentSpringBeans.xml
@@ -1,0 +1,871 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2005-2014 The Kuali Foundation.
+
+    Licensed under the Educational Community License, Version 1.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.opensource.org/licenses/ecl1.php
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+       xmlns:p="http://www.springframework.org/schema/p" 
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xmlns:beans="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:lang="http://www.springframework.org/schema/lang"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="http://www.springframework.org/schema/aop
+                           http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+                           http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                           http://www.springframework.org/schema/context
+                           http://www.springframework.org/schema/context/spring-context-3.0.xsd
+                           http://www.springframework.org/schema/lang
+                           http://www.springframework.org/schema/lang/spring-lang-3.0.xsd
+                           http://www.springframework.org/schema/tx
+                           http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+                           http://www.springframework.org/schema/util
+                           http://www.springframework.org/schema/util/spring-util-3.0.xsd">
+    
+    <import resource="classpath:org/kuali/rice/core/RiceJTASpringBeans.xml" />
+    <import resource="classpath:org/kuali/kra/KC-RiceDataSourceSpringBeans.xml" />
+    <import resource="classpath:org/kuali/kra/core/CommonSpringBeans.xml" />
+    
+    <bean id="proposalDevelopmentModule" class="org.kuali.rice.krad.service.impl.ModuleServiceBase">
+        <property name="moduleConfiguration" ref="proposalDevelopmentModuleConfiguration"/>
+        <property name="kualiModuleService" ref="kualiModuleService"/>
+    </bean>
+
+    <bean id="proposalDevelopmentModuleConfiguration" parent="proposalDevelopmentModuleConfiguration-parentBean" />
+    <bean id="proposalDevelopmentModuleConfiguration-parentBean" class="org.kuali.rice.krad.bo.ModuleConfiguration" abstract="true">
+        <property name="namespaceCode" value="KC-PD" />
+        <property name="packagePrefixes">
+            <list>
+                <value>org.kuali.kra.proposaldevelopment</value>
+            </list>
+        </property>
+        <property name="databaseRepositoryFilePaths">
+            <list>
+                <value>org/kuali/kra/proposaldevelopment/repository-proposaldevelopment.xml</value>
+            </list>
+        </property>
+    </bean>
+   
+    <bean id="awardService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="awardService" />
+    </bean>
+    
+    <bean id="budgetService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="budgetService" />
+    </bean>
+    
+    <bean id="budgetSummaryService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="budgetSummaryService" />
+    </bean>
+    
+    <bean id="businessObjectService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="businessObjectService" />
+    </bean>
+    
+    <bean id="businessObjectDictionaryService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="businessObjectDictionaryService" />
+    </bean>
+    
+    <bean id="businessObjectMetaDataService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="businessObjectMetaDataService" />
+    </bean>
+    
+    <bean id="dataDictionaryService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="dataDictionaryService" />
+    </bean>
+    
+    <bean id="dateTimeService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="dateTimeService" />
+    </bean>
+    
+    <bean id="documentService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="documentService" />
+    </bean>
+    
+    <bean id="encryptionService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="encryptionService" />
+    </bean>
+    
+    <bean id="identityService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="identityService" />
+    </bean>
+    
+    <bean id="kraAuthorizationService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="kraAuthorizationService" />
+    </bean>
+    
+    <bean id="kraDocumentRejectionService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="kraDocumentRejectionService" />
+    </bean>
+    
+    <bean id="kraPersistenceStructureService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="kraPersistenceStructureService" />
+    </bean>
+    
+    <bean id="kcPersonService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="kcPersonService" />
+    </bean>
+    
+    <bean id="kraWorkflowService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="kraWorkflowService" />
+    </bean>
+    
+    <bean id="knsSessionDocumentService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="knsSessionDocumentService" />
+    </bean>
+    
+    <bean id="kradWorkflowDocumentService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="kradWorkflowDocumentService" />
+    </bean>
+    
+    <bean id="kualiConfigurationService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="kualiConfigurationService" />
+    </bean>
+    
+    <bean id="kualiModuleService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="kualiModuleService" />
+    </bean>
+    
+    <bean id="lookupService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="lookupService" />
+    </bean>
+    
+    <bean id="lookupResultsService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="lookupResultsService" />
+    </bean>
+    
+    <bean id="parameterService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="parameterService" />
+    </bean>
+    
+    <bean id="persistenceStructureService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="persistenceStructureService" />
+    </bean>
+    
+    <bean id="persistenceStructureServiceOjb" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="persistenceStructureServiceOjb" />
+    </bean>
+    
+    <bean id="persistenceStructureServiceJpa" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="persistenceStructureServiceJpa" />
+    </bean> 
+    
+    <bean id="personService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="personService" />
+    </bean>
+    
+    <bean id="printingService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="printingService" />
+    </bean>
+
+    <bean id="questionnaireService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="questionnaireService" />
+    </bean>
+    
+    <bean id="questionnaireAnswerService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="questionnaireAnswerService" />
+    </bean>
+    
+    <bean id="roleService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="roleService" />
+    </bean>
+    
+    <bean id="sequenceAccessorService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="sequenceAccessorService" />
+    </bean>
+    
+    <bean id="sponsorService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="sponsorService" />
+    </bean>
+    
+    <bean id="systemAuthorizationService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="systemAuthorizationService" />
+    </bean>
+    
+    <bean id="taskAuthorizationService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="taskAuthorizationService" />
+    </bean>
+    
+    <bean id="unitAuthorizationService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="unitAuthorizationService" />
+    </bean>
+    
+    <bean id="versionHistoryService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="versionHistoryService" />
+    </bean>
+
+    <bean id="ynqService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="ynqService" />
+    </bean>
+    <bean id="kcKrmsJavaFunctionTermService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="kcKrmsJavaFunctionTermService"/>
+    </bean>
+    
+    <bean id="parentLookupableHelperService" abstract="true">
+        <property name="persistenceStructureService" ref="persistenceStructureService" />
+        <property name="businessObjectDictionaryService" ref="businessObjectDictionaryService" />
+        <property name="dataDictionaryService" ref="dataDictionaryService" />
+        <property name="encryptionService" ref="encryptionService" />
+        <property name="lookupService" ref="lookupService" />
+        <property name="businessObjectMetaDataService" ref="businessObjectMetaDataService" />
+        <property name="sequenceAccessorService" ref="sequenceAccessorService" />
+        <property name="businessObjectService" ref="businessObjectService" />
+        <property name="lookupResultsService" ref="lookupResultsService" />
+    </bean>
+    
+    <!-- Proposal Development Services -->
+    
+	<bean id="proposalDevelopmentService" class="org.kuali.kra.proposaldevelopment.service.impl.ProposalDevelopmentServiceImpl">
+		<property name="businessObjectService" ref="businessObjectService" />
+		<property name="unitAuthorizationService" ref="unitAuthorizationService" />
+		<property name="kraPersistenceStructureService" ref="kraPersistenceStructureService" />
+		<property name="budgetService" ref="budgetService" />
+		<property name="parameterService" ref="parameterService" />
+		<property name="versionHistoryService" ref="versionHistoryService" />
+		<property name="documentService" ref="documentService" />
+	</bean>
+
+	<bean id="proposalDevelopmentLookupable" class="org.kuali.rice.kns.lookup.KualiLookupableImpl" scope="prototype">
+		<property name="lookupableHelperService" ref="proposalDevelopmentLookupableHelperService" />
+	</bean>
+	
+    <bean id="proposalDevelopmentLookupableHelperService" class="org.kuali.kra.proposaldevelopment.service.impl.DevelopmentProposalLookupableHelperServiceImpl" 
+          parent="parentLookupableHelperService" scope="prototype">
+        <property name="kraAuthorizationService" ref="kraAuthorizationService" />
+    </bean>
+    
+    <bean id="lookupableDevelopmentProposalLookupable" class="org.kuali.rice.kns.lookup.KualiLookupableImpl" scope="prototype">
+		<property name="lookupableHelperService" ref="lookupableDevelopmentProposalLookupableHelperService" />
+	</bean>
+    
+    <bean id="lookupableDevelopmentProposalLookupableHelperService" class="org.kuali.kra.proposaldevelopment.service.impl.LookupableDevelopmentProposalLookupableHelperServiceImpl" 
+          parent="parentLookupableHelperService" scope="prototype">
+        <property name="proposalPersonDao" ref="proposalPersonDao" />
+        <property name="businessObjectService" ref="businessObjectService" />
+        <property name="documentService" ref="documentService" />
+    </bean>
+    
+    <bean id="proposalPersonDao" parent="platformAwareDao" class="org.kuali.kra.proposaldevelopment.dao.ojb.ProposalPersonDaoOjb">
+        <property name="lookupDao" ref="lookupDao" />
+        <property name="dataDictionaryService" ref="dataDictionaryService" />
+    </bean>  
+
+    <bean id="lookupDao" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="lookupDao" />
+    </bean>
+    
+    <bean id="proposalAbstractsService" class="org.kuali.kra.proposaldevelopment.service.impl.ProposalAbstractsServiceImpl">
+        <property name="personService" ref="personService" />
+    </bean>
+    
+    <bean id="proposalAllUnitAdministratorDerivedRoleTypeService" 
+          class="org.kuali.kra.proposaldevelopment.service.impl.ProposalAllUnitAdministratorDerivedRoleTypeServiceImpl">
+        <property name="unitService" ref="unitService" />
+    </bean>
+  
+    <bean id="proposalAllUnitAdministratorDerivedRoleTypeServiceCallback" parent="kcCallbackService"
+		p:callbackService-ref="proposalAllUnitAdministratorDerivedRoleTypeService" 
+		p:localServiceName="proposalAllUnitAdministratorDerivedRoleTypeService" 
+		p:serviceInterface="org.kuali.rice.kim.framework.role.RoleTypeService"/>
+    
+    <bean id="proposalCopyService" class="org.kuali.kra.proposaldevelopment.service.impl.ProposalCopyServiceImpl">
+        <property name="businessObjectService" ref="businessObjectService" />
+        <property name="keyPersonnelService" ref="keyPersonnelService" />
+        <property name="documentService" ref="documentService" />
+        <property name="parameterService" ref="parameterService" />
+        <property name="dateTimeService" ref="dateTimeService" />
+        <property name="budgetService" ref="budgetService" />
+        <property name="budgetSummaryService" ref="budgetSummaryService" />
+        <property name="questionnaireService" ref="questionnaireService"/>
+        <property name="questionnaireAnswerService" ref="questionnaireAnswerService"/>
+        <property name="unitService" ref="unitService" />
+    </bean>
+    
+    <bean id="keyPersonnelService" class="org.kuali.kra.proposaldevelopment.service.impl.KeyPersonnelServiceImpl">
+        <property name="businessObjectService" ref="businessObjectService" />
+        <property name="narrativeService" ref="narrativeService" />
+        <property name="parameterService" ref="parameterService" />
+        <property name="ynqService" ref="ynqService" />
+        <property name="sponsorService" ref="sponsorService"/>
+    </bean>
+
+    <bean id="proposalLockService" class="org.kuali.kra.proposaldevelopment.service.impl.ProposalLockServiceImpl">
+        <property name="businessObjectService" ref="businessObjectService" />
+    </bean>
+    
+    <bean id="proposalDevelopmentNotificationRenderer" class="org.kuali.kra.proposaldevelopment.notification.ProposalDevelopmentNotificationRenderer" 
+          scope="prototype">
+        <property name="proposalDevelopmentService" ref="proposalDevelopmentService"/>
+    </bean>
+    
+    <bean id="proposalDevelopmentNotificationRoleQualifierService" 
+          class="org.kuali.kra.proposaldevelopment.notification.ProposalDevelopmentNotificationRoleQualifierServiceImpl" scope="prototype" />
+    
+    <bean id="proposalHierarchyDao" parent="platformAwareDao" class="org.kuali.kra.proposaldevelopment.hierarchy.dao.ojb.ProposalHierarchyDaoOjb" />
+    
+    <bean id="proposalHierarchyService" class="org.kuali.kra.proposaldevelopment.hierarchy.service.impl.ProposalHierarchyServiceImpl">
+        <property name="businessObjectService" ref="businessObjectService" />
+        <property name="documentService" ref="documentService" />
+        <property name="kraAuthorizationService" ref="kraAuthorizationService" />
+        <property name="narrativeService" ref="narrativeService" />
+        <property name="proposalHierarchyDao" ref="proposalHierarchyDao" />
+        <property name="budgetService" ref="budgetService" />
+        <property name="budgetSummaryService" ref="budgetSummaryService" />
+        <property name="propPersonBioService" ref="proposalPersonBiographyService" />
+        <property name="parameterService" ref="parameterService" />
+        <property name="identityManagementService" ref="identityService" />
+        <property name="configurationService" ref="kualiConfigurationService" />
+        <property name="kraDocumentRejectionService" ref="kraDocumentRejectionService" />
+        <property name="sessionDocumentService" ref="knsSessionDocumentService" />
+        <property name="workflowDocumentService" ref="kradWorkflowDocumentService" />       
+    </bean>
+    
+    <bean id="proposalPersonService" class="org.kuali.kra.proposaldevelopment.service.impl.ProposalPersonServiceImpl">
+        <property name="businessObjectService" ref="businessObjectService" />
+        <property name="kcPersonService" ref="kcPersonService" />
+    </bean>
+    
+    <bean id="proposalPersonBiographyService" class="org.kuali.kra.proposaldevelopment.service.impl.ProposalPersonBiographyServiceImpl">
+        <property name="businessObjectService" ref="businessObjectService" />
+        <property name="attachmentDao" ref="attachmentDao" />
+        <property name="personService" ref="personService" />
+    </bean>
+    
+    <bean id="proposalRoleService" class="org.kuali.kra.kim.service.impl.ProposalRoleServiceImpl">
+        <property name="systemAuthorizationService" ref="systemAuthorizationService" />
+    </bean>
+    
+    <bean id="proposalRoleTemplateService" class="org.kuali.kra.proposaldevelopment.service.impl.ProposalRoleTemplateServiceImpl">
+        <property name="kraAuthorizationService" ref="kraAuthorizationService" />
+        <property name="roleManagementService" ref="roleService" />
+        <property name="proposalRoleService" ref="proposalRoleService" />
+    </bean>
+
+	<bean id="proposalRoleTypeService" class="org.kuali.kra.workflow.ProposalPersonDerivedRoleTypeServiceImpl">
+		<property name="proposalPersonService" ref="proposalPersonService" />
+	</bean>
+	
+	<bean id="proposalRoleTypeServiceCallback" parent="kcCallbackService" 
+		p:callbackService-ref="proposalRoleTypeService"
+		p:localServiceName="proposalRoleTypeService" 
+		p:serviceInterface="org.kuali.rice.kim.framework.role.RoleTypeService"/>
+	
+    <bean id="proposalStatusService" class="org.kuali.kra.proposaldevelopment.service.impl.ProposalStatusServiceImpl">
+        <property name="businessObjectService" ref="businessObjectService" />
+    </bean>
+
+	<bean id="narrativeService" class="org.kuali.kra.proposaldevelopment.service.impl.NarrativeServiceImpl">
+		<property name="systemAuthorizationService" ref="systemAuthorizationService" />
+		<property name="dateTimeService" ref="dateTimeService" />
+		<property name="businessObjectService" ref="businessObjectService" />
+		<property name="narrativeAuthZService" ref="narrativeAuthZService" />
+		<property name="proposalPersonService" ref="proposalPersonService" />
+		<property name="kcPersonService" ref="kcPersonService" />
+		<property name="personService" ref="personService" />
+		<property name="attachmentDao" ref="attachmentDao" />
+	</bean>
+	
+    <bean id="attachmentDao" parent="platformAwareDao" class="org.kuali.kra.proposaldevelopment.dao.ojb.AttachmentDaoOjb" />
+	
+    <bean id="narrativeAuthZService" class="org.kuali.kra.proposaldevelopment.service.impl.NarrativeAuthZServiceImpl">
+        <property name="businessObjectService" ref="businessObjectService" />
+        <property name="systemAuthorizationService" ref="systemAuthorizationService" />
+        <property name="kraAuthorizationService" ref="kraAuthorizationService" />
+    </bean>
+
+    <!-- Proposal Development Printing Services -->
+    
+    <bean id="proposalDevelopmentPrintingService" class="org.kuali.kra.proposaldevelopment.printing.service.impl.ProposalDevelopmentPrintingServiceImpl"
+          lazy-init="true">
+        <property name="printCertificationPrint" ref="printCertificationPrint" />
+        <property name="proposalSponsorFormsPrint" ref="proposalSponsorFormsPrint" />
+        <property name="printingService" ref="printingService" />
+        <property name="s2SUtilService" ref="s2SUtilService" />
+        <property name="businessObjectService" ref="businessObjectService" />
+        <property name="parameterService" ref="parameterService" />
+    </bean>
+    
+    <bean id="printCertificationPrint" class="org.kuali.kra.proposaldevelopment.printing.print.PrintCertificationPrint" scope="prototype">
+        <property name="xmlStream" ref="printCertificationXmlStream" />
+    </bean>
+    
+    <bean id="proposalSponsorFormsPrint" class="org.kuali.kra.proposaldevelopment.printing.print.ProposalSponsorFormsPrint" scope="prototype" lazy-init="true">
+        <property name="nihResearchAndRelatedXmlStream" ref="nihResearchAndRelatedXmlStream" />
+        <property name="businessObjectService" ref="businessObjectService" />
+        <property name="proposalDevelopmentXmlStream" ref="proposalDevelopmentXmlStream" />
+    </bean>
+    
+    <bean id="proposalBaseStream" class="org.kuali.kra.proposaldevelopment.printing.xmlstream.ProposalBaseStream" abstract="true">
+        <property name="businessObjectService" ref="businessObjectService" />
+        <property name="dateTimeService" ref="dateTimeService" />
+    </bean>
+    
+    <bean id="printCertificationXmlStream" class="org.kuali.kra.proposaldevelopment.printing.xmlstream.PrintCertificationXmlStream" 
+          parent="proposalBaseStream" />
+
+    <bean id="proposalSubmissionXmlStream" class="org.kuali.kra.proposaldevelopment.printing.xmlstream.ProposalSubmissionXmlStream" 
+          parent="proposalBaseStream" />
+    
+    <bean id="abstractResearchAndRelatedStream" class="org.kuali.kra.proposaldevelopment.printing.xmlstream.AbstractResearchAndRelatedStream" abstract="true" 
+          parent="proposalBaseStream">
+        <property name="kcPersonService" ref="kcPersonService" />
+        <property name="s2SUtilService" ref="s2SUtilService" />
+    </bean>
+    
+    <bean id="researchAndRelatedXmlStream" class="org.kuali.kra.proposaldevelopment.printing.xmlstream.ResearchAndRelatedXmlStream" 
+          parent="abstractResearchAndRelatedStream" />
+    
+    <bean id="nihResearchAndRelatedXmlStream" class="org.kuali.kra.proposaldevelopment.printing.xmlstream.NIHResearchAndRelatedXmlStream"
+          parent="abstractResearchAndRelatedStream" lazy-init="true">
+        <property name="parameterService" ref="parameterService" />
+        <property name="awardService" ref="awardService" />
+        <property name="sponsorService" ref="sponsorService" />
+    </bean>
+    
+    <bean id="proposalDevelopmentXmlStream" class="org.kuali.kra.proposaldevelopment.printing.xmlstream.ProposalDevelopmentXmlStream" 
+          parent="proposalBaseStream" />
+
+    <!-- Current and Pending Report Services -->
+    
+    <bean id="currentAndPendingReportService" class="org.kuali.kra.printing.service.impl.CurrentAndPendingReportServiceImpl" scope="prototype">
+        <property name="currentReportDao" ref="currentReportDao" />
+        <property name="pendingReportDao" ref="pendingReportDao" />
+        <property name="currentProposalPrint" ref="currentProposalPrint" />
+        <property name="pendingProposalPrint" ref="pendingProposalPrint" />
+        <property name="printingService" ref="printingService" />
+    </bean>
+    
+    <bean id="currentReportDao" parent="platformAwareDao" class="org.kuali.kra.dao.ojb.CurrentReportDaoOjb" />
+    
+    <bean id="pendingReportDao" parent="platformAwareDao" class="org.kuali.kra.dao.ojb.PendingReportDaoOjb" />
+    
+    <bean id="currentProposalPrint" class="org.kuali.kra.printing.print.CurrentProposalPrint" scope="prototype">
+        <property name="xmlStream" ref="currentProposalXmlStream" />
+    </bean>
+    
+    <bean id="pendingProposalPrint" class="org.kuali.kra.printing.print.PendingProposalPrint" scope="prototype">
+        <property name="xmlStream" ref="pendingProposalXmlStream" />
+    </bean>
+
+    <bean id="currentProposalXmlStream" class="org.kuali.kra.printing.xmlstream.CurrentProposalXmlStream">
+        <property name="businessObjectService" ref="businessObjectService" />
+        <property name="dateTimeService" ref="dateTimeService" />
+    </bean>
+    
+    <bean id="pendingProposalXmlStream" class="org.kuali.kra.printing.xmlstream.PendingProposalXmlStream">
+        <property name="businessObjectService" ref="businessObjectService" />
+        <property name="dateTimeService" ref="dateTimeService" />
+    </bean>
+
+    <!-- Proposal Development S2s Questionnaire Services -->
+    
+    <bean id = "proposalDevelopmentS2sQuestionnaireService" class = "org.kuali.kra.proposaldevelopment.service.impl.ProposalDevelopmentS2sQuestionnaireServiceImpl">
+        <property name="businessObjectService" ref="businessObjectService"/>
+        <property name="questionnaireAnswerService" ref="questionnaireAnswerService"/>
+        <property name="questionnaireService" ref="questionnaireService"/>
+    </bean>
+
+	<!-- Proposal Development Task Authorizers -->
+
+	<bean id="parentProposalAuthorizer" abstract="true">
+		<property name="unitAuthorizationService" ref="unitAuthorizationService" />
+		<property name="kraWorkflowService" ref="kraWorkflowService" />
+        <property name="kraAuthorizationService" ref="kraAuthorizationService" />
+	</bean>
+
+	<bean id="proposalTaskAuthorizers" class="org.kuali.kra.authorization.TaskAuthorizerGroup">
+		<property name="groupName" value="proposal" />
+		<property name="taskAuthorizers">
+			<list>
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.ModifyProposalAuthorizer" parent="parentProposalAuthorizer">
+					<property name="taskName" value="modifyProposal" />
+					<property name="requiresWritableDoc" value="true" />
+				</bean>
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.ViewProposalAuthorizer" parent="parentProposalAuthorizer">
+					<property name="taskName" value="viewProposal" />
+				</bean>
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.AddNoteProposalAuthorizer" parent="parentProposalAuthorizer">
+					<property name="taskName" value="proposalAddNoteAttachment" />
+				</bean>
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.BasicProposalAuthorizer" parent="parentProposalAuthorizer">
+					<property name="taskName" value="maintainProposalHierarchy" />
+					<property name="permission" value="Maintain ProposalHierarchy" />
+					<property name="requiresWritableDoc" value="true" />
+				</bean>
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.BasicProposalAuthorizer" parent="parentProposalAuthorizer">
+					<property name="taskName" value="printProposal" />
+					<property name="permission" value="Print Proposal" />
+				</bean>
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.SubmitToSponsorAuthorizer" parent="parentProposalAuthorizer">
+					<property name="taskName" value="submitToSponsor" />
+					<property name="requiresWritableDoc" value="true" />
+				</bean>
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.SubmitToWorkflowAuthorizer" parent="parentProposalAuthorizer">
+					<property name="taskName" value="submitToWorkflow" />
+					<property name="requiresWritableDoc" value="true" />
+				</bean>
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.BasicProposalAuthorizer" parent="parentProposalAuthorizer">
+					<property name="taskName" value="certify" />
+					<property name="permission" value="Certify" />
+					<property name="requiresWritableDoc" value="true" />
+				</bean>
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.ShowAlterProposalDataAuthorizer" parent="parentProposalAuthorizer">
+					<property name="taskName" value="showAlterProposalData" />
+				</bean>
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.AlterProposalDataAuthorizer" parent="parentProposalAuthorizer">
+					<property name="taskName" value="alterProposalData" />
+					<property name="requiresWritableDoc" value="true" />
+				</bean>
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.ModifyProposalPermissionsAuthorizer" parent="parentProposalAuthorizer">
+					<property name="taskName" value="modifyProposalRoles" />
+					<property name="requiresWritableDoc" value="true" />
+				</bean>
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.ProposalHierarchyChildWorkflowActionAuthorizer" 
+				      parent="parentProposalAuthorizer">
+                    <property name="taskName" value="hierarchyChildWorkflowAction" />
+                </bean>
+                <bean class="org.kuali.kra.proposaldevelopment.document.authorizer.ProposalHierarchyChildWorkflowActionAuthorizer" 
+                      parent="parentProposalAuthorizer">
+                    <property name="taskName" value="hierarchyChildAcknowledgeAction" />
+                </bean>
+                <bean class="org.kuali.kra.proposaldevelopment.document.authorizer.RejectProposalAuthorizer" parent="parentProposalAuthorizer">
+                    <property name="taskName" value="rejectProposal" />
+                    <property name="requiresWritableDoc" value="true" />
+                </bean>
+                <bean class="org.kuali.kra.proposaldevelopment.document.authorizer.AnswerProposalQuestionnaireAuthorizer" parent="parentProposalAuthorizer">
+                    <property name="taskName" value="answerProposalQuestionnaire" />
+                </bean>
+                <bean class="org.kuali.kra.proposaldevelopment.document.authorizer.DeleteProposalAuthorizer" parent="parentProposalAuthorizer">
+                    <property name="taskName" value="deleteProposal" />
+                    <property name="requiresWritableDoc" value="true" />
+                </bean>
+                <bean class="org.kuali.kra.proposaldevelopment.document.authorizer.PersonnelAttachmentReplaceAuthorizer" parent="parentProposalAuthorizer">
+                    <property name="taskName" value="replacePersonnelAttachmentAuthorizer" />
+                    <property name="requiresWritableDoc" value="true" />
+                </bean>
+                
+				<!-- Narrative -->
+				
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.NarrativeAddAuthorizer" parent="parentProposalAuthorizer">
+					<property name="taskName" value="addNarrative" />
+					<property name="requiresWritableDoc" value="true" />
+				</bean>
+
+				<!-- Budget -->
+				
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.BudgetAddAuthorizer" parent="parentProposalAuthorizer">
+					<property name="taskName" value="addBudget" />
+					<property name="requiresWritableDoc" value="true" />
+				</bean>
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.BudgetOpenAuthorizer" parent="parentProposalAuthorizer">
+					<property name="taskName" value="openBudgets" />
+				</bean>
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.ModifyBudgetPermission" parent="parentProposalAuthorizer">
+					<property name="taskName" value="modifyBudget" />
+					<property name="requiresWritableDoc" value="true" />
+				</bean>
+				
+                <bean class="org.kuali.kra.proposaldevelopment.document.authorizer.CreateProtocolFromProposalAuthorizer" parent="parentProposalAuthorizer">
+                    <property name="taskName" value="createIrbProtocolFromProposal" />
+                </bean>   
+                <bean class="org.kuali.kra.proposaldevelopment.document.authorizer.CreateIacucProtocolFromProposalAuthorizer" parent="parentProposalAuthorizer">
+                    <property name="taskName" value="createIacucProtocolFromProposal" />
+                </bean>   
+                <bean class="org.kuali.kra.proposaldevelopment.document.authorizer.RecallAuthorizer" parent="parentProposalAuthorizer">
+                    <property name="taskName" value="recallProposal" />
+                </bean>
+			</list>
+		</property>
+	</bean>
+
+	<!-- Narrative Task Authorizers -->
+	
+	<bean id="narrativeTaskAuthorizers" class="org.kuali.kra.authorization.TaskAuthorizerGroup">
+		<property name="groupName" value="narrative" />
+		<property name="taskAuthorizers">
+			<list>
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.NarrativeModifyAuthorizer" parent="parentProposalAuthorizer">
+					<property name="taskName" value="modifyNarrativeRights" />
+					<property name="requiresWritableDoc" value="true" />
+				</bean>
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.NarrativeReadAuthorizer" parent="parentProposalAuthorizer">
+					<property name="taskName" value="downloadNarrative" />
+				</bean>
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.NarrativeModifyAuthorizer" parent="parentProposalAuthorizer">
+					<property name="taskName" value="deleteNarrative" />
+					<property name="requiresWritableDoc" value="true" />
+				</bean>
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.NarrativeReplaceAuthorizer" parent="parentProposalAuthorizer">
+					<property name="taskName" value="replaceNarrative" />
+					<property name="requiresWritableDoc" value="true" />
+				</bean>
+				<bean class="org.kuali.kra.proposaldevelopment.document.authorizer.ModifyNarrativesAuthorizer" parent="parentProposalAuthorizer">
+					<property name="taskName" value="modifyNarratives" />
+					<property name="requiresWritableDoc" value="true" />
+				</bean>
+			</list>
+		</property>
+	</bean>
+
+	<bean id="proposalDevelopmentWebAuthorizer" class="org.kuali.kra.web.struts.authorization.WebAuthorizer">
+		<property name="classname" value="org.kuali.kra.proposaldevelopment.web.struts.action.ProposalDevelopmentAction" />
+		<property name="mappings">
+			<map>
+				<entry key="save">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+						<property name="taskName" value="modifyProposal" />
+					</bean>
+				</entry>
+			</map>
+		</property>
+	</bean>
+	
+    <bean id="proposalGrantsGovWebAuthorizer" class="org.kuali.kra.web.struts.authorization.WebAuthorizer">
+        <property name="classname" value="org.kuali.kra.proposaldevelopment.web.struts.action.ProposalDevelopmentGrantsGovAction" />
+        <property name="mappings">
+            <map>
+                <entry key="printForms">
+                    <bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+                        <property name="taskName" value="printProposal" />
+                    </bean>
+                </entry>
+            </map>
+        </property>
+    </bean>
+    
+    <bean id="proposalKeyPersonnelWebAuthorizer" class="org.kuali.kra.web.struts.authorization.WebAuthorizer">
+        <property name="classname" value="org.kuali.kra.proposaldevelopment.web.struts.action.ProposalDevelopmentKeyPersonnelAction" />
+        <property name="mappings">
+            <map>
+                <entry key="addCertificationQuestion">
+                    <bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+                        <property name="taskName" value="modifyProposal" />
+                    </bean>
+                </entry>
+                <entry key="removeCertificationQuestion">
+                    <bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+                        <property name="taskName" value="modifyProposal" />
+                    </bean>
+                </entry>
+                <entry key="addUnitDetails">
+                    <bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+                        <property name="taskName" value="modifyProposal" />
+                    </bean>
+                </entry>
+                <entry key="removeUnitDetails">
+                    <bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+                        <property name="taskName" value="modifyProposal" />
+                    </bean>
+                </entry>
+            </map>
+        </property>
+    </bean>
+
+	<bean id="proposalAbstractsAttachmentsWebAuthorizer" class="org.kuali.kra.web.struts.authorization.WebAuthorizer">
+       <property name="classname" value="org.kuali.kra.proposaldevelopment.web.struts.action.ProposalDevelopmentAbstractsAttachmentsAction" />
+		<property name="mappings">
+			<map>
+				<entry key="addProposalAttachment">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+						<property name="taskName" value="addNarrative" />
+					</bean>
+				</entry>
+				<entry key="addProposalAttachmentRights">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalAttachmentTaskFactory">
+						<property name="taskName" value="modifyNarrativeRights" />
+					</bean>
+				</entry>
+				<entry key="downloadProposalAttachment">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalAttachmentTaskFactory">
+						<property name="taskName" value="downloadNarrative" />
+					</bean>
+				</entry>
+				<entry key="deleteProposalAttachment">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalAttachmentTaskFactory">
+						<property name="taskName" value="deleteNarrative" />
+					</bean>
+				</entry>
+				<entry key="replaceProposalAttachment">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalAttachmentTaskFactory">
+						<property name="taskName" value="replaceNarrative" />
+					</bean>
+				</entry>
+				<entry key="addInstitutionalAttachment">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+						<property name="taskName" value="addNarrative" />
+					</bean>
+				</entry>
+				<entry key="addInstituteAttachmentRights">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.InstituteAttachmentTaskFactory">
+						<property name="taskName" value="modifyNarrativeRights" />
+					</bean>
+				</entry>
+				<entry key="downloadInstituteAttachment">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.InstituteAttachmentTaskFactory">
+						<property name="taskName" value="downloadNarrative" />
+					</bean>
+				</entry>
+				<entry key="deleteInstitutionalAttachment">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.InstituteAttachmentTaskFactory">
+						<property name="taskName" value="deleteNarrative" />
+					</bean>
+				</entry>
+				<entry key="replaceInstituteAttachment">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.InstituteAttachmentTaskFactory">
+						<property name="taskName" value="replaceNarrative" />
+					</bean>
+				</entry>
+				<entry key="save">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.NarrtivesCommonTaskFactory">
+						<property name="taskName" value="modifyNarratives" />
+					</bean>
+				</entry>
+			</map>
+		</property>
+	</bean>
+	
+    <bean id="proposalBudgetVersionsWebAuthorizer" class="org.kuali.kra.web.struts.authorization.WebAuthorizer">
+        <property name="classname" value="org.kuali.kra.proposaldevelopment.web.struts.action.ProposalDevelopmentBudgetVersionsAction" />
+        <property name="mappings">
+            <map>
+                <entry key="addBudgetVersion">
+                    <bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+                        <property name="taskName" value="addBudget" />
+                    </bean>
+                </entry>
+                <entry key="openBudgetVersion">
+                    <bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+                        <property name="taskName" value="openBudgets" />
+                    </bean>
+                </entry>
+                <entry key="copyBudgetVersion">
+                    <bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+                        <property name="taskName" value="addBudget" />
+                    </bean>
+                </entry>
+            </map>
+        </property>
+    </bean>
+
+	<bean id="proposalPermissionsWebAuthorizer" class="org.kuali.kra.web.struts.authorization.WebAuthorizer">
+		<property name="classname" value="org.kuali.kra.proposaldevelopment.web.struts.action.ProposalDevelopmentPermissionsAction" />
+		<property name="mappings">
+			<map>
+				<entry key="addProposalUser">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+						<property name="taskName" value="modifyProposalRoles" />
+					</bean>
+				</entry>
+				<entry key="deleteProposalUser">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+						<property name="taskName" value="modifyProposalRoles" />
+					</bean>
+				</entry>
+				<entry key="setEditRoles">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+						<property name="taskName" value="modifyProposalRoles" />
+					</bean>
+				</entry>
+			</map>
+		</property>
+	</bean>
+
+	<bean id="proposalActionsWebAuthorizer" class="org.kuali.kra.web.struts.authorization.WebAuthorizer">
+		<property name="classname" value="org.kuali.kra.proposaldevelopment.web.struts.action.ProposalDevelopmentActionsAction" />
+		<property name="mappings">
+			<map>
+				<entry key="printForms">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+						<property name="taskName" value="printProposal" />
+					</bean>
+				</entry>
+				<entry key="route">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+						<property name="taskName" value="submitToWorkflow" />
+					</bean>
+				</entry>
+				<entry key="submitToSponsor">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+						<property name="taskName" value="submitToSponsor" />
+					</bean>
+				</entry>
+				<entry key="resubmit">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+						<property name="taskName" value="submitToSponsor" />
+					</bean>
+				</entry>
+				<entry key="approve">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+						<property name="taskName" value="hierarchyChildWorkflowAction" />
+					</bean>
+				</entry>
+				<entry key="reject">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+						<property name="taskName" value="rejectProposal" />
+					</bean>
+				</entry>
+				<entry key="disapprove">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+						<property name="taskName" value="hierarchyChildWorkflowAction" />
+					</bean>
+				</entry>
+				<!-- 
+				<entry key="cancel"> 
+				    <bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+				        <property name="taskName" value="hierarchyChildWorkflowAction" />
+				    </bean>
+				</entry>
+				-->
+				<entry key="blanketApprove">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+						<property name="taskName" value="hierarchyChildWorkflowAction" />
+					</bean>
+				</entry>
+				<entry key="acknowledge">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+						<property name="taskName" value="hierarchyChildAcknowledgeAction" />
+					</bean>
+				</entry>
+				<entry key="fyi">
+					<bean class="org.kuali.kra.proposaldevelopment.web.struts.authorization.ProposalTaskFactory">
+						<property name="taskName" value="hierarchyChildWorkflowAction" />
+					</bean>
+				</entry>
+			</map>
+		</property>
+	</bean>
+	
+	<bean id="proposalDevelopmentFactBuilderService" class="org.kuali.kra.proposaldevelopment.service.impl.ProposalDevelopmentFactBuilderServiceImpl">
+		  <property name="documentService" ref="documentService" />
+	</bean>
+    <bean id="propDevJavaFunctionKrmsTermService" class="org.kuali.kra.proposaldevelopment.service.impl.PropDevJavaFunctionKrmsTermServiceImpl">
+    	<property name="businessObjectService" ref="businessObjectService" />
+    	<property name="unitService" ref="unitService" />
+    	<property name="parameterService" ref="parameterService" />
+    	<property name="documentService" ref="documentService" />
+        <property name="dateTimeService" ref="dateTimeService" />
+    </bean>
+
+    <bean id="countryService" class="org.kuali.rice.core.framework.resourceloader.GlobalResourceLoaderServiceFactoryBean">
+        <property name="serviceName" value="countryService" />
+    </bean>
+
+	<bean id="proposalCountryService" class="org.kuali.kra.proposaldevelopment.service.impl.ProposalCountryServiceImpl">
+		 <property name="countryService" ref="countryService" />
+	</bean>
+		
+</beans>

--- a/src/main/resources/repository.xml
+++ b/src/main/resources/repository.xml
@@ -287,6 +287,25 @@
 		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
     	<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="false" />
 	</class-descriptor>
+    
+     <class-descriptor class="edu.arizona.kra.proposaldevelopment.bo.SPSRestrictedNote" table="EPS_PROP_SPS_NOTES">
+        <field-descriptor name="id" column="ID" jdbc-type="INTEGER" primarykey="true" sequence-name="EPS_PROP_SPS_NOTES_SEQ" autoincrement="true"/>
+        <field-descriptor name="authorId" column="AUTH_PRINCIPAL_ID" jdbc-type="VARCHAR"/>
+        <field-descriptor name="createdDate" column="CREATED_DATE" jdbc-type="TIMESTAMP" />
+        <field-descriptor name="noteTopic" column="NOTE_TOPIC" jdbc-type="VARCHAR"/>
+        <field-descriptor name="noteText" column="NOTE_TEXT" jdbc-type="VARCHAR" />
+        <field-descriptor name="proposalNumber" column="PROPOSAL_NUMBER" jdbc-type="VARCHAR" nullable="false" />
+        <field-descriptor name="proposalReceivedDate" column="PROPOSAL_RECEIVED_DATE" jdbc-type="DATE" />
+        <field-descriptor name="proposalReceivedTime" column="PROPOSAL_RECEIVED_TIME" jdbc-type="VARCHAR" />
+        <field-descriptor name="active" column="ACTV_IND" jdbc-type="VARCHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
+        <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" />
+        <field-descriptor name="updateTimestamp" column="UPDATE_TIMESTAMP" jdbc-type="TIMESTAMP" />
+        <field-descriptor name="updateUser" column="UPDATE_USER" jdbc-type="VARCHAR" />
+        <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="false" />
+        <reference-descriptor name="propDev" class-ref="org.kuali.kra.proposaldevelopment.bo.DevelopmentProposal" auto-retrieve="false" auto-update="none" auto-delete="none">
+            <foreignkey field-ref="devProposalNumber" />
+        </reference-descriptor>  
+    </class-descriptor>
 
 	<class-descriptor class="org.kuali.kra.bo.S2sRevisionType" table="S2S_REVISION_TYPE">
 		<field-descriptor name="s2sRevisionTypeCode" column="S2S_REVISION_TYPE_CODE" jdbc-type="VARCHAR" primarykey="true"/>

--- a/src/main/webapp/WEB-INF/jsp/proposaldevelopment/ProposalDevelopmentAbstractsAttachments.jsp
+++ b/src/main/webapp/WEB-INF/jsp/proposaldevelopment/ProposalDevelopmentAbstractsAttachments.jsp
@@ -1,0 +1,41 @@
+<%--
+ Copyright 2005-2014 The Kuali Foundation
+
+ Licensed under the Educational Community License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.osedu.org/licenses/ECL-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+--%>
+<%@ include file="/WEB-INF/jsp/kraTldHeader.jsp"%>
+<%@ page language="java" %> 
+
+<link rel="stylesheet" href="css/jquery/new_kuali.css" type="text/css" />
+
+<kul:documentPage
+	showDocumentInfo="true"
+	htmlFormAction="proposalDevelopmentAbstractsAttachments"
+	documentTypeName="ProposalDevelopmentDocument"
+	renderMultipart="true"
+	showTabButtons="true"
+	auditCount="0"
+  	headerDispatch="${KualiForm.headerDispatch}"
+  	headerTabActive="abstractsAttachments">
+<div align="right"><kul:help documentTypeName="ProposalDevelopmentDocument" pageName="Abstracts and Attachments" /></div>
+<kra-pd:proposalDevelopmentAttachments /> 
+<kra-pd:proposalDevelopmentPersonnelAttachments /> 
+<kra-pd:proposalDevelopmentInstitutionalAttachments /> 
+<kra-pd:proposalDevelopmentAbstracts />
+<kra-pd:proposalNotes />
+<kul:panelFooter />
+<kul:documentControls transactionalDocument="true" suppressRoutingControls="true" suppressCancelButton="true" />
+<script language="javascript" src="scripts/kuali_application.js"></script>
+
+
+</kul:documentPage>

--- a/src/main/webapp/WEB-INF/jsp/proposaldevelopment/ProposalDevelopmentAbstractsAttachments.jsp
+++ b/src/main/webapp/WEB-INF/jsp/proposaldevelopment/ProposalDevelopmentAbstractsAttachments.jsp
@@ -33,6 +33,7 @@
 <kra-pd:proposalDevelopmentInstitutionalAttachments /> 
 <kra-pd:proposalDevelopmentAbstracts />
 <kra-pd:proposalNotes />
+<kra-pd:proposalSPSNotes />
 <kul:panelFooter />
 <kul:documentControls transactionalDocument="true" suppressRoutingControls="true" suppressCancelButton="true" />
 <script language="javascript" src="scripts/kuali_application.js"></script>

--- a/src/main/webapp/WEB-INF/tags/proposaldevelopment/proposalSPSNotes.tag
+++ b/src/main/webapp/WEB-INF/tags/proposaldevelopment/proposalSPSNotes.tag
@@ -1,0 +1,121 @@
+<%--
+ Copyright 2005-2015 The Kuali Foundation
+ 
+ Licensed under the Educational Community License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.opensource.org/licenses/ecl2.php
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+--%>
+<%@ include file="/kr/WEB-INF/jsp/tldHeader.jsp"%>
+
+<%@ attribute name="noteType" required="false" type="java.lang.Enum"%>
+<%@ attribute name="displayTopicFieldInNotes" required="false"%>
+<%@ attribute name="transparentBackground" required="false"%>
+<%@ attribute name="defaultOpen" required="false" description="Whether the tab for the notes is rendered as open." %>
+
+<c:set var="documentTypeName" value="${KualiForm.docTypeName}" />
+<c:set var="canEditSPSNote" value="${KualiForm.canEditSPSRestrictedNotes}" />
+<c:set var="documentEntry" value="${DataDictionary[documentTypeName]}" />
+<c:set var="tabTitle" value="SPS Restricted Notes" />
+<c:set var="SPSNotesAttributes" value="${DataDictionary.SPSRestrictedNote.attributes}" />
+<c:set var="newSPSRestrictedNote" value="${KualiForm.newSPSRestrictedNote}" />
+<c:set var="SPSRestrictedNotes" value="${KualiForm.SPSRestrictedNotes}" />
+
+<c:if test="${empty displayTopicFieldInNotes}">
+    <c:set var="displayTopicFieldInNotes" value="${documentEntry.displayTopicFieldInNotes}" />
+</c:if>
+
+
+<kul:tab tabTitle="${tabTitle}" defaultOpen="${!empty SPSRestrictedNotes or (not empty defaultOpen and defaultOpen)}" tabErrorKey="${Constants.DOCUMENT_NOTES_ERRORS}" tabItemCount="${fn:length(SPSRestrictedNotes)}" transparentBackground="${transparentBackground}">
+
+    <div class="tab-container" align=center id="G4">
+        <p align=left><jsp:doBody />
+        <h3>${tabTitle}
+            <span class="subhead-right"><kul:help parameterNamespace="KC-PD" parameterDetailType="Document" parameterName="proposalDevelopmentnotesHelpUrl" altText="help" /></span>
+        </h3>
+        <table cellpadding="0" cellspacing="0" class="datatable" summary="view/add notes">
+            <tbody>
+                <tr>
+                    <th><div align="left">&nbsp;</div></th>
+                    <kul:htmlAttributeHeaderCell attributeEntry="${SPSNotesAttributes.createdDate}" hideRequiredAsterisk="true" scope="col" align="left"/>
+                    <kul:htmlAttributeHeaderCell attributeEntry="${SPSNotesAttributes.authorId}" hideRequiredAsterisk="true" scope="col" align="left"/>
+                   
+                    <c:if test="${displayTopicFieldInNotes eq true}">
+                        <th><div align="center">
+                                <kul:htmlAttributeLabel attributeEntry="${SPSNotesAttributes.noteTopic}" />
+                            </div></th>
+                    </c:if>
+                    <th><div align="center">
+                            <kul:htmlAttributeLabel attributeEntry="${SPSNotesAttributes.noteText}" />
+                        </div></th>
+                    <th><div align="center">
+                            <kul:htmlAttributeLabel attributeEntry="${SPSNotesAttributes.proposalReceivedDate}" />
+                        </div></th>
+                    <th><div align="center">
+                            <kul:htmlAttributeLabel attributeEntry="${SPSNotesAttributes.proposalReceivedTime}" />
+                        </div></th>
+                    <c:if test="${canEditSPSNote eq true}">
+                        <kul:htmlAttributeHeaderCell literalLabel="Actions" scope="col" />
+                    </c:if>
+                </tr>
+
+                <c:if test="${canEditSPSNote eq true}">
+                    <tr class="addline">
+                        <kul:htmlAttributeHeaderCell literalLabel="add:" scope="row" />
+                        <td class="infoline">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+                        <td class="infoline">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+
+                        <c:if test="${displayTopicFieldInNotes eq true}">
+                            <td class="infoline"><kul:htmlControlAttribute property="newSPSRestrictedNote.noteTopic" attributeEntry="${SPSNotesAttributes.noteTopic}" forceRequired="${SPSNotesAttributes.noteTopic.required}" readOnly="false" /></td>
+                        </c:if>
+
+                        <td class="infoline"><kul:htmlControlAttribute property="newSPSRestrictedNote.noteText" attributeEntry="${SPSNotesAttributes.noteText}" forceRequired="${SPSNotesAttributes.noteText.required}" readOnly="false" /></td>
+                        <td class="infoline"><kul:htmlControlAttribute property="newSPSRestrictedNote.proposalReceivedDate" attributeEntry="${SPSNotesAttributes.proposalReceivedDate}"
+                                forceRequired="${SPSNotesAttributes.proposalReceivedDate.required}" readOnly="false" datePicker="true" /></td>
+                        <td class="infoline"><kul:htmlControlAttribute property="newSPSRestrictedNote.proposalReceivedTime" attributeEntry="${SPSNotesAttributes.proposalReceivedTime}"
+                                forceRequired="${SPSNotesAttributes.proposalReceivedTime.required}" readOnly="false" /> </td>
+
+                        <td class="infoline">
+                            <div align="center">
+                                <html:image property="methodToCall.insertSPSNote" src="${ConfigProperties.kr.externalizable.images.url}tinybutton-add1.gif" alt="Add SPS Note" title="Add SPS Note" styleClass="tinybutton addButton" />
+                            </div>
+                        </td>
+                    </tr>
+                </c:if>
+
+                <c:forEach var="SPSNote" items="${KualiForm.SPSRestrictedNotes}" varStatus="status">
+                    <c:set var="authorUniversalIdentifier" value="${SPSNote.authorId}" />
+                    <tr>
+                        <th width="5%" class="infoline" rowspan="1"><c:out value="${status.index+1}" /></th>
+
+                        <td class="datacell center"><kul:htmlControlAttribute property="SPSRestrictedNotes[${status.index}].createdDate" readOnly="true" attributeEntry="${SPSNotesAttributes.createdDate}" /></td>
+
+                        <td class="datacell center"><kul:htmlControlAttribute property="SPSRestrictedNotes[${status.index}].authorName" readOnly="true" attributeEntry="${SPSNotesAttributes.authorId}" /></td>
+                        <c:if test="${displayTopicFieldInNotes eq true}">
+                            <td class="datacell center"><kul:htmlControlAttribute property="SPSRestrictedNotes[${status.index}].noteTopic" readOnly="true" attributeEntry="${SPSNotesAttributes.noteTopic}" /></td>
+                        </c:if>
+
+                        <td class="datacell center"><kul:htmlControlAttribute property="SPSRestrictedNotes[${status.index}].noteText" readOnly="true" attributeEntry="${SPSNotesAttributes.noteText}" /></td>
+                        <td class="datacell center"><kul:htmlControlAttribute property="SPSRestrictedNotes[${status.index}].proposalReceivedDate" readOnly="true" attributeEntry="${SPSNotesAttributes.proposalReceivedDate}" /></td>
+                        <td class="datacell center"><kul:htmlControlAttribute property="SPSRestrictedNotes[${status.index}].proposalReceivedTime" readOnly="true" attributeEntry="${SPSNotesAttributes.proposalReceivedTime}" /></td>
+                        <c:if test="${canEditSPSNote eq true}">
+                            <td class="infoline">
+                                <div align="center">
+                                    <html:image property="methodToCall.deleteSPSNote.line${status.index}" src="${ConfigProperties.kr.externalizable.images.url}tinybutton-delete1.gif" title="Delete Note" alt="Delete Note" styleClass="tinybutton" />
+                                </div>
+                            </td>
+                        </c:if>
+                    </tr>
+                </c:forEach>
+
+            </tbody>
+        </table>
+    </div>
+</kul:tab>


### PR DESCRIPTION
Added new SPSRestrictedNote business object with appropriate DataDictionary file, DaoOjb and methods in the PropDevRoutingStateService to be able to add,search and delete an SPS Restricted Note. The new table is linked in repository.xml. Added new tag file proposalSPSNotes.tag displayed in ProposalDevelopmentAbstractsAttachments.jsp just below the 'normal' notes
Also made modifications in PropDevRoutingStateDaoOjb to retrieve the Yes/No for the Final Proposal Received column.
The SPS Restricted Notes, same as the other 'normal' notes on a Proposal are EDITABLE even when the proposal is not in an editable state. The consequence is that notes can be added/deleted from the proposal without having to save it/edit it by the users who have corresponding rights (in this case Edit SPS Restricted notes permission)