### PR TITLE
UAR-2818 Apply IRB PDF watermarks to only Informed Consent/PHI Form attachment types

### DIFF
--- a/src/main/java/org/kuali/kra/irb/ProtocolAction.java
+++ b/src/main/java/org/kuali/kra/irb/ProtocolAction.java
@@ -433,9 +433,10 @@ public abstract class ProtocolAction extends ProtocolActionBase {
         byte[] attachmentFile =null;
         final AttachmentFile file = attachment.getFile();
         Protocol currentProtocol = (Protocol) form.getProtocolDocument().getProtocol();
-        Printable printableArtifacts= getProtocolPrintingService().getProtocolPrintArtifacts(currentProtocol);     
+        Printable printableArtifacts= getProtocolPrintingService().getProtocolPrintArtifacts(currentProtocol);
+        boolean isValidWaterMarkAttachmentType = getWatermarkService().isValidWaterMarkAttachmentType(attachment.getTypeCode());
         try {
-            if (printableArtifacts.isWatermarkEnabled() && ProtocolAttachmentProtocol.COMPLETE_STATUS_CODE.equals(attachment.getStatusCode())){              
+            if (printableArtifacts.isWatermarkEnabled() && ProtocolAttachmentProtocol.COMPLETE_STATUS_CODE.equals(attachment.getStatusCode()) && isValidWaterMarkAttachmentType){
                 if( attachment.isDraft() || 
                         ProtocolStatus.AMENDMENT_MERGED.equals(currentProtocol.getProtocolStatusCode()) ||
                         ProtocolStatus.RENEWAL_MERGED.equals(currentProtocol.getProtocolStatusCode()) ||

--- a/src/main/resources/edu/arizona/kc/db/changelog/changesets/db.changelog-UAR-2818.xml
+++ b/src/main/resources/edu/arizona/kc/db/changelog/changesets/db.changelog-UAR-2818.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="UAR-2818" author="Eric Lee">
+        <comment>
+            Adding parameter for allowable watermark attachment types
+        </comment>
+        <sql>
+            INSERT INTO KRCR_PARM_T (APPL_ID, NMSPC_CD, CMPNT_CD, PARM_NM, VAL, PARM_DESC_TXT, PARM_TYP_CD, EVAL_OPRTR_CD, OBJ_ID, VER_NBR)
+            VALUES ('KC', 'KC-PROTOCOL', 'Document', 'WATERMARK_ATTACHMENT_TYPES', '1', 'Allowable types for watermark attachments.', 'CONFG', 'A', sys_guid(), 1);
+        </sql>
+        <rollback>
+            delete from KRCR_PARM_T
+            where APPL_ID= 'KC'
+            and NMSPC_CD = 'KC-PROTOCOL'
+            and CMPNT_CD = 'Document'
+            and PARM_NM = 'WATERMARK_ATTACHMENT_TYPES'
+            and VAL = '1'
+            and PARM_DESC_TXT = 'Allowable types for watermark attachments.'
+            and PARM_TYP_CD = 'CONFG'
+            and EVAL_OPRTR_CD = 'A'
+            and VER_NBR = 1;
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/edu/arizona/kc/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/edu/arizona/kc/db/changelog/db.changelog-master.xml
@@ -26,5 +26,6 @@
   <include file="changesets/db.changelog-UAR-1489.xml" />
   <include file="changesets/db.changelog-UAR-1764.xml" />
   <include file="changesets/db.changelog-UAR-2677.xml" />
+  <include file="changesets/db.changelog-UAR-2818.xml" />
 </databaseChangeLog>
 


### PR DESCRIPTION
1) Modify ProtocolAction.java to also check whether the type code of an attachment is valid before applying the watermark. 
2) Add liquibase changeset to create the new watermark parameter. 