### PR TITLE
UAR-2265: Fixing issue with duplicate Award Funding Sources when canc…

### DIFF
--- a/src/main/java/org/kuali/kra/award/document/AwardDocument.java
+++ b/src/main/java/org/kuali/kra/award/document/AwardDocument.java
@@ -341,15 +341,13 @@ public class AwardDocument extends BudgetParentDocument<Award> implements  Copya
 
     private void updateFundedProposals() {
         Set<String> modifiedProposals = new HashSet<String>();
-        List<AwardFundingProposal> pendingVersions = new ArrayList<AwardFundingProposal>();
         for (AwardFundingProposal afp : getAward().getFundingProposals()) {
             InstitutionalProposalBoLite proposal = afp.getProposal();
             if (!ProposalStatus.FUNDED.equals(proposal.getStatusCode())) {
                 modifiedProposals.add(proposal.getProposalNumber());
-                pendingVersions.add(afp);
             }
         }
-
+        // AFP need to be removed for old version of IP to avoid having duplicate ones on the Award side.
         if (modifiedProposals.size() > 0) {
             for(InstitutionalProposal ip: getInstitutionalProposalService().fundInstitutionalProposals(modifiedProposals)){
                 List<AwardFundingProposal> removedFundingProposals = getAward().removeFundingProposals(ip.getProposalNumber());


### PR DESCRIPTION
…elling an Award with a Funded IP
When adding an IP to an AWARD, we are checking if the AFP does already exist in IP's list before creating a new AFP, and use that one instead of creating a duplicate one.