### PR TITLE
UAR-1685: Fixing stack trace at subaward lookup

### DIFF
--- a/src/main/java/org/kuali/kra/subaward/web/struts/action/SubAwardAction.java
+++ b/src/main/java/org/kuali/kra/subaward/web/struts/action/SubAwardAction.java
@@ -662,11 +662,14 @@ protected void checkSubAwardTemplateCode(SubAward subAward){
      protected List<SubAwardFundingSourceBean> findSFSForDisplay(SubAwardDocument subAwardDocument){
          List<SubAwardFundingSourceBean> sfs = new ArrayList<SubAwardFundingSourceBean>();
          SubAward subAward = subAwardDocument.getSubAward();
-         Collection<Award> linkedAwards = getSubAwardService().getLinkedAwards(subAward);
-         int idx=0;
-         for (Award award:linkedAwards){
-             SubAwardFundingSourceBean sfsForDisplay = new SubAwardFundingSourceBean(String.valueOf(idx++),subAward, award);
-             sfs.add(sfsForDisplay);
+         // avoid querying for newly created Subawards that weren't saved to the DB and don't have a subawardId yet
+         if (subAward.getSubAwardId() != null){
+             Collection<Award> linkedAwards = getSubAwardService().getLinkedAwards(subAward);
+             int idx = 0;
+             for (Award award : linkedAwards) {
+                 SubAwardFundingSourceBean sfsForDisplay = new SubAwardFundingSourceBean(String.valueOf(idx++), subAward, award);
+                 sfs.add(sfsForDisplay);
+             }
          }
     
          return sfs;

--- a/src/main/resources/org/kuali/kra/subaward/repository-subAward.xml
+++ b/src/main/resources/org/kuali/kra/subaward/repository-subAward.xml
@@ -33,11 +33,9 @@
 	
 	<class-descriptor class="org.kuali.kra.subaward.bo.SubAward" table="SUBAWARD">
 		<field-descriptor name="subAwardId" column="SUBAWARD_ID" jdbc-type="BIGINT" primarykey="true"  autoincrement="true" sequence-name="SUBAWARD_ID_S" />
+    <field-descriptor name="documentNumber" column="DOCUMENT_NUMBER" jdbc-type="VARCHAR" access="anonymous" />
     <field-descriptor id="1" name="subAwardCode" column="SUBAWARD_CODE" jdbc-type="VARCHAR" />
     <field-descriptor id="2" name="sequenceNumber" column="SEQUENCE_NUMBER" jdbc-type="INTEGER"/>
-    <field-descriptor name="documentNumber" column="DOCUMENT_NUMBER" jdbc-type="VARCHAR" access="anonymous" />
-		<field-descriptor name="sequenceNumber" column="SEQUENCE_NUMBER" jdbc-type="INTEGER"/>	
-		<field-descriptor name="subAwardCode" column="SUBAWARD_CODE" jdbc-type="VARCHAR" />
 		<field-descriptor name="organizationId" column="ORGANIZATION_ID" jdbc-type="VARCHAR" />
 		<field-descriptor name="startDate" column="START_DATE" jdbc-type="DATE" />
 		<field-descriptor name="endDate" column="END_DATE" jdbc-type="DATE" />


### PR DESCRIPTION
Removed duplicate columns from subaward reporsitory file and improve SubAwardAction to query for SubAward Funding Sources only when the SubAward is not new.