### PR TITLE
Refactor to account for buckets in the path and that dirs will not only be protocol summaries.

### DIFF
--- a/src/main/resources/edu/arizona/pdf/compare-pdfs.sh
+++ b/src/main/resources/edu/arizona/pdf/compare-pdfs.sh
@@ -19,83 +19,20 @@ THREAD_COUNT=8
 LOG_FILE="$OUTPUT_DIR/compare-pdfs.log"
 TEXT_DIR_ONE="$OUTPUT_DIR/env-one/converted-text"
 TEXT_DIR_TWO="$OUTPUT_DIR/env-two/converted-text"
-CHUNK_DIR="$OUTPUT_DIR/chunks"
-MASTER_FILE_LIST="$CHUNK_DIR/master_file_list.txt"
+CHUNK_DIR="$OUTPUT_DIR/chunk"
+PDF_CHUNK_DIR_ONE="$CHUNK_DIR/pdf_chunk_one"
+PDF_CHUNK_DIR_TWO="$CHUNK_DIR/pdf_chunk_two"
+TEXT_CHUNK_DIR="$CHUNK_DIR/text_chunk"
+PDF_FILE_LIST_ONE="$CHUNK_DIR/pdf_file_list_one.txt"
+PDF_FILE_LIST_TWO="$CHUNK_DIR/pdf_file_list_two.txt"
+TEXT_FILE_LIST="$CHUNK_DIR/text_file_list.txt"
 
 
-#
 # Delete dynamically generated output upon any type of exit
