### PR TITLE
Add blob byte length to spreadsheet table for later comparison.

### DIFF
--- a/src/main/java/edu/arizona/kra/irb/pdf/EfsAttachment.java
+++ b/src/main/java/edu/arizona/kra/irb/pdf/EfsAttachment.java
@@ -1,19 +1,22 @@
 package edu.arizona.kra.irb.pdf;
 
 public class EfsAttachment {
-    private String efsPath;
-    private String md5hash;
+    private final String efsPath;
+    private final int bytesLength;
 
-    public EfsAttachment(String efsPath, String md5hash) {
+
+    public EfsAttachment(String efsPath, int bytesLength) {
         this.efsPath = efsPath;
-        this.md5hash = md5hash;
+        this.bytesLength = bytesLength;
     }
+
 
     public String getEfsPath() {
         return efsPath;
     }
 
-    public String getMd5hash() {
-        return md5hash;
+
+    public int getBytesLength() {
+        return bytesLength;
     }
 }

--- a/src/main/java/edu/arizona/kra/irb/pdf/ProtocolPdfWorker.java
+++ b/src/main/java/edu/arizona/kra/irb/pdf/ProtocolPdfWorker.java
@@ -152,10 +152,10 @@ public class ProtocolPdfWorker extends Thread {
         logInfo(String.format("Pushing protocol %s to efs", protocolNumber));
 
         byte[] bytes = attachmentDataSource.getContent();
-        String md5hash = DigestUtils.md5Hex(bytes);
+        int bytesLength = bytes.length;
 
         String fullEfsFilePath = efsAgent.pushFileToEfs(attachmentDataSource.getFileName(), bytes, pushToEfs);
-        EfsAttachment efsAttachment = new EfsAttachment(fullEfsFilePath, md5hash);
+        EfsAttachment efsAttachment = new EfsAttachment(fullEfsFilePath, bytesLength);
 
         logInfo(String.format("Pushed protocol %s to efs complete", protocolNumber));
 

--- a/src/main/java/edu/arizona/kra/irb/pdf/excel/ExcelDbAgent.java
+++ b/src/main/java/edu/arizona/kra/irb/pdf/excel/ExcelDbAgent.java
@@ -30,10 +30,10 @@ public class ExcelDbAgent {
         int destAttrIsSet = 1;
         String fullSftpFilePath = efsAttachment.getEfsPath().replace(efsRootDir, sftpRootDir);
         String category = Category.Other.getDescription();
-        String md5checksum = efsAttachment.getMd5hash();
+        int bytesLength = efsAttachment.getBytesLength();
 
         sqlExecutor.insert(QueryConstants.INSERT_EXCEL_ROW,
-                id, destType, protocolNumber, huronDestination, destAttrIsSet, fileName, fullSftpFilePath, category, md5checksum);
+                id, destType, protocolNumber, huronDestination, destAttrIsSet, fileName, fullSftpFilePath, category, bytesLength);
     }
 
 }

--- a/src/main/java/edu/arizona/kra/irb/pdf/sql/QueryConstants.java
+++ b/src/main/java/edu/arizona/kra/irb/pdf/sql/QueryConstants.java
@@ -15,14 +15,14 @@ public class QueryConstants {
                     "    is_processed      VARCHAR2(10), \n" +
                     "    error             VARCHAR2(10), \n" +
                     "    document_id       VARCHAR2(10), \n" +
-                    "    md5checksum       VARCHAR2(32) \n" +
+                    "    bytes_length      NUMBER \n" +
                     ")";
 
     public static final String DROP_SPREADSHEET_TABLE_SQL = "drop table attachment_spreadsheet_sum";
 
     public static final String INSERT_EXCEL_ROW =
             "insert into attachment_spreadsheet_sum \n" +
-                "(id, dest_type, protocol_number, huron_destination, dest_att_is_set, ui_filename, sftp_path, category, md5checksum) \n" +
+                "(id, dest_type, protocol_number, huron_destination, dest_att_is_set, ui_filename, sftp_path, category, bytes_length) \n" +
                 "values (?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
     public static final String FIND_ALL_EXCEL_ROWS = "select * from attachment_spreadsheet_sum";


### PR DESCRIPTION
Summary PDFs have a timestamp within their binary so an MD5 hash across envs will be different. So to track file parity across envs, this commit takes the size of the blob and saves it to the spreadsheet table. This will at least show that blobs have equivalent size.