### PR TITLE
UAR-3192: java.util.ConcurrentModificationException after upgrading to Java 1.8

### DIFF
--- a/src/main/java/org/kuali/kra/budget/core/Budget.java
+++ b/src/main/java/org/kuali/kra/budget/core/Budget.java
@@ -607,14 +607,15 @@ public class Budget extends BudgetVersionOverview {
     public List<RateClassType> getRateClassTypes() {
         if (rateClassTypes.isEmpty() && !rateClassTypesReloaded && (!this.getBudgetRates().isEmpty() || !this.getBudgetLaRates().isEmpty())) {
             getBudgetRatesService().syncBudgetRateCollectionsToExistingRates(this.rateClassTypes, getBudgetDocument());
+            Collections.sort(rateClassTypes, new RateClassTypeComparator());
         } else if (rateClassTypesReloaded) {
             if (!rateClassTypes.isEmpty()) {
                 rateClassTypes.clear();
             }
             rateClassTypesReloaded = false;
             getBudgetRatesService().getBudgetRates(this.rateClassTypes, getBudgetDocument());
+            Collections.sort(rateClassTypes, new RateClassTypeComparator());
         }
-        Collections.sort(rateClassTypes, new RateClassTypeComparator());
         return rateClassTypes;
     }
 
@@ -709,20 +710,20 @@ public class Budget extends BudgetVersionOverview {
     }
 
     public List<BudgetPerson> getBudgetPersons() {
-    	Collections.sort(budgetPersons, new Comparator<BudgetPerson>() {
-    		@Override
-    		public int compare(final BudgetPerson object1, final BudgetPerson object2) {
-    			if (StringUtils.equalsIgnoreCase(object1.getPersonName(), object2.getPersonName())){
-    				return object1.getJobCode().compareTo(object2.getJobCode());
-    			}
-    			return 0;    			
-    		}    		
-    	});    	
         return budgetPersons;
     }
 
     public void setBudgetPersons(List<BudgetPerson> budgetPersons) {
         this.budgetPersons = budgetPersons;
+        Collections.sort(this.budgetPersons, new Comparator<BudgetPerson>() {
+            @Override
+            public int compare(final BudgetPerson object1, final BudgetPerson object2) {
+                if (StringUtils.equalsIgnoreCase(object1.getPersonName(), object2.getPersonName())){
+                    return object1.getJobCode().compareTo(object2.getJobCode());
+                }
+                return 0;
+            }
+        });    	;
     }
 
     /**

--- a/src/main/java/org/kuali/kra/common/committee/bo/CommitteeScheduleBase.java
+++ b/src/main/java/org/kuali/kra/common/committee/bo/CommitteeScheduleBase.java
@@ -561,19 +561,35 @@ public abstract class CommitteeScheduleBase<CS extends CommitteeScheduleBase<CS,
     }
 
     public List<CSM> getCommitteeScheduleMinutes() {
-        if (committeeScheduleMinutes != null) {
-            Collections.sort(committeeScheduleMinutes, new Comparator<CSM>() {
+        return committeeScheduleMinutes;
+    }
+
+    public void setCommitteeScheduleMinutes(List<CSM> committeeScheduleMinutes) {
+        this.committeeScheduleMinutes = committeeScheduleMinutes;
+        if (this.committeeScheduleMinutes != null) {
+            Collections.sort(this.committeeScheduleMinutes, new Comparator<CSM>() {
                 @Override
                 public int compare(CSM o1, CSM o2) {
                     return o1.getEntryNumber().compareTo(o2.getEntryNumber());
                 }
             });
         }
-        return committeeScheduleMinutes;
     }
 
-    public void setCommitteeScheduleMinutes(List<CSM> committeeScheduleMinutes) {
-        this.committeeScheduleMinutes = committeeScheduleMinutes;
+    public void addCommitteeScheduleMinute(CommitteeScheduleMinuteBase committeeScheduleMinute) {
+        if (committeeScheduleMinute != null) {
+            //lazy initialization
+            if (this.committeeScheduleMinutes == null ){
+                this.committeeScheduleMinutes = new ArrayList<CSM>();
+            }
+            this.committeeScheduleMinutes.add((CSM)committeeScheduleMinute);
+            Collections.sort(this.committeeScheduleMinutes, new Comparator<CSM>() {
+                @Override
+                public int compare(CSM o1, CSM o2) {
+                    return o1.getEntryNumber().compareTo(o2.getEntryNumber());
+                }
+            });
+        }
     }
 
     public List<CommitteeScheduleAttachmentsBase> getCommitteeScheduleAttachments() {

--- a/src/main/java/org/kuali/kra/common/committee/meeting/MeetingServiceImplBase.java
+++ b/src/main/java/org/kuali/kra/common/committee/meeting/MeetingServiceImplBase.java
@@ -476,28 +476,29 @@ public abstract class MeetingServiceImplBase<CS extends CommitteeScheduleBase<CS
      * @see org.kuali.kra.common.committee.meeting.CommonMeetingService#addCommitteeScheduleMinute(org.kuali.kra.common.committee.meeting.MeetingHelperBase)
      */
     public void addCommitteeScheduleMinute(MeetingHelperBase meetingHelper) {
-        meetingHelper.getNewCommitteeScheduleMinute().refreshReferenceObject("minuteEntryType");
-        meetingHelper.getNewCommitteeScheduleMinute().refreshReferenceObject("protocol");
-        meetingHelper.getNewCommitteeScheduleMinute().refreshReferenceObject("commScheduleActItem");
+        CommitteeScheduleMinuteBase newCommitteeScheduleMinute = meetingHelper.getNewCommitteeScheduleMinute();
+        newCommitteeScheduleMinute.refreshReferenceObject("minuteEntryType");
+        newCommitteeScheduleMinute.refreshReferenceObject("protocol");
+        newCommitteeScheduleMinute.refreshReferenceObject("commScheduleActItem");
         
         Long submissionId = null;
-        if (meetingHelper.getNewCommitteeScheduleMinute().getProtocol() != null) {
-            submissionId = meetingHelper.getNewCommitteeScheduleMinute().getProtocol().getProtocolSubmission().getSubmissionId();
+        if (newCommitteeScheduleMinute.getProtocol() != null) {
+            submissionId = newCommitteeScheduleMinute.getProtocol().getProtocolSubmission().getSubmissionId();
         }
         Long scheduleId = meetingHelper.getCommitteeSchedule().getId();
         Integer entryNumber = getNextMinuteEntryNumber((CS) meetingHelper.getCommitteeSchedule());
         String principalName = GlobalVariables.getUserSession().getPrincipalName();
         String minuteEntryTypeCode = meetingHelper.getNewCommitteeScheduleMinute().getMinuteEntryTypeCode();
         Timestamp createTimestamp = dateTimeService.getCurrentTimestamp();
-        
-        meetingHelper.getNewCommitteeScheduleMinute().setSubmissionIdFk(submissionId);
-        meetingHelper.getNewCommitteeScheduleMinute().setScheduleIdFk(scheduleId);
-        meetingHelper.getNewCommitteeScheduleMinute().setEntryNumber(entryNumber);
-        meetingHelper.getNewCommitteeScheduleMinute().setCreateUser(principalName);
-        meetingHelper.getNewCommitteeScheduleMinute().setUpdateUser(principalName);
-        meetingHelper.getNewCommitteeScheduleMinute().setCreateTimestamp(createTimestamp);
+
+        newCommitteeScheduleMinute.setSubmissionIdFk(submissionId);
+        newCommitteeScheduleMinute.setScheduleIdFk(scheduleId);
+        newCommitteeScheduleMinute.setEntryNumber(entryNumber);
+        newCommitteeScheduleMinute.setCreateUser(principalName);
+        newCommitteeScheduleMinute.setUpdateUser(principalName);
+        newCommitteeScheduleMinute.setCreateTimestamp(createTimestamp);
         // set this up for display when 'add'
-        meetingHelper.getNewCommitteeScheduleMinute().setUpdateTimestamp(createTimestamp);
+        newCommitteeScheduleMinute.setUpdateTimestamp(createTimestamp);
         
         if (MinuteEntryType.ATTENDANCE.equals(minuteEntryTypeCode)) {
             addAttendanceMinuteEntry(meetingHelper);
@@ -510,7 +511,7 @@ public abstract class MeetingServiceImplBase<CS extends CommitteeScheduleBase<CS
             resetActionItemFields(meetingHelper);
         }
         
-        ((List<CSM>)(meetingHelper.getCommitteeSchedule().getCommitteeScheduleMinutes())).add((CSM) meetingHelper.getNewCommitteeScheduleMinute());
+        meetingHelper.getCommitteeSchedule().addCommitteeScheduleMinute(newCommitteeScheduleMinute);
         meetingHelper.setNewCommitteeScheduleMinute(getNewCommitteeScheduleMinuteInstanceHook());
     }
     


### PR DESCRIPTION
Code Fixes:
1. Budget BO: rateClasses collection and budgetPersons collection: Move the sorting out of the getters into the setters
2. CommitteeScheduleBase: committeeScheduleMinutes collection: move the sorting out of the getter and put it in the setter. Additional method: addCommitteeScheduleMinute for adding another element that sorts the collection after.
3. MeetingServiceImplBase: modified addCommitteeScheduleMinute to use the abovementioned new method