-#
-cleanup() {
+function cleanup() {
     rm -rf "$CHUNK_DIR"
 }
 trap cleanup EXIT
-
-
-#
-# $1: <chunck_file>
-#
-# This is the function that will get forked into multiple threads, and its the
-# workhorse logic of this script.
-#
-function check_pdfs() {
-    chunk_file="$1"
-
-    # Convert all the pdfs for env-1
-    while IFS= read -r filename; do
-        pdf_file="$PDF_DIR_ONE/$filename"
-        text_file="$TEXT_DIR_ONE/${filename%.*}.txt"
-        pdftotext "$pdf_file" "$text_file"
-    done < "$chunk_file"
-
-    # Convert all the pdfs for env-2
-    while IFS= read -r filename; do
-        pdf_file="$PDF_DIR_TWO/$filename"
-        text_file="$TEXT_DIR_TWO/${filename%.*}.txt"
-        pdftotext "$pdf_file" "$text_file"
-    done < "$chunk_file"
-
-    # Diff the two converted text files
-    while IFS= read -r filename; do
-        text_file="${filename%.*}.txt"
-        result=$(diff "$TEXT_DIR_ONE/$text_file" "$TEXT_DIR_TWO/$text_file")
-        if [[ -n "$result" ]]; then
-            log "ERROR: '$filename' is not equivalent!"
-        fi
-    done < "$chunk_file"
-}
-
-
-function chunk_filenames() {
-    # Create a master file list based on files from env one
-    while IFS= read -r file; do
-        filename=$(basename "$file")
-        echo "$filename" >> "$MASTER_FILE_LIST"
-    done < <(find "$PDF_DIR_ONE" -type f -name '*.pdf')
-
-    # Chunk out a file for each thread that will get forked, e.g. chunk.00.txt chunk.01.txt
-    split -n l/$THREAD_COUNT -e -d "$MASTER_FILE_LIST" "$CHUNK_DIR/chunk." --additional-suffix=.txt
-}
-
-
-function setup_dirs() {
-    rm -rf "$OUTPUT_DIR"
-    mkdir -p "$OUTPUT_DIR"
-    mkdir -p "$TEXT_DIR_ONE"
-    mkdir -p "$TEXT_DIR_TWO"
-    mkdir -p "$CHUNK_DIR"
-    touch "$LOG_FILE"
-}
-
-
-function start_threads() {
-    while IFS= read -r -d '' chunk_file; do
-        file_name=$(basename "$chunk_file")
-        line_count=$(wc -l < "$chunk_file")
-        log "Launching thread for $file_name with $line_count commands(s)"
-        check_pdfs "$chunk_file" &
-    done < <(find "$CHUNK_DIR" -maxdepth 1 -type f -name 'chunk*.txt' -print0)
-}
 
 
 function timestamp(){
@@ -109,15 +46,137 @@ function log() {
 }
 
 
-function main() {
-    setup_dirs
+function setup_file_system() {
+    rm -rf "$OUTPUT_DIR"
+    mkdir -p "$OUTPUT_DIR"
+    mkdir -p "$TEXT_DIR_ONE"
+    mkdir -p "$TEXT_DIR_TWO"
+    mkdir -p "$CHUNK_DIR"
+    mkdir -p "$PDF_CHUNK_DIR_ONE"
+    mkdir -p "$PDF_CHUNK_DIR_TWO"
+    mkdir -p "$TEXT_CHUNK_DIR"
+    touch "$LOG_FILE"
+}
 
-    log "Starting..."
-    chunk_filenames
-    start_threads
 
-    # Wait for all the threads to join back
+function chunk_pdf_filenames() {
+    _chunk_pdf_filenames "$PDF_FILE_LIST_ONE" "$PDF_DIR_ONE" "$PDF_CHUNK_DIR_ONE"
+    _chunk_pdf_filenames "$PDF_FILE_LIST_TWO" "$PDF_DIR_TWO" "$PDF_CHUNK_DIR_TWO"
+}
+
+
+# $1: pdf_file_list
+# $2: pdf_dir
+# #3: chunk_dir
+function _chunk_pdf_filenames() {
+    pdf_file_list="$1"
+    pdf_dir="$2"
+    chunk_dir="$3"
+
+    while IFS= read -r file; do
+        echo "$file" >> "$pdf_file_list"
+    done < <(find "$pdf_dir" -type f -name 'Protocol Summary Report*.pdf')
+
+    # Chunk out a file for each thread that will get forked, e.g. chunk.00.txt chunk.01.txt
+    log "Splitting pdf file list: '$pdf_file_list'"
+    log "$(wc -l < "$pdf_file_list") entries found"
+    split -n l/$THREAD_COUNT -e -d "$pdf_file_list" "$chunk_dir/chunk." --additional-suffix=.txt
+}
+
+
+function run_pdf_converter_threads() {
+    log "Converting env one pdfs to text"
+    _run_converter_threads "$PDF_CHUNK_DIR_ONE" "$TEXT_DIR_ONE"
+
+    log "Converting env two pdfs to text"
+    _run_converter_threads "$PDF_CHUNK_DIR_TWO" "$TEXT_DIR_TWO"
+}
+
+
+# $1: chunks_dir
+# $2: text_output_dir
+function _run_converter_threads() {
+    chunk_dir="$1"
+    text_output_dir="$2"
+
+    while IFS= read -r -d '' chunk_file; do
+        filename=$(basename "$chunk_file")
+        line_count=$(wc -l < "$chunk_file")
+        log "Launching convert thread for $filename with $line_count commands(s)"
+        convert_pdfs "$chunk_file" "$text_output_dir" &
+    done < <(find "$chunk_dir" -maxdepth 1 -type f -name 'chunk*.txt' -print0)
+
     wait
+}
+
+
+# $1: chunk_file
+# $2: output_text_dir
+function convert_pdfs() {
+    chunk_file="$1"
+    output_text_dir="$2"
+
+    while IFS= read -r pdf_file; do
+        filename=$(basename "$pdf_file")
+        text_file="$output_text_dir/${filename%.*}.txt"
+        pdftotext "$pdf_file" "$text_file"
+    done < "$chunk_file"
+}
+
+
+function chunk_text_file_names() {
+    while IFS= read -r file; do
+        filename=$(basename "$file")
+        echo "$filename" >> "$TEXT_FILE_LIST"
+    done < <(find "$TEXT_DIR_ONE" -type f -name '*.txt')
+
+    log "Splitting text file list: '$TEXT_FILE_LIST'"
+    log "$(wc -l < "$TEXT_FILE_LIST") entries found"
+    split -n l/$THREAD_COUNT -e -d "$TEXT_FILE_LIST" "$TEXT_CHUNK_DIR/chunk." --additional-suffix=.txt
+}
+
+
+function run_text_diff_threads() {
+    while IFS= read -r -d '' chunk_file; do
+        filename=$(basename "$chunk_file")
+        line_count=$(wc -l < "$chunk_file")
+        log "Launching diff thread for $filename with $line_count commands(s)"
+        diff_text_files "$chunk_file" &
+    done < <(find "$TEXT_CHUNK_DIR" -maxdepth 1 -type f -name 'chunk*.txt' -print0)
+
+    wait
+}
+
+
+# $1: chunk_file
+function diff_text_files() {
+    chunk_file="$1"
+
+    # Diff the two converted text files
+    while IFS= read -r text_file; do
+        result=$(diff "$TEXT_DIR_ONE/$text_file" "$TEXT_DIR_TWO/$text_file")
+        if [[ -n "$result" ]]; then
+            log "ERROR: '$text_file' is not equivalent!"
+        fi
+    done < "$chunk_file"
+}
+
+
+function main() {
+    log "Setting up file system"
+    setup_file_system
+
+    log "Chunking pdf filenames"
+    chunk_pdf_filenames
+
+    log "Running converter threads"
+    run_pdf_converter_threads
+
+    log "Chunking text filenames"
+    chunk_text_file_names
+
+    log "Running diff threads"
+    run_text_diff_threads
 
     log "All comparisons complete."
 }


### PR DESCRIPTION
The script wasn't initially developed against the EFS bucket scheme, and testing was limited to only protocol summaries.

Implemented a refactor that is bucket agnostic, and that uses a `find` pattern that will only pull protocol summary files.