### PR TITLE
UAR-2576 Apply the loading page to only apply to Actions and Document Id links

### DIFF
--- a/src/main/webapp/scripts/ua_kuali_application.js
+++ b/src/main/webapp/scripts/ua_kuali_application.js
@@ -30,6 +30,18 @@ var replaceWordChars = function(taElement) {
 }
 
 jQuery( document ).ready(function() {
+    // Show loader for hyperlinks that contain displayDocSearchView in the href url. This applies to links for the Document Id in the Document Search and the Actions in the Development Proposal Lookup.
+    jQuery('#lookup-results a[href*="displayDocSearchView"]').click(function(e) {
+
+        var targetValue = jQuery(this).attr('target');
+
+        //We will only create the loading page if the document or action opens in the same window.  This will ignore the links on the Proposal Routing Dashboard because we don't want them to be impacted.
+        if(targetValue != '_blank'){
+            e.preventDefault();
+            createLoading(true);
+            window.location.href = jQuery(this).attr('href');
+        }
+    });
 	
 	/* Show/Hide search criteria on the lookups */
 	jQuery("#lookup-criteria-toggle").click(function(event){


### PR DESCRIPTION
1) Change jQuery selector to only find anchor tags from the lookup results where the href contains 'displayDocSearchView' in the url. These are the links associated with the the Document Id from the Document Search and the Actions links.

2) Apply logic to make sure that the loading screen only shows if the anchor tag target opens on the same tab to prevent the lookup links from the Proposal Routing Dashboard to be affected.