### PR TITLE
UAR-2188: Fixing issues with unqualified roles that should have view …

### DIFF
--- a/src/main/java/edu/arizona/kra/irb/ProtocolConstants.java
+++ b/src/main/java/edu/arizona/kra/irb/ProtocolConstants.java
@@ -47,13 +47,24 @@ public final class ProtocolConstants {
     public static final String PROTOCOL_DOC_NUMBER = "documentNumber";
 
     public static final String PROTOCOL_NUMBERS_FOR_PERSONNEL_QUERY = "select unique protocol_number from protocol_persons where PERSON_ID=?";
+    public static final String ROLE_WITHOUT_QUALIFIERS_FOR_MEMBER_QUERY_PART1 =
+            "select r.role_id from KRIM_ROLE_MBR_T r left join KRIM_ROLE_MBR_ATTR_DATA_T a on r.ROLE_MBR_ID = a.ROLE_MBR_ID "+
+            " where r.mbr_id=? and ROLE_ID in (";
+    public static final String ROLE_WITHOUT_QUALIFIERS_FOR_MEMBER_QUERY_PART2 = ") and (r.actv_to_dt IS NULL OR sysdate <= r.actv_to_dt) and a.ROLE_MBR_ID IS NULL";
 
     public static final String ROLE_QUALIFIERS_FOR_MEMBER_AND_ATTRIBUTE_QUERY_PART1 = " select r.role_mbr_id, a.attr_val from KRIM_ROLE_MBR_T r left join KRIM_ROLE_MBR_ATTR_DATA_T a on "+
-            "r.ROLE_MBR_ID = a.ROLE_MBR_ID "+
-            "where r.ROLE_ID in (";
+            "r.ROLE_MBR_ID = a.ROLE_MBR_ID where r.ROLE_ID in (";
+
     public static final String ROLE_QUALIFIERS_FOR_MEMBER_AND_ATTRIBUTE_QUERY_PART2 = ") and (r.actv_to_dt IS NULL OR sysdate <= r.actv_to_dt) "+
             "and r.MBR_ID=? and a.KIM_ATTR_DEFN_ID in ("+
             "select kim_attr_defn_id from krim_attr_defn_t where ACTV_IND='Y' and NM=?)" ;
+
+    public static final String ROLE_QUALIFIERS_FOR_ROOT_UNIT_QUERY_PART1= "select r.role_mbr_id, r.MBR_ID, r.ROLE_ID, a.attr_val, b.attr_val from KRIM_ROLE_MBR_T r inner join KRIM_ROLE_MBR_ATTR_DATA_T a on r.ROLE_MBR_ID = a.ROLE_MBR_ID inner join KRIM_ROLE_MBR_ATTR_DATA_T b on a.role_mbr_id = b.role_mbr_id "
+    +" where r.ROLE_ID in (";
+    public static final String ROLE_QUALIFIERS_FOR_ROOT_UNIT_QUERY_PART2 = ") and (r.actv_to_dt IS NULL OR sysdate <= r.actv_to_dt) and r.MBR_ID=? "
+    +" and a.KIM_ATTR_DEFN_ID in (select KIM_ATTR_DEFN_ID from krim_attr_defn_t where ACTV_IND='Y' and NM='unitNumber') and a.ATTR_VAL='000001' "
+    +" and b.KIM_ATTR_DEFN_ID in (select KIM_ATTR_DEFN_ID from krim_attr_defn_t where ACTV_IND='Y' and NM='subunits') and b.ATTR_VAL='Y'";
+
 
     public static final String PROTOCOL_NUMBER_WITH_LEAD_UNIT_QUERY = "select unique protocol_number from protocol_units where LEAD_UNIT_FLAG='Y' and UNIT_NUMBER in (";
 

--- a/src/main/java/edu/arizona/kra/irb/dao/UaProtocolDao.java
+++ b/src/main/java/edu/arizona/kra/irb/dao/UaProtocolDao.java
@@ -1,9 +1,7 @@
 package edu.arizona.kra.irb.dao;
 
-import org.apache.ojb.broker.accesslayer.LookupException;
 import org.kuali.kra.irb.ProtocolDao;
 
-import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -19,12 +17,34 @@ public interface UaProtocolDao extends ProtocolDao {
      * @param userId
      * @return Collection<String>
      */
-    public Collection<String> getProtocolNumbersForPersonnelRole(String userId) throws SQLException, LookupException;
+    public Collection<String> getProtocolNumbersForPersonnelRole(String userId);
 
+
+    /**
+     * Returns true if the users is a member of any of the given roles but without further qualifiers for that membership
+     * @param userId
+     * @param roleIds - list of roles to look for
+     *
+     * @return boolean
+     */
+    public boolean hasUnqualifiedRoles(String userId, List<String> roleIds);
+
+    /**
+     * Returns true if the users has 'View Protocol' for root unit - University of Arizona - descending hierarchy.
+     * This means he can practically see any protocol because all the lead units are included.
+     * @param userId
+     * @param roleIds - list of roles to look for
+     *
+     * @return boolean
+     */
+    public boolean hasViewPermissionOnAllUnitHierarchy(String userId, List<String> roleIds);
 
     /**
      * Returns the qualifiers for the roles that have view protocol permission that the given user is a member of
      * @param userId
+     * @param roleIds - list of roles to look for
+     * @param qualifierName
+     *
      * @return Collection<String>
      */
     public Map<String,String> getQualifiersForMemberAndAttributeName(List<String> roleIds, String userId, String qualifierName);
@@ -32,6 +52,7 @@ public interface UaProtocolDao extends ProtocolDao {
     /**
      * Returns the protocol numbers that have the leading unit in the leadUnits list.
      * @param leadUnits
+     *
      * @return Collection<String>
      */
     public Collection<String> getProtocolNumbersWithLeadUnits(Collection<String> leadUnits);

--- a/src/main/java/edu/arizona/kra/irb/dao/ojb/UaProtocolDaoOjb.java
+++ b/src/main/java/edu/arizona/kra/irb/dao/ojb/UaProtocolDaoOjb.java
@@ -170,6 +170,60 @@ public class UaProtocolDaoOjb extends ProtocolDaoOjbBase<Protocol> implements Ua
 
     }
 
+    public boolean hasUnqualifiedRoles(String userId, List<String> roleIds) {
+        LOG.debug("ENTER hasUnqualifiedRoles userid="+userId );
+        StringBuffer sqlQuery = new StringBuffer(ROLE_WITHOUT_QUALIFIERS_FOR_MEMBER_QUERY_PART1);
+        for (String roleId:roleIds){
+            sqlQuery.append("'"+roleId+"',");
+        }
+        sqlQuery.deleteCharAt(sqlQuery.length()-1);
+        sqlQuery.append(ROLE_WITHOUT_QUALIFIERS_FOR_MEMBER_QUERY_PART2);
+        LOG.debug(" hasUnqualifiedRoles sqlQuery="+sqlQuery );
+        Object[] params = new Object[] { userId };
+        try (DBConnection dbc = new DBConnection(this.getPersistenceBroker(true)) ){
+            ResultSet rs = dbc.executeQuery(sqlQuery.toString(), params);
+            if (rs.next()){
+                LOG.info("User "+ userId+" has unqualified role: "+ rs.getString(1));
+                return true;
+            }
+        } catch (SQLException sqle) {
+            LOG.error("SQLException: " + sqle.getMessage(), sqle);
+        } catch (Exception le) {
+            LOG.error("Exception: " + le.getMessage(), le);
+        }
+
+        return false;
+    }
+
+    public boolean hasViewPermissionOnAllUnitHierarchy(String userId, List<String> roleIds){
+        LOG.debug("ENTER hasViewPermissionOnAllUnitHierarchy roleIds={}"+roleIds.toString()+" userid="+userId);
+
+        StringBuffer sqlQuery = new StringBuffer(ROLE_QUALIFIERS_FOR_ROOT_UNIT_QUERY_PART1);
+        for (String roleId:roleIds){
+            sqlQuery.append("'"+roleId+"',");
+        }
+        sqlQuery.deleteCharAt(sqlQuery.length()-1);
+        sqlQuery.append(ROLE_QUALIFIERS_FOR_ROOT_UNIT_QUERY_PART2);
+
+        Map<String,String> qualifiers = new HashMap<String, String>();
+        Object[] params = new Object[] {userId };
+        try (DBConnection dbc = new DBConnection(this.getPersistenceBroker(true)) ){
+            ResultSet rs = dbc.executeQuery(sqlQuery.toString(), params);
+            if (rs.next()){
+                LOG.info("User "+ userId+" has root unit view permission! ");
+                return true;
+            }
+        } catch (SQLException sqle) {
+            LOG.error("SQLException: " + sqle.getMessage(), sqle);
+
+        } catch (LookupException le) {
+            LOG.error("LookupException: " + le.getMessage(), le);
+        }
+
+        return false;
+    }
+
+
 
     public Map<String,String> getQualifiersForMemberAndAttributeName(List<String> roleIds, String userId, String qualifierName){
         LOG.debug("ENTER getQualifiersForMemberAndAttributeName roleIds={}"+roleIds.toString()+" userid="+userId +" qualifierName="+qualifierName);

--- a/src/main/java/edu/arizona/kra/irb/service/ProtocolSecurityService.java
+++ b/src/main/java/edu/arizona/kra/irb/service/ProtocolSecurityService.java
@@ -63,5 +63,12 @@ public interface ProtocolSecurityService {
     public boolean userHasPrivilegedProtocolRoles(String userId);
 
 
+    /**
+     * Check if the user has any roles with view permission without any qualifications (i.e. specific unit number or specific protocol number etc)
+     * @param userId
+     * @return
+     */
+    public boolean userHasUnrestrictedViewPermission(String userId);
+
 
 }

--- a/src/main/java/edu/arizona/kra/irb/service/impl/ProtocolSecurityServiceImpl.java
+++ b/src/main/java/edu/arizona/kra/irb/service/impl/ProtocolSecurityServiceImpl.java
@@ -90,6 +90,16 @@ public class ProtocolSecurityServiceImpl implements ProtocolSecurityService {
         return roleService.principalHasRole(userId, getPrivilegedProtocolRolesIds(), NO_QUALIFIERS, false);
     }
 
+
+    public boolean userHasUnrestrictedViewPermission(String userId){
+        boolean hasUnrestrictedViewPermission = getProtocolDao().hasUnqualifiedRoles(userId, getRoleIdsWithProtocolViewPermission());
+        if (!hasUnrestrictedViewPermission){
+            hasUnrestrictedViewPermission =  getProtocolDao().hasViewPermissionOnAllUnitHierarchy(userId, getRoleIdsWithProtocolViewPermission());
+        }
+        return hasUnrestrictedViewPermission;
+    };
+
+
     public Collection<String> findProtocolNumbersForProtocolQualifiedRoles(String userId) {
         Map<String,String> protocolRoleQualifiers = getProtocolDao().getQualifiersForMemberAndAttributeName(getRoleIdsWithProtocolViewPermission(), userId, ROLE_QUALIFIER_PROTOCOL);
         if ( protocolRoleQualifiers!=null && !protocolRoleQualifiers.isEmpty()){
@@ -97,6 +107,8 @@ public class ProtocolSecurityServiceImpl implements ProtocolSecurityService {
         }
         return new ArrayList<String>(0);
     }
+
+
 
 
     public Collection<String> findProtocolNumbersByUserPermissions(String userId) {


### PR DESCRIPTION
…permission

Previous fix was missing out on role memberships that are not qualified with either units/protocol numbers. If a user simply has a role that has the view protocol permission he should be able to view all the protocols.