### PR TITLE
UAR-1708: Adding additional query for workFlow unit to the Proposal Routing Dashboard

### DIFF
--- a/src/main/java/edu/arizona/kra/proposaldevelopment/PropDevRoutingStateConstants.java
+++ b/src/main/java/edu/arizona/kra/proposaldevelopment/PropDevRoutingStateConstants.java
@@ -63,6 +63,23 @@ public final class PropDevRoutingStateConstants {
     public static final String SPS_REVIEWER_QUERY = "select person_id AS sps_id FROM eps_prop_sps_reviewer WHERE cur_ind=1 AND proposal_number=?";
     public static final String SPS_REVIEWERS_QUERY = "select prncpl_id AS sps_id, (COALESCE(first_nm, '')||' '||COALESCE(middle_nm, '')||' '||COALESCE(last_nm, '')) AS sps_reviewer FROM krim_entity_cache_t WHERE prncpl_id IN (";
 
+    public static final String WORKFLOW_UNITS_PROPOSALS_QUERY = "SELECT DISTINCT proposal_number FROM ("+
+            " SELECT DISTINCT e.PROPOSAL_NUMBER FROM EPS_PROP_PERSON_UNITS e WHERE e.UNIT_NUMBER IN ";
+    public static final String WORKFLOW_UNITS_PROPOSALS_QUERY_CONT = "UNION SELECT distinct p.PROPOSAL_NUMBER FROM EPS_PROP_COST_SHARING ecs"+
+            " JOIN BUDGET b ON b.BUDGET_ID = ecs.BUDGET_ID "+
+            " JOIN BUDGET_DOCUMENT bd ON bd.DOCUMENT_NUMBER=b.DOCUMENT_NUMBER "+
+            " JOIN EPS_PROPOSAL_DOCUMENT epd on bd.PARENT_DOCUMENT_KEY= epd.DOCUMENT_NUMBER "+
+            " JOIN EPS_PROPOSAL p on p.DOCUMENT_NUMBER = epd.DOCUMENT_NUMBER "+
+            " WHERE bd.PARENT_DOCUMENT_TYPE_CODE='PRDV' AND b.FINAL_VERSION_FLAG='Y' AND p.STATUS_CODE in (1,2,5,12) " +
+            " AND ecs.SOURCE_UNIT IS NOT NULL and ecs.SOURCE_UNIT IN ";
+    public static final String WORKFLOW_UNITS_PROPOSALS_QUERY_FIN = ")";
+
+    public static final String WORKFLOW_UNIT_HIERARCHY_QUERY="SELECT DISTINCT unit_number FROM (" +
+            " SELECT unit_number FROM unit u WHERE u.ACTIVE_FLAG='Y' START WITH u.UNIT_NUMBER=? CONNECT BY PRIOR u.UNIT_NUMBER = u.PARENT_UNIT_NUMBER " +
+            " UNION " +
+            " SELECT unit_number FROM unit u WHERE ACTIVE_FLAG='Y' START WITH u.UNIT_NUMBER=? CONNECT BY u.UNIT_NUMBER = PRIOR u.PARENT_UNIT_NUMBER)";
+
+
     public static final String CUR_IND_UPDATE_STMT = "UPDATE $tablename SET cur_ind=0 where proposal_number=? and cur_ind=1";
     public static final String ORD_EXP_TABLE_NAME = "eps_prop_ord_expedited";
     public static final String SPS_REV_TABLE_NAME = "eps_prop_sps_reviewer"; 
@@ -71,6 +88,7 @@ public final class PropDevRoutingStateConstants {
             +" VALUES(eps_prop_ord_expedited_seq.NEXTVAL, ?, ?, 1, SYS_GUID(), CURRENT_TIMESTAMP, ?)";
     public static final String ADD_SPS_REVIEWER_QUERY = "INSERT INTO eps_prop_sps_reviewer (ID, PROPOSAL_NUMBER, PERSON_ID, FULL_NAME, CUR_IND, OBJ_ID, UPDATE_TIMESTAMP, UPDATE_USER)"
             +" VALUES(eps_prop_sps_reviewer_seq.NEXTVAL, ?, ?, ?, 1, SYS_GUID(), CURRENT_TIMESTAMP, ?)";
+
 
     public static final String COL_STOP_DATE = "stop_date";
     public static final String COL_NODE_NAME = "node_name";
@@ -104,6 +122,7 @@ public final class PropDevRoutingStateConstants {
     public static final String PROPOSAL_PERSON_NAME = "proposalPersonName";
     public static final String LEAD_UNIT = "leadUnit.unitNumber";
     public static final String LEAD_COLLEGE = "leadUnit.parentUnitNumber";
+    public static final String WORKFLOW_UNIT = "workflowUnit.unitNumber";
 
     public static final String NODE_NAME_CRITERIA = " AND rn.NM = '";
     public static final String SPONSOR_NAME_CRITERIA = " AND lower(s.SPONSOR_NAME) LIKE '%";
@@ -119,7 +138,8 @@ public final class PropDevRoutingStateConstants {
     public static final String LEAD_COLLEGE_CRITERIA = " AND prop.owned_by_unit IN (SELECT unit_number FROM unit u START WITH u.UNIT_NUMBER='";
     public static final String LEAD_COLLEGE_CRITERIA_CONT = "' CONNECT BY PRIOR u.UNIT_NUMBER = u.PARENT_UNIT_NUMBER)";
     public static final String ORDER_CRITERIA = " ORDER BY stop_date";
-
+    public static final String WORKFLOW_UNITS_CRITERIA = " AND prop.owned_by_unit IN (";
+    public static final String WORKFLOW_UNITS_CRITERIA_CONT = ") ";
 
     public static final String DATE_QUERY_PREFIX = "to_date('";
     public static final String DATE_FORMAT_STR = "','MM/DD/RRRR')";

--- a/src/main/java/edu/arizona/kra/proposaldevelopment/bo/ProposalDevelopmentRoutingState.java
+++ b/src/main/java/edu/arizona/kra/proposaldevelopment/bo/ProposalDevelopmentRoutingState.java
@@ -62,7 +62,9 @@ public class ProposalDevelopmentRoutingState extends TransientBusinessObjectBase
     private SPSReviewer spsReviewer;
     private Unit leadUnit;
     private Unit nodeStopLeadUnit;
+    private Unit workflowUnit;
     private Sponsor sponsor;
+    private String workflowUnitNumber;
 
 
 
@@ -137,7 +139,6 @@ public class ProposalDevelopmentRoutingState extends TransientBusinessObjectBase
     public void setPrincipalInvestigatorName(String principalInvestigatorName) {
         this.principalInvestigatorName = principalInvestigatorName;
     }
-
 
     public String getProposalPersonName() {
         return proposalPersonName;
@@ -246,6 +247,14 @@ public class ProposalDevelopmentRoutingState extends TransientBusinessObjectBase
         this.leadCollege = leadCollege;
     }
 
+    public Unit getNodeStopLeadUnit(){
+        return this.nodeStopLeadUnit;
+    }
+
+    public void setNodeStopLeadUnit(Unit unit){
+        this.nodeStopLeadUnit = unit;
+    }
+
     public Unit getLeadUnit(){
         return this.leadUnit;
     }
@@ -254,12 +263,12 @@ public class ProposalDevelopmentRoutingState extends TransientBusinessObjectBase
         this.leadUnit = unit;
     }
 
-    public Unit getNodeStopLeadUnit() {
-        return nodeStopLeadUnit;
+    public Unit getWorkflowUnit() {
+        return workflowUnit;
     }
 
-    public void setNodeStopLeadUnit(Unit nodeStopLeadUnit) {
-        this.nodeStopLeadUnit = nodeStopLeadUnit;
+    public void setWorkflowUnit(Unit workflowUnit) {
+        this.workflowUnit = workflowUnit;
     }
 
     public Sponsor getSponsor() {
@@ -276,6 +285,14 @@ public class ProposalDevelopmentRoutingState extends TransientBusinessObjectBase
 
     public void setProposalDocument(ProposalDevelopmentDocument proposalDocument) {
         this.proposalDocument = proposalDocument;
+    }
+
+    public String getWorkflowUnitNumber(){
+        return workflowUnitNumber;
+    }
+
+    public void setWorkflowUnitNumber(String workflowUnitNumber){
+        this.workflowUnitNumber = workflowUnitNumber;
     }
 
     @Override

--- a/src/main/java/edu/arizona/kra/util/DBConnection.java
+++ b/src/main/java/edu/arizona/kra/util/DBConnection.java
@@ -6,15 +6,23 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.io.Closeable;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import org.apache.ojb.broker.PersistenceBroker;
 import org.apache.ojb.broker.accesslayer.LookupException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springmodules.orm.ojb.OjbFactoryUtils;
 
-
+/**
+ * Class for properly obtaining/releasing connections from the PersistenceBroker
+ * Designed to be used with Java> 1.7 in a try-with-resources statement
+ *
+ * (see PropDevRoutingStateDaoOjb for usage examples)
+ *
+ * @author nataliac
+ */
 public class DBConnection implements Closeable{
-    private static final Log LOG = LogFactory.getLog(DBConnection.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DBConnection.class);
 
     private Connection conn = null;
     private PreparedStatement ps = null;
@@ -25,12 +33,46 @@ public class DBConnection implements Closeable{
         broker = pb;
     }
 
-
+    /**
+     * Executes a query an returns the resulting result set
+     *
+     * @param sqlQuery
+     * @param queryParams
+     * @return
+     * @throws SQLException
+     * @throws LookupException
+     */
     public ResultSet executeQuery(String sqlQuery, Object[] queryParams) throws SQLException, LookupException{ 
-        LOG.debug("executeQuery="+sqlQuery);
+        LOG.debug("executeQuery={}",sqlQuery);
         conn = broker.serviceConnectionManager().getConnection();
         ps = conn.prepareStatement(sqlQuery);
-        if (queryParams != null && queryParams.length > 0){
+        setParams(ps, queryParams);
+        rs = ps.executeQuery();
+        LOG.debug("executeQuery successfully ended.");
+        return rs;
+    }
+
+    /**
+     * Executes an update query returning the result code
+     * @param sqlQuery
+     * @param queryParams
+     * @return
+     * @throws SQLException
+     * @throws LookupException
+     */
+    public int executeUpdate(String sqlQuery, Object[] queryParams) throws SQLException, LookupException{
+        LOG.debug("executeUpdate={}",sqlQuery);
+        conn = broker.serviceConnectionManager().getConnection();
+        ps = conn.prepareStatement(sqlQuery);
+        setParams(ps, queryParams);
+        int resultCode = ps.executeUpdate();
+        LOG.debug("executeUpdate ended with result={}",resultCode);
+        return resultCode;
+    }
+
+
+    protected void setParams(PreparedStatement ps, Object[] queryParams) throws SQLException{
+        if (ps!=null && queryParams != null && queryParams.length > 0){
             for (int i = 0; i < queryParams.length; i++) {
                 if (queryParams[i] == null) {
                     ps.setNull(i + 1, Integer.MIN_VALUE);
@@ -39,9 +81,6 @@ public class DBConnection implements Closeable{
                 }
             }
         }
-        rs = ps.executeQuery();
-        LOG.debug("executeQuery successfully ended.");
-        return rs;
     }
 
 

--- a/src/main/resources/edu/arizona/kra/datadictionary/ProposalDevelopmentRoutingState.xml
+++ b/src/main/resources/edu/arizona/kra/datadictionary/ProposalDevelopmentRoutingState.xml
@@ -39,7 +39,8 @@
                 <ref bean="ProposalDevelopmentRoutingState-routeLog"/> 
                 <ref bean="ProposalDevelopmentRoutingState-finalProposalReceived"/>
                 <ref bean="ProposalDevelopmentRoutingState-spsReviewerName"/>
-                <ref bean="ProposalDevelopmentRoutingState-ordExpedited"/>     
+                <ref bean="ProposalDevelopmentRoutingState-ordExpedited"/>
+                <ref bean="ProposalDevelopmentRoutingState-workflowUnit.unitNumber"/>
             </list>
         </property>
         <property name="relationships" >
@@ -55,14 +56,24 @@
               </property>
             </bean>
             <bean parent="RelationshipDefinition">
-              <property name="objectAttributeName" value="nodeStopLeadUnit" />
+              <property name="objectAttributeName" value="workflowUnit" />
               <property name="primitiveAttributes" >
                 <list>
                   <bean parent="PrimitiveAttributeDefinition"
-                        p:sourceName="nodeStopLeadUnit.unitNumber"
+                        p:sourceName="workflowUnit.unitNumber"
                         p:targetName="unitNumber" />
                 </list>
               </property>
+            </bean>
+            <bean parent="RelationshipDefinition">
+                <property name="objectAttributeName" value="nodeStopLeadUnit" />
+                <property name="primitiveAttributes" >
+                    <list>
+                        <bean parent="PrimitiveAttributeDefinition"
+                            p:sourceName="nodeStopLeadUnit.unitNumber"
+                             p:targetName="unitNumber" />
+                    </list>
+                </property>
             </bean>
             <bean parent="RelationshipDefinition">
               <property name="objectAttributeName" value="developmentProposal" />
@@ -357,9 +368,24 @@
         </property>
         <property name="displayLabelAttribute" value="finalProposalReceived" />
     </bean>
-    
-    
-    
+
+    <bean id="ProposalDevelopmentRoutingState-workflowUnit.unitNumber" parent="ProposalDevelopmentRoutingState-workflowUnit.unitNumber-parentBean" />
+    <bean id="ProposalDevelopmentRoutingState-workflowUnit.unitNumber-parentBean" abstract="true" parent="AttributeDefinition">
+        <property name="name" value="workflowUnit.unitNumber" />
+        <property name="label" value="Workflow Unit" />
+        <property name="shortLabel" value="Workflow Unit" />
+        <property name="forceUppercase" value="true" />
+        <property name="maxLength" value="8" />
+        <property name="validationPattern" >
+            <bean parent="AnyCharacterValidationPattern" />
+        </property>
+        <property name="required" value="false" />
+        <property name="control" >
+            <bean parent="TextControlDefinition" p:size="8" />
+        </property>
+        <property name="summary" value="The Proposal's Workflow Unit" />
+        <property name="description" value="The Proposal's Workflow Unit" />
+    </bean>
 
 
     <!-- Business Object Inquiry Definition -->
@@ -413,12 +439,13 @@
                 <bean parent="FieldDefinition" p:attributeName="proposalPersonName"/>
                 <bean parent="FieldDefinition" p:attributeName="leadUnit.unitNumber" p:forceLookup="true" />
                 <bean parent="FieldDefinition" p:attributeName="leadUnit.parentUnitNumber"/>
+                <bean parent="FieldDefinition" p:attributeName="workflowUnit.unitNumber" p:forceLookup="true" />
             </list>
         </property>
         <property name="resultFields" >
             <list>
                 <bean parent="FieldDefinition" p:attributeName="routeStopDate"/>
-				<bean parent="FieldDefinition" p:attributeName="routeStopName"/>
+				        <bean parent="FieldDefinition" p:attributeName="routeStopName"/>
                 <bean parent="FieldDefinition" p:attributeName="proposalNumber"/>
                 <bean parent="FieldDefinition" p:attributeName="proposalDocumentNumber"/>
                 <bean parent="FieldDefinition" p:attributeName="proposalTitle"/>


### PR DESCRIPTION
Added workflow unit to the DD and BO then added workflow unit query to dao.
The logic is to find first the units associated with the workflow unit that the user mentions, from there identify the related proposal numbers and use them filter the current results from the dashboard (only when the user specifies a workflow unit)

Technical Debt: Refactored ProposalRoutingDaoOjb to use DBConnection to make sure connection resources are allocated/released properly.